### PR TITLE
[VOID] Player: Comparison Mode Fixes

### DIFF
--- a/src/VoidUi/BufferSwitch.cpp
+++ b/src/VoidUi/BufferSwitch.cpp
@@ -4,7 +4,6 @@
 /* Internal */
 #include "BufferSwitch.h"
 #include "VoidCore/Logging.h"
-#include "VoidRenderer/RenderTypes.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -88,6 +87,15 @@ void ComparisonModeSelector::Setup()
 
     /* Set the Default Radio Item check state */
     m_RadioActions.front()->setChecked(true);
+}
+
+void ComparisonModeSelector::SetCompareMode(const Renderer::ComparisonMode& mode)
+{
+    /* Update the Text on the Frame */
+    setText(Renderer::ComparisonModesMap.at(mode).c_str());
+
+    /* Emit the index of the Mode so that other components can receive them */
+    emit primaryIndexChanged(static_cast<int>(mode));
 }
 
 /* }}} */

--- a/src/VoidUi/BufferSwitch.h
+++ b/src/VoidUi/BufferSwitch.h
@@ -9,6 +9,7 @@
 #include "Definition.h"
 #include "ViewerBuffer.h"
 #include "QExtensions/Frame.h"
+#include "VoidRenderer/RenderTypes.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -39,6 +40,11 @@ class ComparisonModeSelector : public SplitSectionSelector
 public:
     ComparisonModeSelector(QWidget* parent = nullptr);
 
+    /**
+     * Sets the Comparison Mode
+     */
+    void SetCompareMode(const Renderer::ComparisonMode& mode);
+
 private:
     /**
      * Setup the Comparison Modes and Default values
@@ -53,6 +59,8 @@ class BufferSwitch : public QWidget
 public:
     BufferSwitch(ViewerBuffer* A, ViewerBuffer* B, QWidget* parent = nullptr);
     ~BufferSwitch();
+
+    inline void SetCompareMode(const Renderer::ComparisonMode& mode) { m_ComparisonModes->SetCompareMode(mode); }
 
 signals:
     void switched(const PlayerViewBuffer&);

--- a/src/VoidUi/ControlBar.h
+++ b/src/VoidUi/ControlBar.h
@@ -39,7 +39,7 @@ public:
     ControlBar(ViewerBuffer* A, ViewerBuffer* B, QWidget* parent = nullptr);
     virtual ~ControlBar();
 
-    /*
+    /**
      * Since the viewport could also have a zoom applied on itself, that value should then also
      * need to reflect on the zoom slider, and hence the zoom factor needs to be translated to Slider
      * space and then set on the Zoom slider
@@ -47,6 +47,11 @@ public:
      * the signals are blocked till the time the value has been set on the slider and unblocked after
      */
     void SetFromZoom(float zoom);
+
+    /**
+     * Sets the current Compare mode
+     */
+    inline void SetCompareMode(const Renderer::ComparisonMode& mode) { m_BufferSwitch->SetCompareMode(mode); }
 
 signals:
     void zoomChanged(const float factor);

--- a/src/VoidUi/PlayerWidget.cpp
+++ b/src/VoidUi/PlayerWidget.cpp
@@ -231,16 +231,20 @@ void Player::Load(const SharedPlaybackSequence& sequence)
 void Player::SetFrame(int frame)
 {
     /**
+     * Comparison Gets precedence --> If we're in comparing mode -> Compare Media frames
+     * the media frames could be from any component Track, Clip
+     */
+    if (Comparing())
+        return CompareMediaFrame(frame);
+
+    /**
      * Check what do we want to play
      * if currently playing component on the Active ViewerBuffer is Sequence, meaning that was latest set on it
      */
     if (m_ActiveViewBuffer->PlayingComponent() == ViewerBuffer::PlayableComponent::Sequence)
         return SetSequenceFrame(frame);
     else if (m_ActiveViewBuffer->PlayingComponent() == ViewerBuffer::PlayableComponent::Track)
-        return SetTrackFrame(frame);
-
-    if (m_ComparisonMode != Renderer::ComparisonMode::NONE)
-        return CompareMediaFrame(frame);
+        return SetTrackFrame(frame);        
 
     return SetMediaFrame(frame);
 }
@@ -423,6 +427,13 @@ void Player::SetBlendMode(const int mode)
 
 void Player::SetViewBuffer(const PlayerViewBuffer& buffer)
 {
+    /**
+     * If we're currently comparing -> Then reset the Compare Mode to be None and select the buffer
+     * which was currently opted
+     */
+    if (Comparing())
+        m_ControlBar->SetCompareMode(Renderer::ComparisonMode::NONE);
+
     /* Update the active buffer based on the provided buffer enum */
     if (buffer == PlayerViewBuffer::A)
     {

--- a/src/VoidUi/PlayerWidget.h
+++ b/src/VoidUi/PlayerWidget.h
@@ -60,6 +60,10 @@ public:
      * Returns whether the player is currently fullscreen or not
      */
     [[nodiscard]] inline bool Fullscreen() { return m_Renderer->Fullscreen(); }
+    /**
+     * Returns true if the current comparison mode is not Compare None
+     */
+    [[nodiscard]] inline bool Comparing() { return m_ComparisonMode != Renderer::ComparisonMode::NONE; }
 
     /* Loads a Playable Media (clip) on the Player */
     void Load(const SharedMediaClip& media);


### PR DESCRIPTION
### Fix
* Fixed Comparison Precedence.
* Comparison mode is reset when single buffer is selected.

### Additional
* Added API to allow setting compare mode on the ControlBar -> other Components (via signal)