### PR TITLE
[VOID] MediaLister: Selection Feature

### DIFF
--- a/src/VoidCore/VoidTools.cpp
+++ b/src/VoidCore/VoidTools.cpp
@@ -32,6 +32,6 @@ namespace Tools {
         return -1;
     }
 
-}
+} // namespace Tools
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/MediaItem.cpp
+++ b/src/VoidUi/MediaItem.cpp
@@ -42,25 +42,14 @@ VoidMediaItem::~VoidMediaItem()
 {
 }
 
+void VoidMediaItem::mousePressEvent(QMouseEvent* event)
+{
+    emit clicked(this);
+}
+
 void VoidMediaItem::mouseDoubleClickEvent(QMouseEvent* event)
 {
     emit doubleClicked(this);
-}
-
-void VoidMediaItem::focusInEvent(QFocusEvent* event)
-{
-    m_Selected = true;
-
-    /* Set Stylesheet for Selected Item */
-    setStyleSheet(m_SelectedSS.c_str());
-}
-
-void VoidMediaItem::focusOutEvent(QFocusEvent* event)
-{
-    m_Selected = false;
-
-    /* Apply default stylesheet */
-    setStyleSheet(m_DefaultSS.c_str());
 }
 
 void VoidMediaItem::Build()
@@ -163,6 +152,24 @@ void VoidMediaItem::SetPlaying(bool play)
         );
     else
         m_PlayLabel->setPixmap(QPixmap(""));
+}
+
+void VoidMediaItem::SetSelected(bool selected)
+{
+    /* Update the selection state */
+    m_Selected = selected;
+
+    /* Update the color corresponding to the selection */
+    if (m_Selected)
+    {
+        /* Set Stylesheet for Selected Item */
+        setStyleSheet(m_SelectedSS.c_str());
+    }
+    else
+    {
+        /* Apply default stylesheet */
+        setStyleSheet(m_DefaultSS.c_str());
+    }
 }
 
 void VoidMediaItem::Update()

--- a/src/VoidUi/MediaItem.h
+++ b/src/VoidUi/MediaItem.h
@@ -34,7 +34,11 @@ public:
     /* Sets the Playing state on the Media */
     void SetPlaying(bool play);
 
+    /* Sets the selection state on the media item */
+    void SetSelected(bool selected);
+
 signals:
+    void clicked(VoidMediaItem*);
     void doubleClicked(VoidMediaItem*);
 
 private: /* Methods */
@@ -60,9 +64,8 @@ private: /* Methods */
     QPixmap GetThumbnail() const;
 
 protected:
+    void mousePressEvent(QMouseEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
-    void focusInEvent(QFocusEvent* event) override;
-    void focusOutEvent(QFocusEvent* event) override;
 
 private: /* Members */
     /* State for the widget selection */

--- a/src/VoidUi/MediaLister.h
+++ b/src/VoidUi/MediaLister.h
@@ -32,11 +32,20 @@ public:
 signals:
     void mediaChanged(const VoidImageSequence& sequence);
 
+protected: /* Methods */
+    void mousePressEvent(QMouseEvent* event) override;
+
 private: /* Methods */
     void Build();
 
     /* Clears the play state of the item which was last playing, if any */
     void ClearPlaying();
+
+    /* Clears the selected item(s), if any */
+    void ClearSelection();
+    
+    /* Changes the selection state of the media item(s) */
+    void SelectItem(VoidMediaItem* item);
 
     /*
      * Changes the state of the media items being played to the provided item
@@ -54,6 +63,9 @@ private: /* Members */
     
     /* Holds the media item which is currently playing */
     VoidMediaItem* m_CurrentPlaying;
+
+    /* Holds the media item which is currently selected */
+    VoidMediaItem* m_CurrentSelectedItem;
 
 };
 


### PR DESCRIPTION
## Feature
### Media Lister Selection
* MediaLister is now able to allow selecting and retaining selection of media items even with defocus on widget and clicks on other components
* Removed focus feature from media item and added clicked signal on mousePress
*capturing the signal on the media lister to use as a way of selecting media.