### PR TITLE
[VOID] ViewerBuffer: Added Viewer Buffer

### DIFF
--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
     TitleBar.cpp
     Track.cpp
     TrackItem.cpp
+    ViewerBuffer.cpp
     VoidStyle.cpp
 )
 

--- a/src/VoidUi/MediaItem.cpp
+++ b/src/VoidUi/MediaItem.cpp
@@ -18,7 +18,7 @@ VoidMediaItem::VoidMediaItem(const SharedMediaClip& media, QWidget* parent)
     , m_Selected(false)
     , m_Playing(false)
     , m_Clip(media)
-    , m_AssociatedColor(VOID_PURPLE_COLOR)
+    , m_AssociatedColor(media->Color())
 {
     /* Build the layout */
     Build();

--- a/src/VoidUi/PlayerWindow.h
+++ b/src/VoidUi/PlayerWindow.h
@@ -138,6 +138,9 @@ private: /* Members */
     QAction* m_ZoomInAction;
     QAction* m_ZoomOutAction;
     QAction* m_ZoomToFitAction;
+    /* TODO: Remove this when we have our viewer buffer selector on the Viewer */
+    QAction* m_SetViewBufferA;
+    QAction* m_SetViewBufferB;
 
     /* Window Menu */
     QMenu* m_WindowMenu;

--- a/src/VoidUi/Sequence.cpp
+++ b/src/VoidUi/Sequence.cpp
@@ -47,7 +47,7 @@ void PlaybackSequence::AddVideoTrack(const SharedPlaybackTrack& track)
     /* Connect the signal from the underlying pointer to the Track to updating the range of the sequence */
     connect(track.get(), &PlaybackTrack::rangeChanged, this, &PlaybackSequence::UpdateRange);
 
-    /*
+    /**
      * Inorder to update the range on the sequence, we need to see
      * the minimum frame (existing or the provided track) gets set as the start frame
      * and the maximum frame (existing or the provided track) gets set as the end frame
@@ -65,7 +65,7 @@ void PlaybackSequence::AddAudioTrack(const SharedPlaybackTrack& track)
     /* Update the Audio tracks with the provided new track */
     m_AudioTracks.push_back(track);
 
-    /*
+    /**
      * Inorder to update the range on the sequence, we need to see
      * the minimum frame (existing or the provided track) gets set as the start frame
      * and the maximum frame (existing or the provided track) gets set as the end frame
@@ -80,7 +80,7 @@ void PlaybackSequence::AddAudioTrack(const SharedPlaybackTrack& track)
 
 void PlaybackSequence::UpdateRange(int start, int end)
 {
-    /*
+    /**
      * Inorder to update the range on the sequence, we need to see
      * the minimum frame (existing or the provided start) gets set as the start frame
      * and the maximum frame (existing or the provided end) gets set as the end frame
@@ -103,7 +103,7 @@ void PlaybackSequence::UpdateRange(int start, int end)
 
 bool PlaybackSequence::HasMedia() const
 {
-    /*
+    /**
      * A sequence can be said empty if there are no tracks on it
      * But the same seqeunce can have track(s) but no media in them
      * This means that the sequence is not empty but has no media on it to be played
@@ -131,7 +131,7 @@ bool PlaybackSequence::HasMedia() const
 
 bool PlaybackSequence::GetImage(const int frame, VoidImageData* image) const
 {
-    /*
+    /**
      * When the Sequence is asked for an image for a given frame
      * The sequence always returns back the data from the track which is at the top of the stack
      * Meaning bottom of (last added to) the underlying video tracks
@@ -145,9 +145,25 @@ bool PlaybackSequence::GetImage(const int frame, VoidImageData* image) const
     return false;
 }
 
+SharedPlaybackTrack PlaybackSequence::ActiveVideoTrack() const
+{
+    for (auto it = m_VideoTracks.rbegin(); it != m_VideoTracks.rend(); ++it)
+    {
+        /**
+         * Check if the iterated upon track Active?
+         * Meaning its both enabled and visible, if found -> return it
+         */
+        if ((*it)->Active())
+            return *it;
+    }
+
+    /* None of the tracks of the sequence are active or there are no tracks at all */
+    return nullptr;
+}
+
 SharedTrackItem PlaybackSequence::GetTrackItem(const int frame) const
 {
-    /*
+    /**
      * When the Sequence is asked for an image for a given frame
      * The sequence always returns back the data from the track which is at the top of the stack
      * Meaning bottom of (last added to) the underlying video tracks

--- a/src/VoidUi/Sequence.h
+++ b/src/VoidUi/Sequence.h
@@ -47,12 +47,17 @@ public:
     /* Update the range of the Sequence */
     void SetRange(int start, int end);
 
-    /*
+    /**
      * Update the Provided Pointer to VoidImageData with the data of the Media if it exists
      * for the provided frame in the timeline
      * Returns a Bool value to give back a status as to indicate whether the frame exists or not
      */
     bool GetImage(const int frame, VoidImageData* image) const;
+
+    /**
+     * Returns the last track that is active
+     */
+    SharedPlaybackTrack ActiveVideoTrack() const;
 
     SharedTrackItem GetTrackItem(const int frame) const;
 
@@ -63,7 +68,7 @@ signals: /* Signals denoting actions in the seqeuence */
     /* This signal denotes that something in the sequence was changed/modified i.e. updated */
     void updated();
 
-    /*
+    /**
      * Emitted when the time range of the sequence has changed
      * includes the start and end frame of the sequence
      */
@@ -79,7 +84,7 @@ protected: /* Members */
     int m_StartFrame, m_EndFrame;
 
 private: /* Methods */
-    /*
+    /**
      * This method is responsible for updating the range of the sequence based on
      * any changes that have been made to underlying tracks of whose range has been updated
      * This method checks the current start and end frame and then evaluates the min and max of

--- a/src/VoidUi/Timeline.cpp
+++ b/src/VoidUi/Timeline.cpp
@@ -161,7 +161,7 @@ void Timeslider::paintEvent(QPaintEvent* event)
 	int range = maximum() - minimum();
 
 	/* Number of frames to be drawn */
-	int number = range / SL_MARKING_STEP;
+	int number = std::max(range / SL_MARKING_STEP, 1);	// ensure that we don't divide by zero
 
 	/* Step here would give the step based on the number of markings are being generated */
 	int step = range / number;

--- a/src/VoidUi/Track.cpp
+++ b/src/VoidUi/Track.cpp
@@ -10,6 +10,8 @@ PlaybackTrack::PlaybackTrack(QObject* parent)
     : QObject(parent)
     , m_StartFrame(0)
     , m_EndFrame(0)
+    , m_Visible(true)
+    , m_Enabled(true)
     , m_Color(130, 110, 190)    /* Default Purple */
 {
 }
@@ -29,7 +31,7 @@ void PlaybackTrack::SetMedia(const SharedMediaClip& media)
     /* Unblock signals */
     blockSignals(b);
 
-    /*
+    /**
      * When the media gets added, the update and rangeChanged signals are emitted accordingly
      * hence this operation is being performed after the signals have been unblocked and we'll
      * let the other method handle the signals for this operation
@@ -63,14 +65,14 @@ void PlaybackTrack::AddMedia(const SharedMediaClip& media)
     /* Connect to Allow frameCache signal be invoked when media in the track item is cached */
     connect(trackItem.get(), &TrackItem::frameCached, this, [this](int frame) { emit frameCached(frame); });
 
-    /*
+    /**
      * When the media gets added, it always gets added towards the right side which means the start frame
      * would never change in this case and only would result in a change in the last frame
      * which gets calculated based on previous last frame
      */
     m_TrackItems.push_back(trackItem);
 
-    /*
+    /**
      * Since the media is getting added to the start frame should just remain the same,
      * while the updated end frame along with the original start should get emitted to notify others
      */
@@ -79,7 +81,7 @@ void PlaybackTrack::AddMedia(const SharedMediaClip& media)
 
 void PlaybackTrack::Clear()
 {
-    /*
+    /**
      * Clearing a Track means we are getting rid of all the media that has
      * been added to the track first, once the media is cleared from the store
      * the range of the track needs to be reset to the default range of 0 - 0
@@ -110,7 +112,7 @@ bool PlaybackTrack::GetImage(const int frame, VoidImageData* image)
 {
     for (SharedTrackItem item: m_TrackItems)
     {
-        /*
+        /**
          * Check whether the current frame + the offset on the trackItem
          * exists in the range of the Media, if so update the pointer to the data with the
          * data from the Media and we can return true indicating a frame is successfully found
@@ -118,19 +120,19 @@ bool PlaybackTrack::GetImage(const int frame, VoidImageData* image)
         int f = frame + item->GetOffset();
         if (item->GetMedia()->InRange(f))
         {
-            /*
+            /**
              * Check for a case where the frame lies in the range of media but is still not available to read
              * Reason could be that it is missing
              */
             if (!item->GetMedia()->Contains(f))
                 return false;
 
-            /*
+            /**
              * Copy the data of the VoidImageData* which we'll update for anyone to access
              */
             std::memcpy(image, item->GetMedia()->Image(f), sizeof(VoidImageData));
 
-            /*
+            /**
              * Once the Pointer data is copied ->
              * emit the frameCached signal to indicate that this frame data is now available on the Media Class
              */
@@ -149,7 +151,7 @@ SharedTrackItem PlaybackTrack::GetTrackItem(const int frame) const
 {
     for (SharedTrackItem item: m_TrackItems)
     {
-        /*
+        /**
          * Check whether the current frame + the offset on the trackItem
          * exists in the range of the Media, if so update the pointer to the data with the
          * data from the Media and we can return true indicating a frame is successfully found

--- a/src/VoidUi/Track.h
+++ b/src/VoidUi/Track.h
@@ -76,18 +76,26 @@ public:
     /* Returns the Color associated with the Track */
     inline QColor Color() const { return m_Color; }
 
-    /*
+    /**
      * Update the Provided Pointer to VoidImageData with the data of the Media if it exists
      * for the provided frame in the timeline
      * Returns a Bool value to give back a status as to indicate whether the frame exists or not
      */
-    /*
+    /**
      * This function is marked non-const as we're emitting a signal from the function itself
      * TODO: investigate a better way to handle the signal of frameCached
      */
     bool GetImage(const int frame, VoidImageData* image);
 
-    /*
+    /**
+     * Describes whether a track is active for playback or taking in elements with menu options
+     */
+    [[nodiscard]] inline bool Active() const { return m_Visible && m_Enabled; }
+
+    inline bool Visible() const { return m_Visible; }
+    inline bool Enabled() const { return m_Enabled; }
+
+    /**
      * From the track, return the track item which is present at a given frame in the timeline
      * Returns nullptr if there is no trackitem at the given timeframe
      */
@@ -98,7 +106,7 @@ public:
 
     /* Setters */
 
-    /*
+    /**
      * The track's range is always defined by the track items in it
      * The only thing which can/should be changed of a track is the starting frame
      */
@@ -111,13 +119,13 @@ signals: /* Signals Denoting actions in the Track */
     /* This signal denotes that something in the track was changed/modified i.e. updated */
     void updated();
 
-    /*
+    /**
      * Emitted when the time range of the track has changed
      * includes the start and end frame of the track
      */
     void rangeChanged(int start, int end);
 
-    /*
+    /**
      * Emitted when a frame is cached
      * The cache could happen when the media cache operation is run continuously on a thread
      * Or if the frame is queried by the viewport
@@ -131,6 +139,11 @@ protected: /* Members */
     std::vector<SharedTrackItem> m_TrackItems;
 
     int m_StartFrame, m_EndFrame;
+
+    /* State whether the track is visible */
+    bool m_Visible;
+    /* State whether the track is enabled */
+    bool m_Enabled;
 
     /* The color associated with the track */
     QColor m_Color;

--- a/src/VoidUi/ViewerBuffer.cpp
+++ b/src/VoidUi/ViewerBuffer.cpp
@@ -1,0 +1,109 @@
+/* Internal */
+#include "ViewerBuffer.h"
+
+VOID_NAMESPACE_OPEN
+
+ViewerBuffer::ViewerBuffer(QObject* parent)
+    : QObject(parent)
+    , m_Clip(std::make_shared<MediaClip>())
+    , m_Track(std::make_shared<PlaybackTrack>())
+    , m_Sequence(std::make_shared<PlaybackSequence>())
+    , m_PlayingComponent(PlayableComponent::Clip)
+    , m_Startframe(0)
+    , m_Endframe(1)
+    , m_Color(130, 110, 190)    // Purple
+{
+}
+
+ViewerBuffer::~ViewerBuffer()
+{
+}
+
+void ViewerBuffer::Set(const SharedMediaClip& media)
+{
+    /* Update the internal media clip */
+    m_Clip = media;
+
+    /* Update the color on the Media to indicate that it belongs to this buffer */
+    m_Clip->SetColor(m_Color);
+
+    /* Update the current Playing Component */
+    m_PlayingComponent = PlayableComponent::Clip;
+
+    /* Update frame range */
+    m_Startframe = m_Clip->FirstFrame();
+    m_Endframe = m_Clip->LastFrame();
+}
+
+void ViewerBuffer::Set(const SharedPlaybackTrack& track)
+{
+    /* Update the internal track */
+    m_Track = track;
+
+    /* Update the color on the Track to indicate that it belongs to this buffer */
+    m_Track->SetColor(m_Color);
+
+    /* Update the current Playing component */
+    m_PlayingComponent = PlayableComponent::Track;
+
+    /* Update frame range */
+    m_Startframe = m_Track->StartFrame();
+    m_Endframe = m_Track->EndFrame();
+}
+
+void ViewerBuffer::Set(const SharedPlaybackSequence& sequence)
+{
+    /* Update the internal sequence */
+    m_Sequence = sequence;
+
+    /* Update the current Playing Component */
+    m_PlayingComponent = PlayableComponent::Sequence;
+
+    /* Update frame range */
+    m_Startframe = m_Sequence->StartFrame();
+    m_Endframe = m_Sequence->EndFrame();
+}
+
+void ViewerBuffer::SetColor(const QColor& color)
+{
+    /* Update the Buffer Color */
+    m_Color = color;
+
+    /* Update entities with the color change */
+    m_Clip->SetColor(color);
+    m_Track->SetColor(color);
+}
+
+SharedPlaybackTrack ViewerBuffer::ActiveTrack() const
+{
+    switch (m_PlayingComponent)
+    {
+        case PlayableComponent::Clip:
+            /**
+             * A clip is a separate entity and does not relate to track
+             * If a clip is active then it should be the one currently playing and no track
+             */
+            return nullptr;
+        case PlayableComponent::Track:
+            /**
+             * If the current playing component itself is a track, then it will be considered
+             * as the active track, this could involve in adding elements to the active track
+             */
+            return m_Track;
+        case PlayableComponent::Sequence:
+            /**
+             * If a sequence is currently playing, then this returns the currently active track
+             * Meaning the track which is on the very top and also which is both enabled and visible
+             * for it to recieve new entities and also show entities
+             */
+            /**
+             * TODO: Need to think about, if this is really needed when right clicking > add media to sequence?
+             * if added, where does the media go to? at the last of track or clears it?
+             */
+            return m_Sequence->ActiveVideoTrack();
+    }
+
+    return nullptr;
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/ViewerBuffer.h
+++ b/src/VoidUi/ViewerBuffer.h
@@ -1,0 +1,111 @@
+#ifndef _VOID_VIEWER_BUFFER_H
+#define _VOID_VIEWER_BUFFER_H
+
+/* Qt */
+#include <QColor>
+#include <QObject>
+
+/* Internal */
+#include "Definition.h"
+#include "MediaClip.h"
+#include "Track.h"
+#include "Sequence.h"
+
+VOID_NAMESPACE_OPEN
+
+class ViewerBuffer : public QObject
+{
+    Q_OBJECT
+
+public: /* Enums */
+    /**
+     * Describes the playing components on the Buffer
+     * The components are Media Clip
+     * Track from a Sequence
+     * The entire sequence which means all tracks are included and their priority
+     * are controlled by the sequence itself
+     */
+    enum class PlayableComponent
+    {
+        Sequence,
+        Track,
+        Clip
+    };
+
+public:
+    ViewerBuffer(QObject* parent = nullptr);
+    ~ViewerBuffer();
+
+    SharedPlaybackTrack ActiveTrack() const;
+
+    /**
+     * Range for the buffer
+     */
+    inline int StartFrame() const { return m_Startframe; }
+    inline int EndFrame() const { return m_Endframe; }
+
+    /**
+     * Returns the current Component Type which is playing in the buffer
+     */
+    inline PlayableComponent PlayingComponent() const { return m_PlayingComponent; }
+
+    /**
+     * Returns a track item at a given frame
+     */
+    inline SharedTrackItem TrackItem(const int frame) const
+    {
+        /* Return from the sequence if that is currently playing */
+        if (m_PlayingComponent == PlayableComponent::Sequence)
+            return m_Sequence->GetTrackItem(frame);
+
+        /* Else return from the track */
+        return m_Track->GetTrackItem(frame);
+    }
+
+    /**
+     * Returns the shared media clip instance
+     */
+    inline SharedMediaClip GetMediaClip() const { return m_Clip; }
+
+    /**
+     * Returns the shared media track instance
+     */
+    inline SharedPlaybackTrack GetTrack() const { return m_Track; }
+    
+    /**
+     * Returns the shared sequence instance
+     */
+    inline SharedPlaybackSequence GetSequence() const { return m_Sequence; }
+
+    /**
+     * Set a playable component on the Buffer
+     */
+    void Set(const SharedMediaClip& media);
+    void Set(const SharedPlaybackTrack& track);
+    void Set(const SharedPlaybackSequence& sequence);
+
+    void SetColor(const QColor& color);
+
+private: /* Members */
+    /**
+     * Playable Entities 
+     * Obviously one will get played at a time but can be governed what gets played
+     */
+    SharedMediaClip m_Clip;
+    SharedPlaybackTrack m_Track;
+    SharedPlaybackSequence m_Sequence;
+
+    /* Currently playing component */
+    PlayableComponent m_PlayingComponent;
+
+    /* Frame range of the playing component */
+    int m_Startframe, m_Endframe;
+
+    /* Color associated with the Buffer to indicate where possible */
+    QColor m_Color;
+
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _VOID_VIEWER_BUFFER_H


### PR DESCRIPTION
### Feature: Viewer Buffer Entity
* Added Viewer Buffer to serve as the intermediate layer holding playable entities
* The viewerbuffer is responsible to know what component is currently being played, Clip, Sequence or a track
* The Viewer Buffer will evnetually get its UI on the player tools and will allow choosing what is being currently played
* The player now uses the viewerbuffer to query playable entities and play them accordingly
* The player gets 2 viewer buffers and maintains a state of Active Viewer Buffer.