### PR TITLE
[VOID] Renderer: Fixed Resolution on the Render StatusBar

### DIFF
--- a/src/VoidRenderer/Renderer.cpp
+++ b/src/VoidRenderer/Renderer.cpp
@@ -402,16 +402,24 @@ void VoidRenderer::wheelEvent(QWheelEvent* event)
 
 void VoidRenderer::Render(VoidImageData* data)
 {
-    if (m_Texture)
-    {
-        delete m_Texture;
-        m_Texture = nullptr;
-    }
+    // if (m_Texture)
+    // {
+    //     delete m_Texture;
+    //     m_Texture = nullptr;
+    // }
 
     /* Update the image data */
     m_ImageData = data;
     /* Hide the Error Label */
     m_DisplayLabel->setVisible(false);
+
+    /**
+     * Update the render resolution 
+     * The resolution of the texture is not going to change in the draw (unless we apply a reformat to it)
+     * So constantly redrawing this is just too ineffecient
+     */
+    if (m_ImageData)
+        m_RenderStatus->SetRenderResolution(m_ImageData->Width(), m_ImageData->Height());
 
     /* Trigger a Re-paint */
     update();

--- a/src/VoidRenderer/RendererStatus.cpp
+++ b/src/VoidRenderer/RendererStatus.cpp
@@ -1,3 +1,6 @@
+/* STD */
+#include <sstream>
+
 /* Qt */
 #include <QPainter>
 
@@ -156,12 +159,11 @@ void RendererStatusBar::Build()
 
 void RendererStatusBar::SetRenderResolution(const int width, const int height)
 {
-    QString resolution = std::to_string(width).c_str();
-    resolution += " x ";
-    resolution += std::to_string(height).c_str();
+    std::stringstream ss; 
+    ss << std::to_string(width) << " x " << std::to_string(height);
 
     /* Update the Resolution display */
-    m_ResolutionValue->setText(resolution);
+    m_ResolutionValue->setText(ss.str().c_str());
 }
 
 void RendererStatusBar::SetMouseCoordinates(const int x, const int y)


### PR DESCRIPTION
## FIX
* Fixed an issue where the Render Resolution was not being shown on the Render StatusBar.
* Optimised the minimal QString concatenation by switching to use stringstream.