### PR TITLE
[VOID] Media without frame number

### DIFF
--- a/src/VoidCore/MediaFilesystem.cpp
+++ b/src/VoidCore/MediaFilesystem.cpp
@@ -35,6 +35,7 @@ MEntry::MEntry()
     , m_Name("")
     , m_Extension("")
     , m_Framenumber(0)
+    , m_SingleFile(false)
 {
 }
 
@@ -82,6 +83,8 @@ void MEntry::Parse(const std::string& path)
     else /* In case we don't have an image sequence, just a standard image */
     {
         m_Name = remaining;
+        /* Update the state so we know it is a single file */
+        m_SingleFile = true;
     }
 }
 
@@ -213,6 +216,15 @@ std::string MediaStruct::FirstPath() const
     return m_Entries.begin()->second.Fullpath();
 }
 
+bool MediaStruct::IsSingleFile() const
+{
+    /* Empty container */
+    if (m_Entries.empty())
+        return false;
+
+    return m_Entries.begin()->second.IsSingleFile();
+}
+
 void MediaStruct::Add(const MEntry& entry)
 {
     /* Add the provided entry */
@@ -250,8 +262,9 @@ MediaStruct MediaStruct::FromFile(const std::string& filepath)
     /**
      * If the type of the media is Movie or any other then we can just return the current MediaStruct from here
      * considering a movie or audio is a container on it's own and does not depend on other containers
+     * Also consider if the entry does not have a frame seqeunce number like #### or %03d or %04d something similar
      */
-    if (m.Type() != MediaType::Image)
+    if (m.Type() != MediaType::Image || m.IsSingleFile())
         return m;
 
     std::chrono::time_point start = std::chrono::high_resolution_clock::now();

--- a/src/VoidCore/MediaFilesystem.h
+++ b/src/VoidCore/MediaFilesystem.h
@@ -53,6 +53,12 @@ public:
     inline std::string Name() const { return m_Name; }
     inline std::string Extension() const { return m_Extension; }
     inline int Framenumber() const { return m_Framenumber; }
+    
+    /**
+     * Returns True if the Media does not have a frame number on it to denote that this
+     * file is a separate single entity
+     */
+    [[nodiscard]] inline bool IsSingleFile() const { return m_SingleFile; }
 
     /**
      * Validates and returns true if the other entry is similar to this
@@ -75,9 +81,15 @@ private: /* Members */
     std::string m_Name;
     std::string m_Extension;
 
-    /* Not All files would have this
+    /**
+     *  Not All files would have this
      */
     int m_Framenumber;
+
+    /**
+     * Media is a single file and only has frame sequences
+     */
+    bool m_SingleFile;
 
 private: /* Methods */
     /**
@@ -200,6 +212,7 @@ public:
     std::string Basepath() const;
 
     std::string FirstPath() const;
+    [[nodiscard]] bool IsSingleFile() const;
 
     /**
      * Returns whether the media struct is currently empty


### PR DESCRIPTION
### Improvement: Single File media does not need to iterate over the entire directory to construct a media struct
* If the media entry does not have a frame number then it can be considered single frame
* This single file media struct does not additionally loop over other entries in the directory making the load process faster