### PR TITLE
VOID: Window Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
 option(USE_FRAMED_WINDOW "Enable using Framed Window borders, which is native themed." OFF)
 
 # Mac has it turned on by default unless we don't want it there as well
-if(APPLE AND NOT DEFINED USE_FRAMED_WINDOW)
+if(APPLE)
     set(USE_FRAMED_WINDOW ON)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.7.0)
 
 project(VOID VERSION 0.0.1 LANGUAGES CXX)
 
@@ -9,12 +9,27 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOMOC ON)
 
-if (CMAKE_VERSION VERSION_LESS "3.7.0")
-    set(CMAKE_INCLUDE_CURRENT_DIR ON)
-endif()
-
 # USE CXX11 ABI
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+
+# An explicit option to allow compiling the GUI frameless or with Window borders
+# it's a debate about whether the feature should be inbuilt and an option to switch to either
+# but the frameless way at the moment does not look really nice in mac when mac pulls the menubar away and we're
+# only left with the icon on the left side and window buttons on the right
+# for now, let's have it enabled on compile if we need it or not, later this might change and we have a full frameless
+# or a framed window
+option(USE_FRAMED_WINDOW "Enable using Framed Window borders, which is native themed." OFF)
+
+# Mac has it turned on by default unless we don't want it there as well
+if(APPLE AND NOT DEFINED USE_FRAMED_WINDOW)
+    set(USE_FRAMED_WINDOW ON)
+endif()
+
+# Add Definition for the code to use the flag
+if (USE_FRAMED_WINDOW)
+    message(STATUS "Compiling with Framed Window")
+    add_compile_definitions(USE_FRAMED_WINDOW)
+endif()
 
 # Core Depends on Qt5/Qt6 | OpenGL
 # Supporting both Qt5 and Qt6 at the moment as they are mostly compatible with minor changes

--- a/build_launch.sh
+++ b/build_launch.sh
@@ -37,7 +37,7 @@ if [ "$CLEAR" == true ]; then
 fi
 
 if [ "$BUILD_ONLY" == true ]; then
-    cmake -S . -B _build -DCMAKE_BUILD_TYPE=debug -DCMAKE_VERBOSE_MAKEFILE=ON && make -C _build
+    cmake -S . -B _build -DCMAKE_BUILD_TYPE=debug -DCMAKE_VERBOSE_MAKEFILE=ON && make -C _build -j$(nproc)
     exit 0
 fi
 
@@ -51,8 +51,8 @@ fi
 # Release build does not include logging
 if [[ "$DEBUG" == true ]]; then
     echo -e "\n\n\nRunning with GDB\n\n\n"
-    cmake -S . -B _build -DCMAKE_BUILD_TYPE=debug -DCMAKE_VERBOSE_MAKEFILE=ON && make -C _build && gdb -ex run --args ./_build/src/VOID
+    cmake -S . -B _build -DCMAKE_BUILD_TYPE=debug -DCMAKE_VERBOSE_MAKEFILE=ON && make -C _build -j$(nproc) && gdb -ex run --args ./_build/src/VOID
 else
-    cmake -S . -B _build -DCMAKE_BUILD_TYPE=debug -DCMAKE_VERBOSE_MAKEFILE=ON && make -C _build && ./_build/src/VOID
+    cmake -S . -B _build -DCMAKE_BUILD_TYPE=debug -DCMAKE_VERBOSE_MAKEFILE=ON && make -C _build -j$(nproc) && ./_build/src/VOID
 fi
 

--- a/src/VoidUi/BaseWindow.cpp
+++ b/src/VoidUi/BaseWindow.cpp
@@ -2,15 +2,18 @@
 #include <QMouseEvent>
 
 /* Internal */
-#include "FramelessWindow.h"
+#include "BaseWindow.h"
 #include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
 
+/* If we're not using framed window -> Going for the custom frameless base */
+#ifndef USE_FRAMED_WINDOW
+
 static const int RESIZE_MARGIN = 10;
 static const int TITLEBAR_MARGIN = 40;
 
-FramelessWindow::FramelessWindow(QWidget* parent)
+BaseWindow::BaseWindow(QWidget* parent)
     : QMainWindow(parent)
     , m_Resize(ResizeType::None)
     , m_Dragging(false)
@@ -19,8 +22,8 @@ FramelessWindow::FramelessWindow(QWidget* parent)
     setWindowFlags(Qt::FramelessWindowHint);
 }
 
-#if _QT6 /* Qt 6 Compatible */
-void FramelessWindow::mousePressEvent(QMouseEvent* event)
+#if _QT6        /* Qt 6 Compat */
+void BaseWindow::mousePressEvent(QMouseEvent* event)
 {
     /* Window geometry */
     QRect window = geometry();
@@ -29,44 +32,44 @@ void FramelessWindow::mousePressEvent(QMouseEvent* event)
     Point pos = event->position();
 
     /* TODO: Add all types of resize operations */
-    if (pos.x() > window.width() - RESIZE_MARGIN && pos.y() > window.height() - RESIZE_MARGIN)    /* Bottom Right */
+    if (pos.x() > window.width() - RESIZE_MARGIN && pos.y() > window.height() - RESIZE_MARGIN)   /* Bottom Right */
     {
         m_Resize = ResizeType::BottomRight;
         m_LastPos = event->globalPosition();
     }
-    else if (pos.x() < RESIZE_MARGIN && pos.y() > window.height() - RESIZE_MARGIN)                /* Bottom Left */
+    else if (pos.x() < RESIZE_MARGIN && pos.y() > window.height() - RESIZE_MARGIN)               /* Bottom Left */
     {
         m_Resize = ResizeType::BottomLeft;
         m_LastPos = event->globalPosition();
     }
-    else if (pos.y() > window.height() - RESIZE_MARGIN)                                        /* Bottom */
+    else if (pos.y() > window.height() - RESIZE_MARGIN)                                          /* Bottom */
     {
         m_Resize = ResizeType::Bottom;
         m_LastPos = event->globalPosition();
     }
-    else if (pos.x() > window.width() - RESIZE_MARGIN)                                               /* Right */
+    else if (pos.x() > window.width() - RESIZE_MARGIN)                                           /* Right */
     {
         m_Resize = ResizeType::Right;
         m_LastPos = event->globalPosition();
     }
-    else if (pos.x() < RESIZE_MARGIN && pos.y() < RESIZE_MARGIN)                                  /* Top Left */
+    else if (pos.x() < RESIZE_MARGIN && pos.y() < RESIZE_MARGIN)                                 /* Top Left */
     {
         m_Resize = ResizeType::TopLeft;
         m_LastPos = event->globalPosition();
     }
-    else if (pos.x() < RESIZE_MARGIN)                                                                /* Left */
+    else if (pos.x() < RESIZE_MARGIN)                                                            /* Left */
     {
         m_Resize = ResizeType::Left;
         m_LastPos = event->globalPosition();
     }
-    else if (event->position().y() < TITLEBAR_MARGIN)                                             /* Title Bar Drag Operation */
+    else if (event->position().y() < TITLEBAR_MARGIN)                                            /* Title Bar Drag Operation */
     {
         m_Dragging = true;
         m_LastPos = event->globalPosition();
     }
 }
 
-void FramelessWindow::mouseMoveEvent(QMouseEvent* event)
+void BaseWindow::mouseMoveEvent(QMouseEvent* event)
 {
     /* Window DRAGGING {{{ */
     if (m_Dragging)
@@ -189,7 +192,7 @@ void FramelessWindow::mouseMoveEvent(QMouseEvent* event)
     /* }}} */
 }
 #else
-void FramelessWindow::mousePressEvent(QMouseEvent* event)
+void BaseWindow::mousePressEvent(QMouseEvent* event)
 {
     /* Window geometry */
     QRect window = geometry();
@@ -208,12 +211,12 @@ void FramelessWindow::mousePressEvent(QMouseEvent* event)
         m_Resize = ResizeType::BottomLeft;
         m_LastPos = event->globalPos();
     }
-    else if (pos.y() > window.height() - RESIZE_MARGIN)                                        /* Bottom */
+    else if (pos.y() > window.height() - RESIZE_MARGIN)                                           /* Bottom */
     {
         m_Resize = ResizeType::Bottom;
         m_LastPos = event->globalPos();
     }
-    else if (pos.x() > window.width() - RESIZE_MARGIN)                                               /* Right */
+    else if (pos.x() > window.width() - RESIZE_MARGIN)                                            /* Right */
     {
         m_Resize = ResizeType::Right;
         m_LastPos = event->globalPos();
@@ -223,19 +226,19 @@ void FramelessWindow::mousePressEvent(QMouseEvent* event)
         m_Resize = ResizeType::TopLeft;
         m_LastPos = event->globalPos();
     }
-    else if (pos.x() < RESIZE_MARGIN)                                                                /* Left */
+    else if (pos.x() < RESIZE_MARGIN)                                                             /* Left */
     {
         m_Resize = ResizeType::Left;
         m_LastPos = event->globalPos();
     }
-    else if (event->pos().y() < TITLEBAR_MARGIN)                                             /* Title Bar Drag Operation */
+    else if (event->pos().y() < TITLEBAR_MARGIN)                                                 /* Title Bar Drag Operation */
     {
         m_Dragging = true;
         m_LastPos = event->globalPos();
     }
 }
 
-void FramelessWindow::mouseMoveEvent(QMouseEvent* event)
+void BaseWindow::mouseMoveEvent(QMouseEvent* event)
 {
     /* Window DRAGGING {{{ */
     if (m_Dragging)
@@ -357,9 +360,9 @@ void FramelessWindow::mouseMoveEvent(QMouseEvent* event)
     }
     /* }}} */
 }
-#endif
+#endif  // _QT6
 
-void FramelessWindow::mouseReleaseEvent(QMouseEvent* event)
+void BaseWindow::mouseReleaseEvent(QMouseEvent* event)
 {
     if (m_Resize != ResizeType::None)
     {
@@ -373,5 +376,7 @@ void FramelessWindow::mouseReleaseEvent(QMouseEvent* event)
         m_Dragging = false;
     }
 }
+
+#endif // USE_FRAMED_WINDOW
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/BaseWindow.h
+++ b/src/VoidUi/BaseWindow.h
@@ -9,10 +9,17 @@
 
 VOID_NAMESPACE_OPEN
 
-class FramelessWindow : public QMainWindow
+#ifdef USE_FRAMED_WINDOW
+class BaseWindow : public QMainWindow
 {
 public:
-    FramelessWindow(QWidget* parent = nullptr);
+    BaseWindow(QWidget* parent = nullptr) : QMainWindow(parent) {}
+};
+#else
+class BaseWindow : public QMainWindow
+{
+public:
+    BaseWindow(QWidget* parent = nullptr);
 
 protected:
     /* 
@@ -49,6 +56,7 @@ private: /* members */
     bool m_Dragging;
 
 };
+#endif // USE_FRAMED_WINDOW
 
 VOID_NAMESPACE_CLOSE
 

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(
     ControlScroller.cpp
     Docker.cpp
     Events.h
-    FramelessWindow.cpp
+    BaseWindow.cpp
     MediaClip.cpp
     MediaLister.cpp
     MediaItem.cpp

--- a/src/VoidUi/MediaLister.cpp
+++ b/src/VoidUi/MediaLister.cpp
@@ -158,7 +158,7 @@ void VoidMediaLister::Build()
     int left, top, right, bottom;
     m_layout->getContentsMargins(&left, &top, &right, &bottom);
     /* Only adjust the right side spacing to make it cleaner against the viewer */
-    m_layout->setContentsMargins(left, top, 0, bottom);
+    m_layout->setContentsMargins(0, top, 0, 2);
 }
 
 void VoidMediaLister::Setup()

--- a/src/VoidUi/PlayerWindow.cpp
+++ b/src/VoidUi/PlayerWindow.cpp
@@ -91,7 +91,7 @@ void DockerWindow::ToggleComponent(const Component& component, const bool state)
 /* }}} */
 
 VoidMainWindow::VoidMainWindow(QWidget* parent)
-    : FramelessWindow(parent)
+    : BaseWindow(parent)
     , m_CacheMedia(false)
     , m_Media()
 {
@@ -137,12 +137,14 @@ void VoidMainWindow::Build()
     /* Don't want any extra margins */
     layout->setContentsMargins(2, 0, 2, 2);
 
+    #ifndef USE_FRAMED_WINDOW       /* Not Using Framed window */
     /*
      * The Main title bar for the Void Window
      * This will act as a drop-in replacement for the standard TitleBar OS specific
      */
     m_TitleBar = new VoidTitleBar(this);
     layout->addWidget(m_TitleBar, 0, Qt::AlignTop);
+    #endif // USE_FRAMED_WINDOW
 
     /*
      * This is the internal window holding all of the components inside
@@ -159,8 +161,18 @@ void VoidMainWindow::Build()
     /* Set the central widget */
     setCentralWidget(baseWidget);
 
+    /**
+     * If we're using Framed window which means the menu bar now has to be part of the
+     * Window as a menu bar
+     * Else we use the custom defined menubar from the TitleBar
+     */
+    #ifdef USE_FRAMED_WINDOW
+    QMenuBar* menuBar = new QMenuBar(this);
+    setMenuBar(menuBar);
+    #else
     /* Menubar from the TitleBar */
     QMenuBar* menuBar = m_TitleBar->MenuBar();
+    #endif // USE_FRAMED_WINDOW
 
     /* File Menu {{{ */
     m_FileMenu = new QMenu("File", menuBar);
@@ -273,10 +285,12 @@ void VoidMainWindow::Build()
 
 void VoidMainWindow::Connect()
 {
+    #ifndef USE_FRAMED_WINDOW   /* Not using Framed window */
     /* Title Bar Actions */
     connect(m_TitleBar, &VoidTitleBar::requestMinimize, this, &QWidget::showMinimized);
     connect(m_TitleBar, &VoidTitleBar::requestMaximizeRestore, this, [this]() { isMaximized() ? showNormal() : showMaximized(); });
     connect(m_TitleBar, &VoidTitleBar::requestClose, this, &QWidget::close);
+    #endif  // USE_FRAMED_WINDOW
 
     /* Menu Actions */
     /* File Menu {{{ */

--- a/src/VoidUi/PlayerWindow.h
+++ b/src/VoidUi/PlayerWindow.h
@@ -11,7 +11,7 @@
 #include "About.h"
 #include "Definition.h"
 #include "Docker.h"
-#include "FramelessWindow.h"
+#include "BaseWindow.h"
 #include "MediaClip.h"
 #include "MediaLister.h"
 #include "PlayerWidget.h"
@@ -58,7 +58,7 @@ private: /* Methods */
 
 };
 
-class VoidMainWindow : public FramelessWindow
+class VoidMainWindow : public BaseWindow
 {
     Q_OBJECT
 


### PR DESCRIPTION
### Option to Allow using Framed Window or frameless
* This comes from the tests in mac where the menubar moves to the top pane and is not a part of the floating widget making it look quite less pleasing.
* Accordingly adjusted code to use a base frameless window or a qmainwindow inheritence along with adding menubar to the main window or custom titlebar.

* By Default Linux and Windows get frameless while mac gets Framed window. 
* Configurable with -DUSE_FRAMED_WINDOW=ON arg in cmake.

### Build Script
* Added -j nproc to compile parallelly wherever possible.