### PR TITLE
[VOID] Clip is Connected to the timeline on the player widget

### DIFF
--- a/src/VoidUi/MediaClip.cpp
+++ b/src/VoidUi/MediaClip.cpp
@@ -13,6 +13,7 @@ MediaClip::MediaClip(const Media& media, QObject* parent)
     : VoidObject(parent)
     , m_Media(media)
 {
+    VOID_LOG_INFO("Clip Created: {0}", Vuid());
 }
 
 MediaClip::~MediaClip()

--- a/src/VoidUi/PlayerWidget.cpp
+++ b/src/VoidUi/PlayerWidget.cpp
@@ -95,6 +95,9 @@ void Player::Load(const SharedMediaClip& media)
     /* Update what's currently being played on the viewer buffer */
     m_ActiveViewBuffer->Set(media);
 
+    /* Viewer Buffer - Clip -> Player - Add Cache Frame */
+    ConnectMediaClipToTimeline(media);
+
     /**
      * Once we have the image sequence,
      * First update the timeslider range,

--- a/src/VoidUi/PlayerWidget.h
+++ b/src/VoidUi/PlayerWidget.h
@@ -144,6 +144,14 @@ private:  /* Methods */
     /* Loads the frame from the media in the player */
     void SetMediaFrame(int frame);
 
+    /**
+     * Connects the signals from SharedMediaClip (i.e. shared_ptr for MediaClip)
+     */
+    inline void ConnectMediaClipToTimeline(const SharedMediaClip& clip)
+    {
+        connect(clip.get(), &MediaClip::frameCached, this, &Player::AddCacheFrame);
+    }
+
 private:  /* Members */
     VoidRenderer* m_Renderer;
     Timeline* m_Timeline;

--- a/src/VoidUi/PlayerWindow.cpp
+++ b/src/VoidUi/PlayerWindow.cpp
@@ -410,12 +410,8 @@ void VoidMainWindow::ImportMedia(const std::string& path)
     // m_Track->SetStartFrame(m_Media.FirstFrame());
     SharedMediaClip clip = std::make_shared<MediaClip>(m_Media);
 
-    /* Connect frameCached - Timeline::AddCacheFrame*/
-    ConnectMediaClipToTimeline(clip);
-
     /* Load the clip on the player */
     m_Player->Load(clip);
-
 
     /* Add the media clip on the Media Lister */
     m_MediaLister->AddMedia(clip);

--- a/src/VoidUi/PlayerWindow.h
+++ b/src/VoidUi/PlayerWindow.h
@@ -77,14 +77,6 @@ public:
 private: /* Methods */
     void Build();
     void Connect();
-    
-    /*
-     * Connects the signals from SharedMediaClip (i.e. shared_ptr for MediaClip)
-     */
-    inline void ConnectMediaClipToTimeline(const SharedMediaClip& clip)
-    {
-        connect(clip.get(), &MediaClip::frameCached, m_Player, &Player::AddCacheFrame);
-    }
 
 protected:
     void showEvent(QShowEvent* event) override;


### PR DESCRIPTION
### Improvement
* All instantiated clips are now connected to the player on the class itself.