### PR TITLE
[VOID] MediaFileSystem: Add system dealing with Media

### DIFF
--- a/src/VoidCore/CMakeLists.txt
+++ b/src/VoidCore/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
     ImageData.cpp
     Logging.cpp
     Media.cpp
+    MediaFilesystem.cpp
     VoidTools.cpp
 )
 

--- a/src/VoidCore/MediaFilesystem.cpp
+++ b/src/VoidCore/MediaFilesystem.cpp
@@ -1,0 +1,379 @@
+/* STD */
+#include <chrono>
+
+/* Internal */
+#include "MediaFilesystem.h"
+#include "Logging.h"
+
+VOID_NAMESPACE_OPEN
+
+/* MHelper {{{ */
+
+MediaType MHelper::GetMediaType(const MEntry& entry)
+{
+    /* If it's a Movie */
+    if (IsMovie(entry))
+        return MediaType::Movie;
+    else if (IsImage(entry))
+        return MediaType::Image;
+
+    /**
+     * For Now Audio isn't interpreted
+     * TODO: Add Audio format detection
+     */
+
+    return MediaType::NonMedia;
+}
+
+/* }}} */
+
+/* MEntry {{{ */
+
+MEntry::MEntry()
+    : m_Path("")
+    , m_Basepath("")
+    , m_Name("")
+    , m_Extension("")
+    , m_Framenumber(0)
+{
+}
+
+MEntry::MEntry(const std::string& path)
+    : MEntry()
+{
+    /* Parse the provided path and update internal token */
+    Parse(path);
+}
+
+MEntry::~MEntry()
+{
+}
+
+void MEntry::Parse(const std::string& path)
+{
+    /* Update the fullpath */
+    m_Path = path;
+
+    std::filesystem::path filepath(path);
+
+    /* The base path for the file */
+    m_Basepath = filepath.parent_path().string();
+    /* Grab the filename from the rest of the base path */
+    std::string filename = filepath.filename().string();
+
+    /* From the last . try to get the extension and other parts */
+    size_t lastDot = filename.find_last_of(".");
+    std::string remaining = filename.substr(0, lastDot);
+
+    m_Extension = filename.substr(lastDot + 1);
+
+    lastDot = remaining.find_last_of(".");
+    std::string framestring = remaining.substr(lastDot + 1);
+
+    /**
+     * Image is a sequence or atleast follows a sequential naming convention
+     * Check if the framestring is a valid number before trying to cast that to one
+     */
+    if (ValidFrame(framestring))
+    {
+        m_Framenumber = std::stoi(framestring);
+        m_Name = remaining.substr(0, lastDot);
+    }
+    else /* In case we don't have an image sequence, just a standard image */
+    {
+        m_Name = remaining;
+    }
+}
+
+bool MEntry::ValidFrame(const std::string& framestring) const
+{
+    if (framestring.empty())
+        return false;
+
+    for (char c: framestring)
+    {
+        if (!std::isdigit(c))
+            return false;
+    }
+
+    /* Valid frame */
+    return true;
+}
+
+/* }}} */
+
+/* Media Struct {{{ */
+
+MediaStruct::MediaStruct()
+    : m_MediaType(MediaType::NonMedia)
+{
+}
+
+MediaStruct::MediaStruct(const MEntry& entry, const MediaType& type)
+{
+    /* Setup Media */
+    Reset(entry, type);
+}
+
+MediaStruct::~MediaStruct()
+{
+}
+
+MediaStruct::MediaStruct(const MediaStruct& other)
+{
+    /* Update the Media Type */
+    m_MediaType = other.m_MediaType;
+
+    /* Clear Existing Frames */
+    m_Frames.clear();
+
+    /* Copy the contents of the internal vector */
+    m_Frames.reserve(other.m_Frames.size());
+
+    /* Add back the frame */
+    for (int frame: other.m_Frames)
+        m_Frames.emplace_back(frame);
+
+    /* Copy the MEntries */
+    m_Entries = other.m_Entries;
+}
+
+MediaStruct MediaStruct::operator=(const MediaStruct& other)
+{
+    /* Talking about the same entity */
+    if (this == &other)
+        return *this;
+
+    /* Update the Media Type */
+    m_MediaType = other.m_MediaType;
+
+    /* Clear Existing Frames */
+    m_Frames.clear();
+
+    /* Copy the contents of the internal vector */
+    m_Frames.reserve(other.m_Frames.size());
+
+    /* Add back the frame */
+    for (int frame: other.m_Frames)
+        m_Frames.emplace_back(frame);
+
+    /* Copy the MEntries */
+    m_Entries = other.m_Entries;
+
+    return *this;
+}
+
+MediaStruct MediaStruct::operator=(MediaStruct&& other) noexcept
+{
+    /* Clear Contents */
+    Clear();
+
+    m_MediaType = other.m_MediaType;
+
+    /* Swap the contents of the provided Struct with ours */
+    std::swap(m_Frames, other.m_Frames);
+    std::swap(m_Entries, other.m_Entries);
+
+    return *this;
+}
+
+std::string MediaStruct::Name() const
+{
+    /* Empty container */
+    if (m_Entries.empty())
+        return "";
+
+    return m_Entries.begin()->second.Name();
+}
+
+std::string MediaStruct::Extension() const
+{
+    /* Empty container */
+    if (m_Entries.empty())
+        return "";
+
+    return m_Entries.begin()->second.Extension();
+}
+
+std::string MediaStruct::Basepath() const
+{
+    /* Empty container */
+    if (m_Entries.empty())
+        return "";
+
+    return m_Entries.begin()->second.Basepath();
+}
+
+std::string MediaStruct::FirstPath() const
+{
+    /* Empty container */
+    if (m_Entries.empty())
+        return "";
+
+    return m_Entries.begin()->second.Fullpath();
+}
+
+void MediaStruct::Add(const MEntry& entry)
+{
+    /* Add the provided entry */
+    m_Entries[entry.Framenumber()] = entry;
+    /* Add the frame number on the vector */
+    m_Frames.push_back(entry.Framenumber());
+}
+
+bool MediaStruct::Validate(const MEntry& entry)
+{
+    /* If the underlying struct is empty this still returns false */
+    if (m_Entries.empty())
+        return false;
+
+    MEntry& e = m_Entries.begin()->second;
+
+    /* Return if the provided entry is similar to the current entry */
+    return e.Similar(entry);
+}
+
+MediaStruct MediaStruct::FromFile(const std::string& filepath)
+{
+    /**
+     * Create a Media Entry for reference
+     * Then start iterating over it's directory to see other files and if they are similar
+     * to this path
+     */
+    MEntry e(filepath);
+
+    /**
+     * Create a struct for updating to, representing a media sequence if needed
+     */
+    MediaStruct m(e, MHelper::GetMediaType(e));
+
+    /**
+     * If the type of the media is Movie or any other then we can just return the current MediaStruct from here
+     * considering a movie or audio is a container on it's own and does not depend on other containers
+     */
+    if (m.Type() != MediaType::Image)
+        return m;
+
+    std::chrono::time_point start = std::chrono::high_resolution_clock::now();
+
+    try
+    {
+        for (std::filesystem::directory_entry entry: std::filesystem::directory_iterator(e.Basepath()))
+        {
+            /**
+             * Create a Media Entry for the next path
+             */
+            MEntry next(entry.path().string());
+
+            /* Ignore the entry which is the same as the original one */
+            if (next == e)
+                continue;
+
+            /**
+             * Check if the entry is similar to the MediaStruct representation
+             * i.e. it's name and extension
+             * if they are similar -> add that entry to the struct
+             */
+            if (m.Validate(next))
+                m.Add(next);
+        }
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+        VOID_LOG_ERROR(e.what());
+    }
+
+    std::chrono::time_point end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> duration = end - start;
+
+    VOID_LOG_INFO("Time Taken to Construct Media Struct : {0}", duration.count());
+    return m;
+}
+
+void MediaStruct::Reset(const MEntry& entry, const MediaType& type)
+{
+    /* Clear underlying structs */
+    if (!Empty())
+        Clear();
+
+    /* Add the first Entry */
+    m_Entries[entry.Framenumber()] = entry;
+    /* Add the frame number on the vector */
+    m_Frames.push_back(entry.Framenumber());
+
+    /* Update the media type */
+    m_MediaType = type;
+}
+
+void MediaStruct::Clear()
+{
+    /* Clear entries */
+    m_Entries.clear();
+    m_Frames.clear();
+
+    /* Reset Media Type */
+    m_MediaType = MediaType::NonMedia;
+}
+
+/* }}} */
+
+/* Media FS {{{ */
+
+std::vector<MediaStruct> MediaFS::FromDirectory(const std::string& path)
+{
+    /* Create struct vec */
+    std::vector<MediaStruct> vec;
+
+    std::chrono::time_point start = std::chrono::high_resolution_clock::now();
+
+    try
+    {
+        /* Start iterating over the file system entry and create an Media Entry for it */
+        for (std::filesystem::directory_entry entry : std::filesystem::directory_iterator(path))
+        {
+            MEntry e(entry.path().string());
+
+            /* Flag to control what happens with the entry */
+            bool new_entry = true;
+
+            /**
+             * Iterate over what we have in our vector currently
+             * i.e. the media structs to see if this entry belongs to any one of them
+             * if so, this gets added there, else we create a new media struct from it
+             */
+            for (MediaStruct& m : vec)
+            {
+                /* The entry belongs to this Media Struct */
+                if (m.Validate(e))
+                {
+                    /* Add the Media Entry to the struct */
+                    m.Add(e);
+                    /* Mark the new_entry flag as false to indicate this isn't new */
+                    new_entry = false;
+                }
+            }
+
+            /* Check if no entry in the MediaStruct adopted our newly created Media entry */
+            if (new_entry)
+            {
+                vec.push_back(MediaStruct(e, MHelper::GetMediaType(e)));
+            }
+        }
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+        VOID_LOG_ERROR(e.what());
+    }
+
+    std::chrono::time_point end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> d = end - start;
+
+    VOID_LOG_INFO("Time take to find Media Structs from directory : {0}", d.count());
+
+    /* Return the final vec */
+    return vec;
+}
+
+/* }}} */
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/MediaFilesystem.h
+++ b/src/VoidCore/MediaFilesystem.h
@@ -1,0 +1,286 @@
+#ifndef _VOID_MEDIA_FILE_SYSTEM_H
+#define _VOID_MEDIA_FILE_SYSTEM_H
+
+/* STD */
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+
+/* Internal */
+#include "Definition.h"
+
+VOID_NAMESPACE_OPEN
+
+/**
+ * Describes how any file could be classified as
+ * We have basic media types, Image (or ImageSequence), Movie, Audio
+ * And a generic non-media
+ */
+enum class VOID_API MediaType
+{
+    /* Describes Image single or Sequence */
+    Image,
+    /* Any moving images format which holds a collection of frame in a single container */
+    Movie,
+    /* Any format which can be just listened to */
+    Audio,
+
+    /* Generic Type to describe anything which isn't a media like .txt file or .cpp file */
+    NonMedia
+};
+
+/**
+ * Represents an entry of a file in the Media Filesystem
+ * This usually represents a MediaFile
+ * But in theory could represent any file format
+ */
+class VOID_API MEntry
+{
+public:
+    MEntry();
+    MEntry(const std::string& path);
+
+    ~MEntry();
+
+    /**
+     * Getters describing the Entry
+     */
+    inline std::string Fullpath() const { return m_Path; }
+    inline std::string Basepath() const { return m_Basepath; }
+    inline std::string Name() const { return m_Name; }
+    inline std::string Extension() const { return m_Extension; }
+    inline int Framenumber() const { return m_Framenumber; }
+
+    /**
+     * Validates and returns true if the other entry is similar to this
+     * Basically checks if the basepath, name and extension are same
+     * frame number is the only thing that can vary here
+     */
+    inline bool Similar(const MEntry& other) const
+    {
+        return other.m_Basepath == m_Basepath && other.m_Name == m_Name && other.m_Extension == m_Extension;
+    }
+
+    /**
+     * Validates the fullpath to see if this and the other entry are pointing to the exact same path
+     */
+    inline bool operator==(const MEntry& other) const { return m_Path == other.m_Path; }
+
+private: /* Members */
+    std::string m_Path;
+    std::string m_Basepath;
+    std::string m_Name;
+    std::string m_Extension;
+
+    /* Not All files would have this
+     */
+    int m_Framenumber;
+
+private: /* Methods */
+    /**
+     * Parses the filepath to derive tokens from the fullpath
+     * like the name of the file, extension, frame number if present
+     *
+     * e.g. a file path is /path/to/file/on/disk/WithThisName.1001.exr
+     * parsing this file would internally populate the struct with
+     * basepath = /path/to/file/on/disk
+     * name = WithThisName
+     * frame = 1001
+     * extension = exr
+     *
+     * and another file /path/to/another/file/on/disk/WithSomeName.jpg results in
+     * basepath = /path/to/another/file/on/disk
+     * name = WithSomeName
+     * frame = 0
+     * extension = jpg
+     */
+    void Parse(const std::string& path);
+
+    /**
+     * Checks and returns whether provided string (generally frames as string)
+     * is a valid frame number or if it contains any unwanted character which may
+     * not allow it to be converted to an integer frame number
+     */
+    bool ValidFrame(const std::string& framestring) const;
+};
+
+struct MHelper
+{
+    static MediaType GetMediaType(const MEntry& entry);
+
+    /**
+     * Checks if the MEntry is a Media format
+     */
+    static inline bool IsImage(const MEntry& entry) { return std::find(std::begin(m_ImageFormats), std::end(m_ImageFormats), entry.Extension()) != std::end(m_ImageFormats); }
+    static inline bool IsMovie(const MEntry& entry) { return std::find(std::begin(m_MovieFormats), std::end(m_MovieFormats), entry.Extension()) != std::end(m_MovieFormats); }
+
+private:
+    /**
+     * To consider grouping files based on their types (extensions) using the below hardcoded extension mapping
+     * This keeps it simpler for now, unless we decide on the plugin mech to dynamically allow distinuguishing file
+     * types based on registered file formats (which will come soon)
+     */
+    /* Which can be classified as Images */
+    inline static const std::string m_ImageFormats[8] = {
+        "bmp",
+        "dpx",
+        "exr",
+        "jpg",
+        "jpeg",
+        "png",
+        "tiff",
+        "tga"
+    };
+
+    /* Can be classified as Movies */
+    inline static const std::string m_MovieFormats[4] = {
+        "mov",
+        "mp4",
+        "mxf",
+        "mkv"
+    };
+};
+
+/**
+ * Collection of Media Entries (one or more)
+ * This is what represents a Media Entity
+ * like an Image Sequence where it holds the MEntry(ies) for the image sequence
+ * or it could hold a single MEntry representing a movie file format
+ */
+class VOID_API MediaStruct
+{
+public:
+    MediaStruct();
+    /**
+     * The MEntry is used to initialize the MediaStruct hence representing itself
+     * and then it may be used to validate other entries against this
+     * like comparison by the name, and extension
+     */
+    MediaStruct(const MEntry& entry, const MediaType& type);
+
+    ~MediaStruct();
+
+    /**
+     * Move and Copy
+     */
+    MediaStruct(const MediaStruct& other);
+
+    MediaStruct operator=(MediaStruct&& other) noexcept;
+    MediaStruct operator=(const MediaStruct& other);
+
+    /**
+     * (Re)Initializes the MediaStruct
+     * Usually should be called only once, as this resets the underlying paramters to now
+     * consider the MediaStruct composed of files having name and extension provided entry
+     */
+    inline void Set(const MEntry& entry, const MediaType& type) { Reset(entry, type); }
+
+    /**
+     * Adds an entry to the struct
+     */
+    void Add(const MEntry& entry);
+
+    /**
+     * Validates the entry based on it's name and filetype (extension)
+     * to indicate whether this entry belongs to the MediaStruct or not
+     * e.g. the MediaStruct currently represents entries with name "SomeNamed"
+     * and extension "jpg"
+     * if another entry with name "TestNamed" is passed this method will return false
+     * as the name is different and similarly if another entry with name "SomeNamed" but
+     * extension "txt" is passed, this still returns false indicating the entry is odd
+     * and does not match what this struct represents
+     */
+    bool Validate(const MEntry& entry);
+
+    std::string Name() const;
+    std::string Extension() const;
+    std::string Basepath() const;
+
+    std::string FirstPath() const;
+
+    /**
+     * Returns whether the media struct is currently empty
+     */
+    inline bool Empty() const { return m_Entries.empty(); }
+
+    /**
+     * Returns if the MediaStruct is a valid Media Type
+     */
+    inline bool ValidMedia() const { return (m_MediaType == MediaType::Image) || (m_MediaType == MediaType::Movie); }
+
+    inline MediaType Type() const { return m_MediaType; }
+
+    /**
+     * Constructs a MediaStuct based on a file
+     * Looks up at the directory to include any files of the same naming under the media struct
+     */
+    static MediaStruct FromFile(const std::string& filepath);
+
+private: /* Members */
+    std::vector<int> m_Frames;
+    std::unordered_map<int, MEntry> m_Entries;
+
+    /* The kind of media */
+    MediaType m_MediaType;
+
+private: /* Methods */
+    /**
+     * Resets underlying map to now start housing the entries represented by the provided first entry
+     */
+    void Reset(const MEntry& entry, const MediaType& type);
+
+    /* Clears underlying structs */
+    void Clear();
+
+private: /* Iterator */
+    /**
+     * Custom Iterator for the MediaStruct to allow iterating over just the entries
+     * leaving the other internals
+     */
+    class Iterator
+    {
+        using Iter = std::unordered_map<int, MEntry>::const_iterator;
+        Iter it;
+
+    public:
+        explicit Iterator(Iter it)
+            : it(it) {}
+
+        /* Dereference operator */
+        const MEntry& operator*() const { return it->second; }
+        /* Arrow operator */
+        const MEntry* operator->() const { return &(it->second); }
+
+        /**
+         * Increment operator
+         * Increment internal iterator
+         */
+        Iterator& operator++() { ++it; return *this; }
+
+        /* Not Equals */
+        bool operator!=(const Iterator& other) const { return it != other.it; }
+    };
+
+public: /* Iterator */
+    Iterator begin() const { return Iterator(m_Entries.begin()); }
+    Iterator end() const { return Iterator(m_Entries.end()); }
+
+};
+
+class VOID_API MediaFS
+{
+public:
+    inline MediaStruct GetMediaStruct(const std::string& filepath) { return MediaStruct::FromFile(filepath); }
+
+    /**
+     * Provides a vector of MediaStructs for a provided Directory
+     */
+    std::vector<MediaStruct> FromDirectory(const std::string& directory);
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _VOID_MEDIA_FILE_SYSTEM_H

--- a/src/VoidUi/Browser.cpp
+++ b/src/VoidUi/Browser.cpp
@@ -19,4 +19,16 @@ bool VoidMediaBrowser::Browse()
     return exec();
 }
 
+MediaStruct VoidMediaBrowser::GetMediaStruct() const
+{
+    QStringList files = selectedFiles();
+
+    /* Empty Media struct */
+    if (files.empty())
+        return MediaStruct();
+
+    /* Return the MediaStruct constructed from the selected file */
+    return MediaStruct::FromFile(files.first().toStdString());
+}
+
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Browser.h
+++ b/src/VoidUi/Browser.h
@@ -6,6 +6,7 @@
 
 /* Internal */
 #include "Definition.h"
+#include "VoidCore/MediaFilesystem.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -23,7 +24,8 @@ public:
      */
     [[nodiscard]] bool Browse();     
 
-    inline std::string GetDirectory() { return directory().absolutePath().toStdString(); }
+    inline std::string GetDirectory() const { return directory().absolutePath().toStdString(); }
+    MediaStruct GetMediaStruct() const;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/PlayerWidget.h
+++ b/src/VoidUi/PlayerWidget.h
@@ -81,6 +81,7 @@ public:
     void SetViewBuffer(const PlayerViewBuffer& buffer);
 
     inline void Refresh() { SetFrame(m_Timeline->Frame()); }
+    inline void ClearCache() { m_ActiveViewBuffer->ClearCache(); }
 
     /* Zoom on the Viewport */
     inline void ZoomIn() { m_Renderer->ZoomIn(); }

--- a/src/VoidUi/PlayerWindow.h
+++ b/src/VoidUi/PlayerWindow.h
@@ -69,7 +69,11 @@ public:
     virtual QSize sizeHint() const override;
 
     /* Reads Media Directory and Loads Media onto the components */
-    void ImportMedia(const std::string& path);
+    void ImportMedia(const MediaStruct& mstruct);
+    /**
+     * Allows all the media in a directory to be imported into the player
+     */
+    void ImportDirectory(const std::string& path);
     void PlayMedia(const std::vector<SharedMediaClip>& items);
 
     SharedPlaybackSequence ActiveSequence() const { return m_Sequence; }

--- a/src/VoidUi/ViewerBuffer.cpp
+++ b/src/VoidUi/ViewerBuffer.cpp
@@ -128,6 +128,16 @@ void ViewerBuffer::Refresh()
     m_CachedTrackItem = nullptr;
 }
 
+void ViewerBuffer::ClearCache()
+{
+    /* Clear Cache from the playing components */
+    if (m_Clip)
+        m_Clip->ClearCache();
+    
+    if (m_Track)
+        m_Track->ClearCache();
+}
+
 SharedTrackItem ViewerBuffer::ItemFromSequence(const int frame)
 {
     /**

--- a/src/VoidUi/ViewerBuffer.h
+++ b/src/VoidUi/ViewerBuffer.h
@@ -116,6 +116,11 @@ public:
     void Refresh();
 
     /**
+     * Clears any cache from underlying components
+     */
+    void ClearCache();
+
+    /**
      * Set a playable component on the Buffer
      */
     void Set(const SharedMediaClip& media);


### PR DESCRIPTION
### Feature: Media File system
* The Media instatiation now depends on MediaFilesystem MediaStruct.
* Each frame or entity inside a MediaStruct is represented by MEntry and that has a 1:1 relation to a file.
* A Movie format will hold one file mostly and and Image Sequence will hold multiple files and multiple MEntries.
* This serves as a base to adding a MediaReader file system where the Media upfront knows what format it is underlying.
* Added directory parse function to get vector of available mediastructs from a given directory which makes loading media directory even robust.