### PR TITLE
[VOID] MainWindow: Bug Fixes

### DIFF
--- a/src/VoidUi/PlayerWindow.cpp
+++ b/src/VoidUi/PlayerWindow.cpp
@@ -55,6 +55,8 @@ void DockerWindow::Build()
     addDockWidget(Qt::RightDockWidgetArea, m_Docker);
     addDockWidget(Qt::LeftDockWidgetArea, m_MListDocker);
 
+    splitDockWidget(m_MListDocker, m_Docker, Qt::Horizontal);
+
     /* The way how dock widgets appear as default */
     /* Dock Widgets */
     m_DockList << m_Docker << m_MListDocker;
@@ -119,12 +121,6 @@ VoidMainWindow::~VoidMainWindow()
 QSize VoidMainWindow::sizeHint() const
 {
     return QSize(1280, 760);
-}
-
-void VoidMainWindow::showEvent(QShowEvent* event)
-{
-    /* Set Default dock size */
-    // resizeDocks(m_DockList, m_DockSizes, Qt::Horizontal);
 }
 
 void VoidMainWindow::Build()

--- a/src/VoidUi/PlayerWindow.h
+++ b/src/VoidUi/PlayerWindow.h
@@ -79,8 +79,6 @@ private: /* Methods */
     void Connect();
 
 protected:
-    void showEvent(QShowEvent* event) override;
-
     /* Caches the Media if Caching is allowed */
     void CacheLookAhead();
 

--- a/src/VoidUi/Timeline.cpp
+++ b/src/VoidUi/Timeline.cpp
@@ -639,7 +639,7 @@ void Timeline::TimeUpdated(const int time)
 void Timeline::SetRange(const int min, const int max)
 {
 	/* Reset any user defined range for the timeslider */
-	m_Timeslider->ResetRange();
+	ResetRange();
 
 	/* Update timeslider range */
 	m_Timeslider->setRange(min, max);


### PR DESCRIPTION
### Fixes
* Add splitter to maintain size of added docks on resize.
* Fixed an issue where resetting the timeline range was not toggling back the user in-out frame buttons.