### PR TITLE
[VOID] Fix Builds on Windows and Mac

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,10 @@ if (QT_MAJOR_VERSION EQUAL 6)
 endif()
 
 # Freetype
-include_directories(${FREETYPE_INCLUDE_DIRS})
+include_directories(
+    ${FREETYPE_INCLUDE_DIRS}
+    ${FFMPEG_INCLUDE_DIRS}
+)
 
 # Main Executable
 add_executable(

--- a/src/VoidCore/FormatForge.cpp
+++ b/src/VoidCore/FormatForge.cpp
@@ -5,6 +5,12 @@
 
 VOID_NAMESPACE_OPEN
 
+Forge& Forge::Instance()
+{
+    static Forge f;
+    return f;
+}
+
 bool Forge::Register(const FormatRegistry<PixForge>& registry)
 {
     for (const std::string& extension: registry.extensions)

--- a/src/VoidCore/Plugins/Loader.cpp
+++ b/src/VoidCore/Plugins/Loader.cpp
@@ -24,6 +24,7 @@ const std::string DELIMITER = ";";
 const std::string EXTENSION = ".dll";
 #elif defined(__APPLE__)                        // APPLE
 const std::string EXTENSION = ".dylib";
+const std::string DELIMITER = ":";
 #else                                           // Linux
 const std::string EXTENSION = ".so";
 const std::string DELIMITER = ":";

--- a/src/VoidCore/Readers/FFmpegReader.h
+++ b/src/VoidCore/Readers/FFmpegReader.h
@@ -90,7 +90,7 @@ private: /* Methods */
 };
 
 
-class FFmpegPixReader : public VoidMPixReader
+class VOID_API FFmpegPixReader : public VoidMPixReader
 {
 public:
     FFmpegPixReader();

--- a/src/VoidCore/Readers/OIIOReader.h
+++ b/src/VoidCore/Readers/OIIOReader.h
@@ -10,7 +10,7 @@
 
 VOID_NAMESPACE_OPEN
 
-class OIIOPixReader : public VoidPixReader
+class VOID_API OIIOPixReader : public VoidPixReader
 {
 public:
     OIIOPixReader();

--- a/src/VoidCore/Readers/OpenEXRReader.h
+++ b/src/VoidCore/Readers/OpenEXRReader.h
@@ -10,7 +10,7 @@
 
 VOID_NAMESPACE_OPEN
 
-class OpenEXRReader : public VoidPixReader
+class VOID_API OpenEXRReader : public VoidPixReader
 {
 public:
     OpenEXRReader();

--- a/src/VoidCore/Readers/Registration.h
+++ b/src/VoidCore/Readers/Registration.h
@@ -24,7 +24,7 @@ struct OIIOReaderPlugin
          * For now Going with all types of formats separately like "jpg" and "JPG" differ in cases
          * We could go for a tolower but the case might have unnecessary copies going for each extension
          * and for each of the frame that's from the source which looks too expensive at the moment
-         * 
+         */ 
         /* Image Registry */
         FormatRegistry<PixForge> f;
 
@@ -88,7 +88,7 @@ struct FFmpegReaderPlugin
  * image readers from that. For now this needs to be done as a way to explicitly call this function
  * after VOID_LOG has been initialized if required
  */
-VOID_API void RegisterReaders()
+void RegisterReaders()
 {
     /* Register OIIO Reader */
     OIIOReaderPlugin o;

--- a/src/VoidRenderer/CMakeLists.txt
+++ b/src/VoidRenderer/CMakeLists.txt
@@ -2,9 +2,11 @@
 add_library(
     VoidRenderer
     SHARED
+    Renderer.h
     Renderer.cpp
     RendererStatus.cpp
     RenderTypes.h
+    VoidRenderer.h
     VoidRenderer.cpp
 
     # Core
@@ -47,6 +49,7 @@ target_link_libraries(
     PRIVATE
     VoidCore
     Qt::Widgets
+    Qt::Core
     OpenGL::GL
     glm::glm
     GLEW::GLEW

--- a/src/VoidRenderer/Renderer.h
+++ b/src/VoidRenderer/Renderer.h
@@ -13,7 +13,7 @@
 
 VOID_NAMESPACE_OPEN
 
-class BasicRenderer : public QOpenGLWidget
+class VOID_API BasicRenderer : public QOpenGLWidget
 {
     Q_OBJECT
 
@@ -47,7 +47,7 @@ public:
      * This needs to be invoked before the context is initialized
      * That means it should get invoked before we create the instance of the VoidRenderer.
      */
-    static VOID_API void SetProfile();
+    static void SetProfile();
 
 signals:
     /**

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -11,6 +11,12 @@ add_library(
     TrackItem.cpp
     ViewerBuffer.cpp
     VoidStyle.cpp
+
+    # Renderer   --- This is needed on windows for the moc compilation to succeed on PlayerWidget which expects
+    # the staticMetaObject for BasicRenderer and VoidRenderer to be present at compile time rather link time
+    ../VoidRenderer/Renderer.h
+    ../VoidRenderer/VoidRenderer.h
+    # TODO: Find a better way around this....
     
     # Base Window
     BaseWindow/Docker.cpp

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Build Ui Library
-add_library(
-    VoidUi
-    SHARED
+set(SOURCES
     About.cpp
     Browser.cpp
     Events.h
@@ -12,12 +10,6 @@ add_library(
     ViewerBuffer.cpp
     VoidStyle.cpp
 
-    # Renderer   --- This is needed on windows for the moc compilation to succeed on PlayerWidget which expects
-    # the staticMetaObject for BasicRenderer and VoidRenderer to be present at compile time rather link time
-    ../VoidRenderer/Renderer.h
-    ../VoidRenderer/VoidRenderer.h
-    # TODO: Find a better way around this....
-    
     # Base Window
     BaseWindow/Docker.cpp
     BaseWindow/BaseWindow.cpp
@@ -61,6 +53,22 @@ add_library(
     QExtensions/Slider.cpp
     QExtensions/SpinBox.cpp
     QExtensions/ToolTip.cpp
+)
+
+if (WIN32)
+    list(APPEND SOURCES
+        # Renderer   --- This is needed on windows for the moc compilation to succeed on PlayerWidget which expects
+        # the staticMetaObject for BasicRenderer and VoidRenderer to be present at compile time rather link time
+        ../VoidRenderer/Renderer.h
+        ../VoidRenderer/VoidRenderer.h
+        # TODO: Find a better way around this....
+    )
+endif()
+
+add_library(
+    VoidUi
+    SHARED
+    ${SOURCES}
 )
 
 target_link_libraries(

--- a/src/include/FormatForge.h
+++ b/src/include/FormatForge.h
@@ -38,17 +38,23 @@ struct FormatRegistry
 
 class VOID_API Forge
 {
+    Forge() = default;
+
 public:
     /**
      * Returns the static instance of the Forge
      * allowing it to be singleton and accessors can then read from the same instance
      * where readers are registered
      */
-    static Forge& Instance()
-    {
-        static Forge f;
-        return f;
-    }
+    static Forge& Instance();
+
+    /* Disable Copy */
+    Forge(const Forge&) = delete;
+    Forge& operator=(const Forge&) = delete;
+
+    /* Disable Move */
+    Forge(Forge&&) = delete;
+    Forge& operator=(Forge&&) = delete;
 
     /**
      * Allows image Reader plugins for Formats to be registered

--- a/src/include/FormatForge.h
+++ b/src/include/FormatForge.h
@@ -36,7 +36,7 @@ struct FormatRegistry
     Ty reader;
 };
 
-class Forge
+class VOID_API Forge
 {
 public:
     /**


### PR DESCRIPTION
### Fixes Builds
* Fixed an issue with MacOS where DELIMITER was not defined.
* Fixed staticMetaObject linker errors with Renderer for Windows.
* Fixed the singleton issue (ODR) for Forge in windows.