### PR TITLE
[VOID] Shared OpenGL Context Issue

### DIFF
--- a/src/VoidRenderer/VoidGL.cpp
+++ b/src/VoidRenderer/VoidGL.cpp
@@ -83,17 +83,19 @@ void main() {
 
 VoidShader::VoidShader()
 {
-    /* Construct a program to be used */
-    m_Shader = new QOpenGLShaderProgram;
 }
 
 VoidShader::~VoidShader()
 {
-    m_Shader->deleteLater();
+    if (m_Shader)
+        m_Shader->deleteLater();
 }
 
 void VoidShader::Initialize()
 {
+    /* Construct a program to be used */
+    m_Shader = new QOpenGLShaderProgram;
+
     /* Try and Initialize Glew */
     unsigned int status = glewInit();
 


### PR DESCRIPTION
### Fix
* Fixed an issue where, dragging the player/renderer widget out would cause gl context errors as shader program was not getting reinitialized.

### Previous Error Details
```
QOpenGLShaderProgram::addShader: Program and shader are not associated with same context.
QOpenGLShaderProgram::addShader: Program and shader are not associated with same context.
[2025-06-30 10:44:54.458] [VOID Logger] [error] Shader Linking Failed:
[2025-06-30 10:44:55.118] [VOID Logger] [info] GLEW Initialized.
QOpenGLShader::link: error: function `main' is multiply defined

[2025-06-30 10:44:55.121] [VOID Logger] [error] Shader Linking Failed: error: function `main' is multiply defined
```

### What caused it
* The shader program was getting initialized in the VoidShader constructor and not in the initializeGL, whenever the widget is dragged out or its parent changes, the GL widget destroys existing context and invokes initializeGL hoping to create another context to continue its rendering. since the shaderProgram was outside of initializeGL it wasn't getting created again so the shaders were not able to link to the shader program and hence the breakage.
