### PR TITLE
[void] UndoStack: Added Undo stack to the media bridge

### DIFF
--- a/src/VoidUi/BaseWindow/PlayerWindow.h
+++ b/src/VoidUi/BaseWindow/PlayerWindow.h
@@ -116,6 +116,8 @@ private: /* Members */
 
     /* Edit Menu */
     QMenu* m_EditMenu;
+    QAction* m_UndoAction;
+    QAction* m_RedoAction;
     QAction* m_EditPrefsAction;
     
     /* Playback Menu */
@@ -154,6 +156,9 @@ private: /* Members */
 
     /* State determining whether to cache the current media upfront or not */
     bool m_CacheMedia;
+
+    /* Media Bridge Instance */
+    MBridge& m_Bridge;
 
     /* Image Sequence */
     Media m_Media;

--- a/src/VoidUi/Browser.cpp
+++ b/src/VoidUi/Browser.cpp
@@ -19,6 +19,17 @@ bool VoidMediaBrowser::Browse()
     return exec();
 }
 
+std::string VoidMediaBrowser::GetSelectedFile() const
+{
+    QStringList files = selectedFiles();
+
+    /* Empty Media struct */
+    if (files.empty())
+        return "";
+
+    return files.first().toStdString();
+}
+
 MediaStruct VoidMediaBrowser::GetMediaStruct() const
 {
     QStringList files = selectedFiles();

--- a/src/VoidUi/Browser.h
+++ b/src/VoidUi/Browser.h
@@ -25,6 +25,7 @@ public:
     [[nodiscard]] bool Browse();     
 
     inline std::string GetDirectory() const { return directory().absolutePath().toStdString(); }
+    std::string GetSelectedFile() const;
     MediaStruct GetMediaStruct() const;
 };
 

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -18,6 +18,10 @@ add_library(
     BaseWindow/PlayerWindow.cpp
     BaseWindow/TitleBar.cpp
 
+    # Commands
+    Commands/VoidCommand.cpp
+    Commands/MediaCommands.cpp
+
     # Media
     Media/MediaBridge.cpp
     Media/MediaClip.cpp

--- a/src/VoidUi/Commands/MediaCommands.cpp
+++ b/src/VoidUi/Commands/MediaCommands.cpp
@@ -1,0 +1,119 @@
+/* Internal */
+#include "MediaCommands.h"
+
+VOID_NAMESPACE_OPEN
+
+/* Media Import Command {{{ */
+
+MediaImportCommand::MediaImportCommand(const std::string& path, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Path(path)
+{
+    /* The current index on which the Media Will be inserted */
+    m_InsertIndex = MBridge::Instance().DataModel()->rowCount();
+
+    setText("Import Media");
+}
+
+void MediaImportCommand::undo()
+{
+    /* Index at which the Media was inserted and now needs removal */
+    QModelIndex index = MBridge::Instance().DataModel()->index(m_InsertIndex, 0);
+
+    /* Remove the Media at the index */
+    MBridge::Instance().Remove(index);
+}
+
+bool MediaImportCommand::Redo()
+{
+    /* Construct the media struct from the file path */
+    MediaStruct mstruct = MediaStruct::FromFile(m_Path);
+
+    /* Validate before adding */
+    if (mstruct.Empty())
+    {
+        VOID_LOG_INFO("Invalid Media");
+        return false;
+    }
+
+    if (!mstruct.ValidMedia())
+    {
+        VOID_LOG_INFO("Invalid Media: {0}", mstruct.FirstPath());
+        return false;
+    }
+
+    /* Add the Media to the Model */
+    return MBridge::Instance().AddMedia(mstruct);
+}
+
+/* }}} */
+
+/* Media Remove Command {{{ */
+
+MediaRemoveCommand::MediaRemoveCommand(const std::vector<QModelIndex>& indexes, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Indexes(indexes)
+{
+    setText("Remove Media(s)");
+}
+
+void MediaRemoveCommand::undo()
+{
+    /* Add each Item back from its original source */
+    for (std::pair<int, std::string> item : m_Paths)
+    {
+        /* Construct the media struct from the file path */
+        MediaStruct mstruct = MediaStruct::FromFile(item.second);
+
+        /* Validate before adding */
+        if (mstruct.Empty())
+        {
+            VOID_LOG_INFO("Invalid Media");
+            return;
+        }
+
+        if (!mstruct.ValidMedia())
+        {
+            VOID_LOG_INFO("Invalid Media: {0}", mstruct.FirstPath());
+            return;
+        }
+
+        /* Add the Media to the Model */
+        MBridge::Instance().InsertMedia(mstruct, item.first);
+    }
+}
+
+bool MediaRemoveCommand::Redo()
+{
+    /* Don't have anything to do */
+    if (m_Indexes.empty())
+        return false;
+
+    /**
+     * Loop over in a a reverse way as forward iteration would shift the model indexes and
+     * result in wrong indexes being deleted, or a worst case scenario result in crashes as
+     * the second model index doesn't even exist after the first has been deleted
+     */
+    for (int i = m_Indexes.size() - 1; i >= 0; --i)
+    {
+
+        QModelIndex index = m_Indexes.at(i);
+
+        /* Update the internal struct so that we know where each clip was and it's path */
+        const SharedMediaClip clip = MBridge::Instance().DataModel()->Media(index);
+
+        /**
+         * Basepath from the clip, which will be used to create the clip back
+         */
+        m_Paths[index.row()] = clip->FirstFrameData().Path();
+
+        /* Now Set this media for being removed */
+        MBridge::Instance().Remove(index);
+    }
+
+    return true;
+}
+
+/* }}} */
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Commands/MediaCommands.h
+++ b/src/VoidUi/Commands/MediaCommands.h
@@ -1,0 +1,50 @@
+#ifndef _VOID_MEDIA_COMMANDS_H
+#define _VOID_MEDIA_COMMANDS_H
+
+/* STD */
+#include <map>
+#include <vector>
+
+/* Internal */
+#include "Definition.h"
+#include "VoidCommand.h"
+#include "VoidUi/Media/MediaBridge.h"
+
+VOID_NAMESPACE_OPEN
+
+class MediaImportCommand : public VoidUndoCommand
+{
+public:
+    MediaImportCommand(const std::string& path, QUndoCommand* parent = nullptr);
+
+    /* Define the Undo Action */
+    void undo() override;
+    /* The return status governs if the command needs to be marked as obsolete when failed */
+    bool Redo() override;
+
+private: /* Members */
+    size_t m_InsertIndex;
+    /* Non Destructable entity that can construct the media */
+    std::string m_Path;
+};
+
+class MediaRemoveCommand : public VoidUndoCommand
+{
+public:
+    MediaRemoveCommand(const std::vector<QModelIndex>& indexes, QUndoCommand* parent = nullptr);
+
+    /* Define the Undo Action */
+    void undo() override;
+    /* The return status governs if the command needs to be marked as obsolete when failed */
+    bool Redo() override;
+
+private: /* Members */
+    /* Mapped to the index of the Clip and the path required to create the Media */
+    std::map<int, std::string> m_Paths;
+    /* Item indexes which are to be removed */
+    std::vector<QModelIndex> m_Indexes;
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _VOID_MEDIA_COMMANDS_H

--- a/src/VoidUi/Commands/VoidCommand.cpp
+++ b/src/VoidUi/Commands/VoidCommand.cpp
@@ -1,0 +1,23 @@
+/* Internal */
+#include "VoidCommand.h"
+
+VOID_NAMESPACE_OPEN
+
+VoidUndoCommand::VoidUndoCommand(QUndoCommand* parent)
+    : QUndoCommand(parent)
+{
+}
+
+void VoidUndoCommand::redo()
+{
+    /**
+     * If the Underlying Redo function returns False
+     * this means that the command failed to execute and cannot be undone or redone again
+     * marking this as obsolete so that this stays out of the undo stack
+     */
+    bool status = Redo();
+
+    setObsolete(!status);
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Commands/VoidCommand.h
+++ b/src/VoidUi/Commands/VoidCommand.h
@@ -1,0 +1,25 @@
+#ifndef _VOID_BASIC_COMMAND_H
+#define _VOID_BASIC_COMMAND_H
+
+/* Qt */
+#include <QUndoCommand>
+
+/* Internal */
+#include "Definition.h"
+
+VOID_NAMESPACE_OPEN
+
+class VoidUndoCommand : public QUndoCommand
+{
+public:
+    VoidUndoCommand(QUndoCommand* parent = nullptr);
+    /* Override the base Redo to set Obsolete state when the Redo function return false */
+    void redo() override;
+
+protected:
+    virtual bool Redo() = 0;
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _VOID_BASIC_COMMAND_H

--- a/src/VoidUi/Media/MediaBridge.cpp
+++ b/src/VoidUi/Media/MediaBridge.cpp
@@ -11,6 +11,7 @@ MBridge::MBridge(QObject* parent)
     : QObject(parent)
 {
     m_Media = new MediaModel(this);
+    m_UndoStack = new QUndoStack(this);
 }
 
 MBridge::~MBridge()
@@ -20,7 +21,7 @@ MBridge::~MBridge()
     m_Media = nullptr;
 }
 
-void MBridge::AddMedia(const MediaStruct& mstruct)
+bool MBridge::AddMedia(const MediaStruct& mstruct)
 {
     /* Create the Media Clip */
     SharedMediaClip clip = std::make_shared<MediaClip>(Media(mstruct), this);
@@ -29,7 +30,7 @@ void MBridge::AddMedia(const MediaStruct& mstruct)
     if (clip->Empty())
     {
         VOID_LOG_INFO("Invalid Media.");
-        return;
+        return false;
     }
 
     /* Add to the underlying struct */
@@ -37,9 +38,35 @@ void MBridge::AddMedia(const MediaStruct& mstruct)
 
     /* Emit that we have added a new media clip now */
     emit mediaAdded(clip);
+
+    /* Added successfully */
+    return true;
 }
 
-void MBridge::Remove(SharedMediaClip clip)
+bool MBridge::InsertMedia(const MediaStruct& mstruct, const int index)
+{
+    /* Create the Media Clip */
+    SharedMediaClip clip = std::make_shared<MediaClip>(Media(mstruct), this);
+
+    /* Check if the clip is valid, there could be cases we don't have a specific media reader */
+    if (clip->Empty())
+    {
+        VOID_LOG_INFO("Invalid Media.");
+        return false;
+    }
+
+    /* Add to the underlying struct */
+    m_Media->Insert(clip, index);
+
+    /* Emit that we have added a new media clip now */
+    emit mediaAdded(clip);
+
+    /* Added successfully */
+    return true;
+
+}
+
+bool MBridge::Remove(SharedMediaClip clip)
 {
     /* Emit the mediaAboutToBeRemoved signal for all listeners to clear the item */
     emit mediaAboutToBeRemoved(clip);
@@ -52,9 +79,11 @@ void MBridge::Remove(SharedMediaClip clip)
 
     /* Remove this from the Underlying model */
     m_Media->Remove(index);
+
+    return true;
 }
 
-void MBridge::Remove(const QModelIndex& index)
+bool MBridge::Remove(const QModelIndex& index)
 {
     /* The Media Associated with the Model index */
     SharedMediaClip clip = m_Media->Media(index);
@@ -67,6 +96,14 @@ void MBridge::Remove(const QModelIndex& index)
 
     /* Remove this from the Underlying model */
     m_Media->Remove(index);
+
+    return true;
+}
+
+void MBridge::PushCommand(QUndoCommand* command)
+{
+    /* Push it on the Undo Stack */
+    m_UndoStack->push(command);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/MediaClip.h
+++ b/src/VoidUi/Media/MediaClip.h
@@ -90,6 +90,7 @@ public:
     Renderer::SharedAnnotation Annotation(const v_frame_t frame) const;
 
     /* Exposed Media Function Accessors */
+    inline std::string Path() const { return m_Media.Path(); }
     inline std::string Name() const { return m_Media.Name(); }
     inline std::string Extension() const { return m_Media.Extension(); }
     inline v_frame_t FirstFrame() const { return m_Media.FirstFrame(); }

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -15,6 +15,9 @@
 #include "VoidCore/Logging.h"
 #include "VoidUi/VoidStyle.h"
 
+/* Commands */
+#include "VoidUi/Commands/MediaCommands.h"
+
 VOID_NAMESPACE_OPEN
 
 VoidMediaLister::VoidMediaLister(QWidget* parent)
@@ -244,18 +247,8 @@ void VoidMediaLister::ShowContextMenu(const Point& position)
 
 void VoidMediaLister::RemoveSelectedMedia()
 {
-    /* Selected Indexes */
-    std::vector<QModelIndex> selected = m_MediaView->SelectedIndexes();
-
-    /**
-     * Loop over in a a reverse way as forward iteration would shift the model indexes and
-     * result in wrong indexes being deleted, or a worst case scenario result in crashes as
-     * the second model index doesn't even exist after the first has been deleted
-     */
-    for (int i = selected.size() - 1; i >= 0; --i)
-    {
-        MBridge::Instance().Remove(selected.at(i));
-    }
+    /* Push all of the selected indexes for removal */
+    MBridge::Instance().PushCommand(new MediaRemoveCommand(m_MediaView->SelectedIndexes()));
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/Models/MediaModel.cpp
+++ b/src/VoidUi/Media/Models/MediaModel.cpp
@@ -118,6 +118,13 @@ void MediaModel::Add(const SharedMediaClip& media)
     endInsertRows();
 }
 
+void MediaModel::Insert(const SharedMediaClip& media, const int index)
+{
+    beginInsertRows(QModelIndex(), index, index);
+    m_Media.insert(m_Media.begin() + index, media);
+    endInsertRows();
+}
+
 void MediaModel::Remove(const QModelIndex& index)
 {
     if (!index.isValid())

--- a/src/VoidUi/Media/Models/MediaModel.h
+++ b/src/VoidUi/Media/Models/MediaModel.h
@@ -50,6 +50,7 @@ public:
 
     /* Media */
     void Add(const SharedMediaClip& media);
+    void Insert(const SharedMediaClip& media, const int index);
     void Remove(const QModelIndex& index);
     
     SharedMediaClip Media(const QModelIndex& index);

--- a/src/VoidUi/VoidStyle.cpp
+++ b/src/VoidUi/VoidStyle.cpp
@@ -9,15 +9,31 @@ VOID_NAMESPACE_OPEN
 VoidDark::VoidDark()
     : QProxyStyle("Fusion")
 {
-    
+
 }
+
+// void VoidDark::drawItemText(QPainter* painter, const QRect& rect, int flags, const QPalette& palette, bool enabled, const QString& text, QPalette::ColorRole textRole) const
+// {
+//     VOID_LOG_INFO(text.toStdString());
+//     if (!enabled)
+//     {
+//         QColor disabled = QColor(240, 240, 240); // palette.color(QPalette::Disabled, textRole);
+//         painter->setPen(disabled);
+//         painter->drawText(rect, flags, text);   // Draw text with disabled text color
+//     }
+//     else
+//     {
+//         /* Base drawing */
+//         QProxyStyle::drawItemText(painter, rect, flags, palette, enabled, text, textRole);
+//     }
+// }
 
 void VoidDark::drawPrimitive(PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const
 {
     // if (element == PE_PanelButtonCommand)
     // {
     //     painter->fillRect(option->rect, QColor(53, 53, 53));
-        
+
     //     return;
     // }
 
@@ -45,6 +61,31 @@ void VoidDark::drawControl(ControlElement element, const QStyleOption* option, Q
 {
     switch (element)
     {
+        case CE_MenuItem:
+        {
+            const QStyleOptionMenuItem* item = qstyleoption_cast<const QStyleOptionMenuItem*>(option);
+
+            if (!item)
+                break;
+
+            /* Get the sub element rect for the icon */
+            // QRect iconRect = QRect(item->rect.left(), item->rect.top(), item->maxIconWidth, )
+            QRect textRect = item->rect;
+            /* Consider the icon width */
+            textRect.setLeft(textRect.left() + item->maxIconWidth + 6); // Add the spacing across icon sides
+
+            if (item->state & QStyle::State_Enabled)
+            {
+                /* Default */
+                QProxyStyle::drawControl(element, option, painter, widget);
+                break;
+            }
+
+            painter->setPen(VOID_FOREGROUND_DISABLED_COLOR);
+            painter->drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, item->text);
+            break;
+
+        }
         // case CE_ShapedFrame:
         //     /* Dark frame background */
         //     painter->fillRect(option->rect, QColor(40, 40, 40));
@@ -73,6 +114,8 @@ void VoidDark::polish(QPalette& palette)
     palette.setColor(QPalette::Highlight, VOID_HIGHLIGHT_GREEN);
     palette.setColor(QPalette::HighlightedText, Qt::black);
     palette.setColor(QPalette::Dark, QColor(20, 20, 20));
+
+    palette.setColor(QPalette::Disabled, QPalette::Text, VOID_FOREGROUND_DISABLED_COLOR);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/VoidStyle.h
+++ b/src/VoidUi/VoidStyle.h
@@ -23,12 +23,14 @@ const QColor VOID_PURPLE_COLOR = {130, 110, 190};
 const QColor VOID_DARK_HIGHLIGHT_GREEN = {70, 110, 30};
 const QColor VOID_HIGHLIGHT_GREEN = {160, 190, 60};
 const QColor VOID_FOREGROUND_COLOR = {190, 190, 190};
+const QColor VOID_FOREGROUND_DISABLED_COLOR = {80, 80, 80};
 
 class VOID_API VoidDark : public QProxyStyle
 {
 public:
     VoidDark();
 
+    // void drawItemText(QPainter* painter, const QRect& rect, int flags, const QPalette& palette, bool enabled, const QString& text, QPalette::ColorRole textRole = QPalette::NoRole) const override;
     void drawPrimitive(PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget = nullptr) const override;
     void drawControl(ControlElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget = nullptr) const override;
     void polish(QPalette& palette) override;

--- a/src/include/Definition.h
+++ b/src/include/Definition.h
@@ -4,8 +4,8 @@
 /* Namespaces */
 #define VOID_NAMESPACE voidplayer
 
-#define VOID_NAMESPACE_OPEN namespace VOID_NAMESPACE { /* VOID namespace */
-#define VOID_NAMESPACE_CLOSE } // namespace VOID
+#define VOID_NAMESPACE_OPEN namespace VOID_NAMESPACE { /* voidplayer namespace */
+#define VOID_NAMESPACE_CLOSE } // namespace voidplayer
 
 /* Symbols Visibility */
 #if defined(_WIN32) || defined(__CYGWIN__)
@@ -19,6 +19,6 @@
 #endif // defined(_WIN32) || defined(__CYGWIN__)
 
 /* type definitions */
-typedef int64_t v_frame_t; // Represents a frame number or something to hold a frame duration
+typedef signed long v_frame_t; // Represents a frame number or something to hold a frame duration
 
 #endif // _VOID_BASIC_DEFINITIONS_H


### PR DESCRIPTION
### FEAT: Undo Stack
* Added a base for Undo and Redo to work.
* Undo Stack currently is a part of the Singleton Media Bridge which is accessible by all the UI components (except Renderer).
* Add Media and Remove selected media is now using Media Import/Remove commands.
* Other commands will be implemented as we progress further.
* The commands also should be written in a way that is the most optimal solution to remove/add back or play.