### PR TITLE
[VOID Player] Add Support for Media with Missing Frames

### DIFF
--- a/src/VoidCore/Media.cpp
+++ b/src/VoidCore/Media.cpp
@@ -137,33 +137,30 @@ Media::~Media()
 
 void Media::UpdateRange()
 {
-    /* Process First Frame {{{ */
-    std::vector<int>::const_iterator fit = std::min_element(m_Framenumbers.begin(), m_Framenumbers.end());
+    /* Sort the Updated frames vector */
+    std::sort(m_Framenumbers.begin(), m_Framenumbers.end());
 
-    if (fit != m_Framenumbers.end())
-    {
-        /* Return the minimum value from the framenumbers set */
-        m_FirstFrame = *fit;
-    }
-    else /* No frames to process */
-    {
-        m_FirstFrame = -1;
-    }
-    /* }}} */
+    /* Update the first and last frame after the framenumbers have been sorted */
+    m_FirstFrame = m_Framenumbers.front();
+    m_LastFrame = m_Framenumbers.back();
+}
 
-    /* Process Last Frame {{{ */
-    std::vector<int>::const_iterator lit = std::max_element(m_Framenumbers.begin(), m_Framenumbers.end());
+int Media::NearestFrame(const int frame) const
+{
+    /* We need the lower bound of the given frame available in the vector */
+    auto it = std::lower_bound(m_Framenumbers.begin(), m_Framenumbers.end(), frame);
 
-    if (lit != m_Framenumbers.end())
+    if (it != m_Framenumbers.end())
     {
-        /* Return the maximum value from the framenumbers set */
-        m_LastFrame = *lit;
+        /* Return the value at the iter after moving it back */
+        return *(--it);
     }
-    else /* No frames to process */
-    {
-        m_LastFrame = -1;
-    }
-    /* }}} */
+
+    /* 
+     * As the provided frame is lower than the first frame,
+     * The most natural nearest frame to it is the first frame
+     */
+    return m_FirstFrame;
 }
 
 void Media::Read(const std::string& path)

--- a/src/VoidCore/Media.h
+++ b/src/VoidCore/Media.h
@@ -115,6 +115,19 @@ public:
      */
     [[nodiscard]] inline bool InRange(const int frame) const { return frame >= m_FirstFrame && frame <= m_LastFrame; }
 
+    /* 
+     * Returns whether a given frame is available to read
+     * There could be a scenario where the given frame is in the range of first - last but is not available
+     * and is referred to as the missing frame.
+     */
+    [[nodiscard]] inline bool Contains(const int frame) const { return m_Mediaframes.find(frame) != m_Mediaframes.end(); }
+
+    /*
+     * Based on the available frames, returns the frame which is just lower than the provided frame
+     * This is used when the current frame is not available but we want the neartest frame to be used in it's place
+     */
+    int NearestFrame(const int frame) const;
+
     Frame GetFrame(const int frame) const { return m_Mediaframes.at(frame); }
 
     Frame FirstFrameData() const { return m_Mediaframes.at(FirstFrame()); }

--- a/src/VoidRenderer/Renderer.cpp
+++ b/src/VoidRenderer/Renderer.cpp
@@ -24,6 +24,9 @@ VoidRenderer::VoidRenderer(QWidget* parent)
 {
     /* Add Render StatusBar */
     m_RenderStatus = new RendererStatusBar(this);
+    /* Message display */
+    m_DisplayLabel = new RendererDisplayLabel(this);
+    m_DisplayLabel->setVisible(false);
 
     /* Enable to track mouse movements */
     setMouseTracking(true);
@@ -40,6 +43,10 @@ VoidRenderer::~VoidRenderer()
     /* Delete the Render Status bar */
     m_RenderStatus->deleteLater();
     m_RenderStatus = nullptr;
+
+    /* Delete the Error Label */
+    m_DisplayLabel->deleteLater();
+    m_DisplayLabel = nullptr;
 }
 
 void VoidRenderer::initializeGL()
@@ -127,6 +134,9 @@ void VoidRenderer::resizeEvent(QResizeEvent* event)
 {
     /* Base Resize */
     QOpenGLWidget::resizeEvent(event);
+
+    /* The Label has to have a certain gap from the edges */
+    m_DisplayLabel->move(10, 10);
 
     /* Ensure that the status bar always stays at the bottom of the Renderer */
     m_RenderStatus->move(0, height() - m_RenderStatus->height());
@@ -229,6 +239,8 @@ void VoidRenderer::Render(VoidImageData* data)
 
     /* Update the image data */
     m_ImageData = data;
+    /* Hide the Error Label */
+    m_DisplayLabel->setVisible(false);
 
     /* Trigger a Re-paint */
     update();
@@ -245,6 +257,8 @@ void VoidRenderer::Clear()
     m_ImageData = nullptr;
     /* Clear the frame */
     ClearFrame();
+    /* Hide the Error Label */
+    m_DisplayLabel->setVisible(false);
 
     /*
      * Trigger a Re-paint

--- a/src/VoidRenderer/Renderer.h
+++ b/src/VoidRenderer/Renderer.h
@@ -35,6 +35,18 @@ public:
     void ZoomOut(float factor = 0.9f);
     void ZoomToFit();
     void UpdateZoom(float zoom);
+
+    /*
+     * Set a Message to be displayed on the Renderer
+     * Mostly gets used to show error messages if anything is not working/available
+     */
+    inline void SetMessage(const std::string& message)
+    {
+        /* Update the display label */
+        m_DisplayLabel->setText(message.c_str());
+        /* And make it visible */
+        m_DisplayLabel->setVisible(true);
+    }
     
 protected:
     virtual void initializeGL() override;
@@ -50,6 +62,7 @@ protected:
 
 private: /* Members */
     RendererStatusBar* m_RenderStatus;
+    RendererDisplayLabel* m_DisplayLabel;
 
     /* Zoom Factor/Level on the Renderer */
     float m_ZoomFactor;

--- a/src/VoidRenderer/RendererStatus.cpp
+++ b/src/VoidRenderer/RendererStatus.cpp
@@ -6,6 +6,7 @@
 
 VOID_NAMESPACE_OPEN
 
+/* Color Widget {{{ */
 ColorWidget::ColorWidget(QWidget* parent)
     : QWidget(parent)
     , m_CurrentColor(Qt::black)
@@ -27,7 +28,54 @@ void ColorWidget::SetColor(const QColor& color)
     /* Repaint */
     update();
 }
+/* }}} */
 
+/* Renderer Diplay Label {{{ */
+RendererDisplayLabel::RendererDisplayLabel(QWidget* parent)
+    : QLabel(parent)
+{
+    Setup();
+}
+
+RendererDisplayLabel::RendererDisplayLabel(const std::string& text, QWidget* parent)
+    : QLabel(text.c_str(), parent)
+{
+    Setup();
+}
+
+void RendererDisplayLabel::paintEvent(QPaintEvent* event)
+{
+    /* Default Draw */
+    QLabel::paintEvent(event);
+
+    /* Painter to draw */
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    /* Add Rounded Border */
+    painter.setPen(QPen(Qt::black, 6));
+    painter.drawRoundedRect(rect().adjusted(-3, -3, 3, 3), 10, 10);
+}
+
+void RendererDisplayLabel::Setup()
+{
+    /* Setup how the Label and text appears */
+    QPalette palette;
+    /* Setup background */
+    palette.setColor(QPalette::Window, Qt::darkGray);
+    /* Text */
+    palette.setColor(QPalette::WindowText, Qt::black);
+    
+    setAutoFillBackground(true);
+    setPalette(palette);
+
+    /* Font Face */
+    QFont font("Arial", 20, QFont::Light);
+    setFont(font);
+}
+/* }}} */
+
+/* RendererStatusBar {{{ */
 RendererStatusBar::RendererStatusBar(QWidget* parent)
     : QWidget(parent)
 {
@@ -133,5 +181,6 @@ void RendererStatusBar::SetColourValues(const float r, const float g, const floa
     /* Update color preview */
     m_ColorPreview->SetColor(QColor(r * 255, g * 255, b * 255, a * 255));
 }
+/* }}} */
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidRenderer/RendererStatus.h
+++ b/src/VoidRenderer/RendererStatus.h
@@ -26,6 +26,19 @@ private: /* Members */
 
 };
 
+class RendererDisplayLabel : public QLabel
+{
+public:
+    RendererDisplayLabel(QWidget* parent = nullptr);
+    RendererDisplayLabel(const std::string& text, QWidget* parent = nullptr);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    void Setup();
+};
+
 class RendererStatusBar : public QWidget
 {
     Q_OBJECT

--- a/src/VoidUi/ControlBar.h
+++ b/src/VoidUi/ControlBar.h
@@ -2,6 +2,7 @@
 #define _VOID_VIEWER_CONTROL_BAR_H
 
 /* Qt */
+#include <QComboBox>
 #include <QLayout>
 #include <QPushButton>
 #include <QSlider>
@@ -48,6 +49,7 @@ public:
 
 signals:
     void zoomChanged(float factor);
+    void missingFrameHandlerChanged(int handler);
 
 private: /* Members */
     /* Base Layout */
@@ -57,6 +59,9 @@ private: /* Members */
     QPushButton* m_ZoomInButton;
     QPushButton* m_ZoomOutButton;
     ControlSlider* m_ZoomSlider;
+
+    /* Missing Frame Handler */
+    QComboBox* m_MissingFrameCombo;
 
 private: /* Methods */
     void Build();

--- a/src/VoidUi/MediaLister.cpp
+++ b/src/VoidUi/MediaLister.cpp
@@ -141,6 +141,12 @@ void VoidMediaLister::Build()
     /* Add to the base Layout */
     m_layout->addLayout(m_OptionsLayout);
     m_layout->addWidget(m_ScollArea);
+
+    /* Spacing */
+    int left, top, right, bottom;
+    m_layout->getContentsMargins(&left, &top, &right, &bottom);
+    /* Only adjust the right side spacing to make it cleaner against the viewer */
+    m_layout->setContentsMargins(left, top, 0, bottom);
 }
 
 void VoidMediaLister::Setup()

--- a/src/VoidUi/PlayerWidget.h
+++ b/src/VoidUi/PlayerWidget.h
@@ -19,6 +19,18 @@ class Player : public QWidget
     Q_OBJECT
 
 public:
+    /* Reprents how to handle missing frame */
+    enum class MissingFrameHandler : short
+    {
+        /* An error is displayed on the Viewport */
+        ERROR,
+        /* Nothing is displayed on the viewport */
+        BLACK_FRAME,
+        /* Continue to display the last frame on the viewport */
+        NEAREST
+    };
+
+public:
     Player(QWidget* parent = nullptr);
     virtual ~Player();
 
@@ -30,6 +42,20 @@ public:
 
     /* Set a frame on the player based on the media */
     void SetFrame(int frame);
+
+    /*
+     * Updates the Handler for Missing frame
+     * Setting the behaviour for when a missing frame is set
+     */
+    inline void SetMissingFrameHandler(int handler)
+    {
+        /* Update the missing frame handler */
+        m_MFrameHandler = static_cast<MissingFrameHandler>(handler);
+        /* And Refresh the viewport */
+        Refresh();
+    }
+
+    inline void Refresh() { SetFrame(m_Timeline->Frame()); }
 
     /* Zoom on the Viewport */
     inline void ZoomIn() { m_Renderer->ZoomIn(); }
@@ -44,7 +70,7 @@ public:
     inline void SetRange(int start, int end) { m_Timeline->SetRange(start, end); }
 
     /*
-     * Timeline Controls: 
+     * Timeline Controls:
      * Below methods expose the functionality from the timeline
      * These are required to be able to govern the play state or set any frame according
      * to the current timeline state
@@ -72,6 +98,9 @@ private:  /* Methods */
     /* Loads the frame from the underlying sequence */
     void SetSequenceFrame(int frame);
 
+    /* Load the frame from a given track item from the sequence/track */
+    void SetTrackItemFrame(SharedTrackItem item, const int frame);
+
     /* Loads the frame from the media in the player */
     void SetMediaFrame(int frame);
 
@@ -79,8 +108,8 @@ private:  /* Members */
     VoidRenderer* m_Renderer;
     Timeline* m_Timeline;
 
-    /* 
-     * The control bar provides users tools to play around with the viewer 
+    /*
+     * The control bar provides users tools to play around with the viewer
      * Providing tweak controls and how the viewer behaves
      */
     ControlBar* m_ControlBar;
@@ -91,18 +120,15 @@ private:  /* Members */
     /* Sequence to be rendered */
     SharedPlaybackSequence m_Sequence;
 
-    /* 
-     * Default VoidImageData* which can be used to read data from the Sequence
-     * This pointer would get updated with data for each frame and then Render it
-     */
-    VoidImageData* m_Image;
-
     /*
      * This boolean reprents the state of playing on the Player
      * Is the Player looking at reading the Sequence of Media(s)
      * Or is the Player looking at playing the Media (which is default)
      */
     bool m_PlaySequence;
+
+    /* Holds the Mode of representing Missing Frames */
+    MissingFrameHandler m_MFrameHandler;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequence.cpp
+++ b/src/VoidUi/Sequence.cpp
@@ -136,13 +136,29 @@ bool PlaybackSequence::GetImage(const int frame, VoidImageData* image) const
      * The sequence always returns back the data from the track which is at the top of the stack
      * Meaning bottom of (last added to) the underlying video tracks
      */
-    if (!m_VideoTracks.empty() && !m_VideoTracks.back()->IsEmpty())
+    if (!m_VideoTracks.empty() && !m_VideoTracks.back()->IsEmpty()) // TODO: FIX this -- The last Track could be just empty but others above it may not be
     {
         return m_VideoTracks.back()->GetImage(frame, image);
     }
 
     /* Either the sequence is empty or the Video Track is empty */
     return false;
+}
+
+SharedTrackItem PlaybackSequence::GetTrackItem(const int frame) const
+{
+    /*
+     * When the Sequence is asked for an image for a given frame
+     * The sequence always returns back the data from the track which is at the top of the stack
+     * Meaning bottom of (last added to) the underlying video tracks
+     */
+    if (!m_VideoTracks.empty() && !m_VideoTracks.back()->IsEmpty()) // TODO: FIX this -- The last Track could be just empty but others above it may not be
+    {
+        return m_VideoTracks.back()->GetTrackItem(frame);
+    }
+
+    /* There is nothing in the sequence */
+    return nullptr;
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequence.h
+++ b/src/VoidUi/Sequence.h
@@ -54,6 +54,8 @@ public:
      */
     bool GetImage(const int frame, VoidImageData* image) const;
 
+    SharedTrackItem GetTrackItem(const int frame) const;
+
 signals: /* Signals denoting actions in the seqeuence */
     void trackAdded();
     void cleared();

--- a/src/VoidUi/Track.cpp
+++ b/src/VoidUi/Track.cpp
@@ -115,6 +115,13 @@ bool PlaybackTrack::GetImage(const int frame, VoidImageData* image)
         if (item->GetMedia().InRange(f))
         {
             /*
+             * Check for a case where the frame lies in the range of media but is still not available to read
+             * Reason could be that it is missing
+             */
+            if (!item->GetMedia().Contains(f))
+                return false;
+
+            /*
              * Copy the data of the VoidImageData* which we'll update for anyone to access
              */
             std::memcpy(image, item->GetMedia().Image(f), sizeof(VoidImageData));
@@ -132,6 +139,26 @@ bool PlaybackTrack::GetImage(const int frame, VoidImageData* image)
 
     /* The provided frame from the timeline does not have any trackitem/media on it */
     return false;
+}
+
+SharedTrackItem PlaybackTrack::GetTrackItem(const int frame) const
+{
+    for (SharedTrackItem item: m_TrackItems)
+    {
+        /*
+         * Check whether the current frame + the offset on the trackItem
+         * exists in the range of the Media, if so update the pointer to the data with the
+         * data from the Media and we can return true indicating a frame is successfully found
+         */
+        int f = frame + item->GetOffset();
+        if (item->GetMedia().InRange(f))
+        {
+            return item;
+        }
+    }
+
+    /* The provided frame from the timeline does not have any trackitem/media on it */
+    return nullptr;
 }
 
 void PlaybackTrack::Cache()

--- a/src/VoidUi/Track.h
+++ b/src/VoidUi/Track.h
@@ -74,6 +74,12 @@ public:
      */
     bool GetImage(const int frame, VoidImageData* image);
 
+    /*
+     * From the track, return the track item which is present at a given frame in the timeline
+     * Returns nullptr if there is no trackitem at the given timeframe
+     */
+    SharedTrackItem GetTrackItem(const int frame) const;
+
     /* The parent of the Track should always be a Sequence, in case it exists inside a Sequence */
     inline PlaybackSequence* Sequence() const { return reinterpret_cast<PlaybackSequence*>(parent()); }
 

--- a/src/VoidUi/TrackItem.cpp
+++ b/src/VoidUi/TrackItem.cpp
@@ -57,4 +57,21 @@ void TrackItem::Cache()
     }
 }
 
+VoidImageData* TrackItem::GetImage(const int frame)
+{
+    /* Update the frame value with the offset so that we match the original media range */
+    int f = frame + m_Offset;
+
+    if (m_Media.Contains(f))
+    {
+        /* Emit that the frame from the timeline was cached -- in case it was not before */
+        emit frameCached(frame);
+
+        return m_Media.Image(f);
+    }
+
+    /* The provided frame is not present in the Media */
+    return nullptr;
+}
+
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/TrackItem.h
+++ b/src/VoidUi/TrackItem.h
@@ -53,8 +53,24 @@ public:
     inline int GetOffset() const { return m_Offset; }
     inline Media GetMedia() const { return m_Media; }
 
+    /*
+     * Retrieves the image pointer from the media for a frame which has to be offsetted by the current offset
+     */
+    VoidImageData* GetImage(const int frame);
+
     inline int StartFrame() const { return m_StartFrame; }
     inline int EndFrame() const { return m_EndFrame; }
+
+    /*
+     * Returns the nearest frame of a given frame from the media in TrackItem space
+     * This means that the output frame is negated with the offset of the track item
+     * E.g. Media's nearest frame for 1003 is 1001 and the offset of the Track Item is 1001
+     * Hence for frame 3, the nearest frame is 0 by adding offset and querying media for nearest frame and
+     * then negating back the offset
+     * 
+     * TODO: See if we can improve our logic to get a frame value or Image Data directly?
+     */
+    inline int NearestFrame(const int frame) const { return m_Media.NearestFrame(frame + m_Offset) - m_Offset; }
 
     /* TODO: Cache the First frame and last frame for Media in that class */
     inline int MediaFirstFrame() const { return m_Media.FirstFrame(); }


### PR DESCRIPTION
### Feature: Missing Frame Handler
* Added Support for how media with any missing frames are dealt with.
* Added Handler to set behaviour in case of any missing frames in the media.
### Feature: Media
* Optimised the approach to read the first and last frame of any media during loading.
* Added support to find out where the provided frame exists in the media to be able to be read.
### Feature: Renderer
* Added Display Message Label on the Renderer viewport to show any type of messages. (mostly error or warnings to be displayed)
