### PR TITLE
[VOID] Renderer: Renderer can now go fullscreen natively

### DIFF
--- a/src/VoidRenderer/Renderer.h
+++ b/src/VoidRenderer/Renderer.h
@@ -24,6 +24,8 @@ VOID_NAMESPACE_OPEN
 
 class VOID_API VoidRenderer : public QOpenGLWidget, protected VoidShader
 {
+    Q_OBJECT
+
 public: /* Enums */
 
     enum class ChannelMode : int
@@ -56,6 +58,15 @@ public:
     void UpdateZoom(const float zoom);
 
     /**
+     * Updates necessary attributes to be ready for fullscreen
+     */
+    void PrepareFullscreen();
+    void ExitFullscreen() { m_Fullscreen = false; }
+    
+    /* Lets other components know whether the Renderer is fullscreen */
+    [[nodiscard]] inline bool Fullscreen() const { return m_Fullscreen; }
+
+    /**
      * Adjusts the Exposure of the Viewer
      */
     void SetExposure(const float exposure);
@@ -79,6 +90,19 @@ public:
         m_DisplayLabel->setVisible(true);
     }
     
+signals: 
+    /**
+     * Signals controlling the playback for the media
+     */
+    void playForwards();
+    void stop();
+    void playBackwards();
+    void moveBackward();
+    void moveForward();
+
+    /* Exit fullscreen view and back to normal */
+    void exitFullscreen();
+
 protected:
     virtual void initializeGL() override;
     virtual void paintGL() override;
@@ -88,6 +112,8 @@ protected:
     virtual void mousePressEvent(QMouseEvent* event) override;
     virtual void mouseReleaseEvent(QMouseEvent* event) override;
     virtual void mouseMoveEvent(QMouseEvent* event) override;
+
+    virtual void keyPressEvent(QKeyEvent* event) override;
 
     virtual void wheelEvent(QWheelEvent* event) override;
 
@@ -124,9 +150,30 @@ private: /* Members */
 
     bool m_Pressed;
 
+    /**
+     * Holds the state whether the Renderer is currently rendering
+     * fullscreen or in normal view
+     */
+    bool m_Fullscreen;
+
     /* Panning */
     glm::vec2 m_Pan;
     Point m_LastMouse;
+
+};
+
+/**
+ * A Placeholder Renderer Widget which shows up when the renderer is fullscreen to occupy it's place
+ * Holds a Label stating that the Renderer is Fullscreen 
+ */
+class VOID_API VoidPlaceholderRenderer : public QWidget
+{
+public:
+    VoidPlaceholderRenderer(QWidget* parent = nullptr);
+
+private: /* Members */
+    QHBoxLayout* m_Layout;
+    QLabel* m_Label;
 
 };
 

--- a/src/VoidUi/PlayerWidget.h
+++ b/src/VoidUi/PlayerWidget.h
@@ -17,41 +17,6 @@
 
 VOID_NAMESPACE_OPEN
 
-class RenderFSWidget : public QWidget
-{
-    Q_OBJECT
-
-public:
-    RenderFSWidget(QWidget* parent = nullptr);
-
-    /**
-     * Sets the renderer's parent onto this widget
-     * Set the renderer in this widget's layout
-     */
-    void SetRenderer(VoidRenderer* renderer);
-
-signals:
-    /**
-     * Signals controlling the playback for the media
-     */
-    void playForwards();
-    void stop();
-    void playBackwards();
-    void moveBackward();
-    void moveForward();
-
-    /* Exit this view and back to normal */
-    void exitView();
-
-protected:
-    /* Override the key presses to trigger signals */
-    void keyPressEvent(QKeyEvent* event) override;
-
-private: /* Members */
-    QHBoxLayout* m_Layout;
-
-};
-
 class Player : public QWidget
 {
     Q_OBJECT
@@ -93,7 +58,7 @@ public:
     /**
      * Returns whether the player is currently fullscreen or not
      */
-    [[nodiscard]] inline bool Fullscreen() { return m_Fullscreen; }
+    [[nodiscard]] inline bool Fullscreen() { return m_Renderer->Fullscreen(); }
 
     /* Loads a Playable Media (clip) on the Player */
     void Load(const SharedMediaClip& media);
@@ -199,6 +164,7 @@ private:  /* Methods */
 
 private:  /* Members */
     VoidRenderer* m_Renderer;
+    VoidPlaceholderRenderer* m_PlaceholderRenderer;
     Timeline* m_Timeline;
 
     /**
@@ -223,10 +189,6 @@ private:  /* Members */
 
     /* Internal Layout to hold Renderer -- For when the renderer has returned from it's fullscreen view */
     QVBoxLayout* m_RendererLayout;
-
-    /* The Widget to house the fullscreen renderer */
-    RenderFSWidget* m_FullscreenRenderer;
-    bool m_Fullscreen;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/PlayerWindow.cpp
+++ b/src/VoidUi/PlayerWindow.cpp
@@ -123,6 +123,13 @@ QSize VoidMainWindow::sizeHint() const
     return QSize(1280, 760);
 }
 
+void VoidMainWindow::closeEvent(QCloseEvent* event)
+{
+    /* Close fullscreen if we're in that*/
+    if (m_Player->Fullscreen())
+        m_Player->ExitFullscreenRenderer();
+}
+
 void VoidMainWindow::Build()
 {
     /* Base Frameless widget */
@@ -266,11 +273,14 @@ void VoidMainWindow::Build()
 
     m_FullscreenAction = new QAction("Show Fullscreen");
     m_FullscreenAction->setShortcut(QKeySequence("Ctrl+F"));
+    
+    m_ExitFullscreenAction = new QAction("Exit Fullscreen");
 
     m_ViewerMenu->addAction(m_ZoomInAction);
     m_ViewerMenu->addAction(m_ZoomOutAction);
     m_ViewerMenu->addAction(m_ZoomToFitAction);
     m_ViewerMenu->addAction(m_FullscreenAction);
+    m_ViewerMenu->addAction(m_ExitFullscreenAction);
     /* }}} */
 
     /* Window Menu {{{ */
@@ -305,15 +315,7 @@ void VoidMainWindow::Connect()
     /* Title Bar Actions */
     connect(m_TitleBar, &VoidTitleBar::requestMinimize, this, &QWidget::showMinimized);
     connect(m_TitleBar, &VoidTitleBar::requestMaximizeRestore, this, [this]() { isMaximized() ? showNormal() : showMaximized(); });
-    connect(m_TitleBar, &VoidTitleBar::requestClose, this, [this]() 
-    {
-        /* Close fullscreen */
-        if (m_Player->Fullscreen())
-            m_Player->ExitFullscreenRenderer();
-
-        /* Close the player */
-        close();
-    });
+    connect(m_TitleBar, &VoidTitleBar::requestClose, this, &QWidget::close);
     #endif  // USE_FRAMED_WINDOW
 
     /* Menu Actions */
@@ -346,6 +348,7 @@ void VoidMainWindow::Connect()
     connect(m_ZoomOutAction, &QAction::triggered, m_Player, &Player::ZoomOut);
     connect(m_ZoomToFitAction, &QAction::triggered, m_Player, &Player::ZoomToFit);
     connect(m_FullscreenAction, &QAction::triggered, m_Player, &Player::SetRendererFullscreen);
+    connect(m_ExitFullscreenAction, &QAction::triggered, m_Player, &Player::ExitFullscreenRenderer);
     /* }}} */
 
     connect(m_MediaListerAction, &QAction::toggled, this, [this](bool checked) { m_InternalDocker->ToggleComponent(DockerWindow::Component::MediaLister, checked); });

--- a/src/VoidUi/PlayerWindow.h
+++ b/src/VoidUi/PlayerWindow.h
@@ -83,6 +83,8 @@ private: /* Methods */
     void Connect();
 
 protected:
+    void closeEvent(QCloseEvent* event) override;
+
     /* Caches the Media if Caching is allowed */
     void CacheLookAhead();
 
@@ -136,6 +138,7 @@ private: /* Members */
     QAction* m_ZoomOutAction;
     QAction* m_ZoomToFitAction;
     QAction* m_FullscreenAction;
+    QAction* m_ExitFullscreenAction;
 
     /* Window Menu */
     QMenu* m_WindowMenu;


### PR DESCRIPTION
### Fix: Fullscreen View
* Add the closeEvent to allow getting rid of the fullscreen view when closing always.
* This gets rid of the need of an additional widget container to hold the renderer
* Mac's AppKit is very picky about allowing something to be fullscreen which does not have a geometry set yet.