### PR TITLE
[VOID] TrackMap:  Added Track Map Data structure holding the Track Items in a Track

### DIFF
--- a/src/VoidCore/Media.h
+++ b/src/VoidCore/Media.h
@@ -113,7 +113,7 @@ public:
      * i.e. between the first and the last frame of media
      * Any frame missing does not matter as this method only returns whether a frame is in the range or not
      */
-    [[nodiscard]] inline bool InRange(const int frame) const { return frame >= m_FirstFrame && frame <= m_LastFrame; }
+    [[nodiscard]] inline bool HasFrame(const int frame) const { return frame >= m_FirstFrame && frame <= m_LastFrame; }
 
     /* 
      * Returns whether a given frame is available to read

--- a/src/VoidUi/MediaClip.h
+++ b/src/VoidUi/MediaClip.h
@@ -89,7 +89,7 @@ public:
      * i.e. between the first and the last frame of media
      * Any frame missing does not matter as this method only returns whether a frame is in the range or not
      */
-    [[nodiscard]] inline bool InRange(const int frame) const { return m_Media.InRange(frame); }
+    [[nodiscard]] inline bool HasFrame(const int frame) const { return m_Media.HasFrame(frame); }
 
     /* 
      * Returns whether a given frame is available to read

--- a/src/VoidUi/PlayerWidget.cpp
+++ b/src/VoidUi/PlayerWidget.cpp
@@ -1,8 +1,8 @@
-/* Internal */
-#include "PlayerWidget.h"
-
 /* Qt */
 #include <QLayout>
+
+/* Internal */
+#include "PlayerWidget.h"
 
 VOID_NAMESPACE_OPEN
 

--- a/src/VoidUi/TrackItem.h
+++ b/src/VoidUi/TrackItem.h
@@ -31,7 +31,7 @@ public:
 
     virtual ~TrackItem();
 
-    /*
+    /**
      * Update the media on the track item
      * Offset corresponds to the offet in the framerange as when compared against the original range
      * of the media. 
@@ -47,7 +47,7 @@ public:
 
     inline void SetColor(const QColor& color) { m_Media->SetColor(color); }
 
-    /* 
+    /** 
      * Caches media frames
      * emits frameCached for each of them emitted
      */
@@ -57,7 +57,7 @@ public:
     inline int GetOffset() const { return m_Offset; }
     inline SharedMediaClip GetMedia() const { return m_Media; }
 
-    /*
+    /**
      * Retrieves the image pointer from the media for a frame which has to be offsetted by the current offset
      */
     VoidImageData* GetImage(const int frame);
@@ -65,7 +65,15 @@ public:
     inline int StartFrame() const { return m_StartFrame; }
     inline int EndFrame() const { return m_EndFrame; }
 
-    /*
+    /**
+     * Returns whether the given frame is in range of the underlying media
+     * Applies the offset of the track item's range back to check against the media
+     * 
+     * TODO: Consider handle frames when they are implemented.
+     */
+    inline bool HasFrame(const int frame) const { return m_Media->HasFrame(frame + m_Offset); }
+
+    /**
      * Returns the nearest frame of a given frame from the media in TrackItem space
      * This means that the output frame is negated with the offset of the track item
      * E.g. Media's nearest frame for 1003 is 1001 and the offset of the Track Item is 1001
@@ -91,13 +99,13 @@ signals: /* Signals denoting Actions in the TrackItem */
     /* This signal denotes that something in the track item was changed/modified i.e. updated */
     void updated();
 
-    /*
+    /**
      * Emitted when the time range of the track item has changed
      * includes the start and end frame of the track item
      */
     void rangeChanged(int start, int end);
 
-    /*
+    /**
      * Emitted when a frame is cached
      * The cache could happen when the media cache operation is run continuously on a thread
      * Or if the frame is queried by the viewport

--- a/src/VoidUi/ViewerBuffer.cpp
+++ b/src/VoidUi/ViewerBuffer.cpp
@@ -40,6 +40,9 @@ void ViewerBuffer::Set(const SharedMediaClip& media)
     /* Update frame range */
     m_Startframe = m_Clip->FirstFrame();
     m_Endframe = m_Clip->LastFrame();
+
+    /* Refresh to clear any underlying caches */
+    Refresh();
 }
 
 void ViewerBuffer::Set(const SharedPlaybackTrack& track)
@@ -56,6 +59,9 @@ void ViewerBuffer::Set(const SharedPlaybackTrack& track)
     /* Update frame range */
     m_Startframe = m_Track->StartFrame();
     m_Endframe = m_Track->EndFrame();
+
+    /* Refresh to clear any underlying caches */
+    Refresh();
 }
 
 void ViewerBuffer::Set(const SharedPlaybackSequence& sequence)
@@ -69,6 +75,9 @@ void ViewerBuffer::Set(const SharedPlaybackSequence& sequence)
     /* Update frame range */
     m_Startframe = m_Sequence->StartFrame();
     m_Endframe = m_Sequence->EndFrame();
+
+    /* Refresh to clear any underlying caches */
+    Refresh();
 }
 
 void ViewerBuffer::SetColor(const QColor& color)
@@ -111,6 +120,46 @@ SharedPlaybackTrack ViewerBuffer::ActiveTrack() const
     }
 
     return nullptr;
+}
+
+void ViewerBuffer::Refresh()
+{
+    /* Clear any cached item */
+    m_CachedTrackItem = nullptr;
+}
+
+SharedTrackItem ViewerBuffer::ItemFromSequence(const int frame)
+{
+    /**
+     * Check if we have a cached track item present -> return that
+     * if the cached track item is not preset or if the item does not have the requested frame
+     * request for a track item from the track at the frame, cache it and return back
+     */
+    if (!m_CachedTrackItem || !m_CachedTrackItem->HasFrame(frame))
+    {
+        /* Cache the item from the Sequence */
+        m_CachedTrackItem = m_Sequence->GetTrackItem(frame);
+    }
+
+    /* Return what has been cached */
+    return m_CachedTrackItem;
+}
+
+SharedTrackItem ViewerBuffer::ItemFromTrack(const int frame)
+{
+    /**
+     * Check if we have a cached track item present -> return that
+     * if the cached track item is not preset or if the item does not have the requested frame
+     * request for a track item from the track at the frame, cache it and return back
+     */
+    if (!m_CachedTrackItem || !m_CachedTrackItem->HasFrame(frame))
+    {
+        /* Cache the item from the track */
+        m_CachedTrackItem = m_Track->GetTrackItem(frame);
+    }
+
+    /* Return what has been cached */
+    return m_CachedTrackItem;
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/ViewerBuffer.h
+++ b/src/VoidUi/ViewerBuffer.h
@@ -67,14 +67,14 @@ public:
     /**
      * Returns a track item at a given frame
      */
-    inline SharedTrackItem TrackItem(const int frame) const
+    inline SharedTrackItem TrackItem(const int frame)
     {
         /* Return from the sequence if that is currently playing */
         if (m_PlayingComponent == PlayableComponent::Sequence)
-            return m_Sequence->GetTrackItem(frame);
+            return ItemFromSequence(frame);
 
-        /* Else return from the track */
-        return m_Track->GetTrackItem(frame);
+        /* Else return the TrackItem from track */
+        return ItemFromTrack(frame);
     }
 
     /**
@@ -111,6 +111,11 @@ public:
     void SetColor(const QColor& color);
 
     /**
+     * Refreshes any underlying caches and updates internals
+     */
+    void Refresh();
+
+    /**
      * Set a playable component on the Buffer
      */
     void Set(const SharedMediaClip& media);
@@ -130,6 +135,16 @@ private: /* Members */
     SharedPlaybackTrack m_Track;
     SharedPlaybackSequence m_Sequence;
 
+    /**
+     * At any point this buffer maintains a cached track item which makes the query to get the track item
+     * at a given frame much less complex in terms of time
+     * The reasoning is, when a standard play operation happens, it happnes sequentially
+     * and a track item at any given frame, if queried can last upto some frames ahead of it (till it's range supports)
+     * so the next query to the underlying struct only happens when this cached track item is out of frames based on the
+     * requested frame and then returned item is then cached till a frame is requested outside and so on...
+     */
+    SharedTrackItem m_CachedTrackItem;
+
     /* Currently playing component */
     PlayableComponent m_PlayingComponent;
 
@@ -147,6 +162,15 @@ private: /* Members */
      * Whether the buffer is active or not at the moment
      */
     bool m_Active;
+
+private: /* Methods */
+    /**
+     * Returns a track item from the track or sequence at a given frame
+     * The item returned from the entity is then cached locally on the class to reduce the operations to try and find
+     * a track item for the next frame (unless the frame is out of items' bounds)
+     */
+    SharedTrackItem ItemFromTrack(const int frame);
+    SharedTrackItem ItemFromSequence(const int frame);
 
 };
 


### PR DESCRIPTION
## Improvement: Optimise the query to Find track item from a track at any given frame
* Introduced a TrackMap which saves track items added to a track
* The sole purpose of the track map is to reduce the time complexity for querying a track item at any given track frame.

* Reduces the overall average time complexity of previous query' O(n) to be now O(log n) in average and worst cases and the best case remains O(1).

### Details
Since the track items may or may not have similar original ranges the track map allows query based on the timeline range of the track bifurcating the query into smaller ones based on start frame of the track item and then considering the range of the underlying media.

Viewer buffer also gets a locally cached track item which further reduces the queries to the underlying track or sequence making the whole play operation much optimised in terms of time complexity.

### Next Steps
* Introduce a SequenceMap to hold the tracks in the sequence and optimise getting the trackItem from a sequence at a frame based on if a track has any track item at the given frame and the track is at a position to provide a track item to the buffer (based on arrangement in the sequence)
* Continue research on ways to optimise this even further.