### PR TITLE
[VOID] Linear Input

### DIFF
--- a/src/VoidCore/Readers/FFmpegReader.h
+++ b/src/VoidCore/Readers/FFmpegReader.h
@@ -147,7 +147,7 @@ public:
     /**
      * Returns if the underlying struct has any pixel data
      */
-    inline virtual bool Empty() override { return m_Pixels.empty(); }
+    inline virtual bool Empty() const override { return m_Pixels.empty(); }
 
     /**
      * Updates the internal filepath to process needed information
@@ -163,6 +163,11 @@ public:
      * Returns the framerate of the movie media
      */
     virtual double Framerate() override;
+
+    /**
+     * Retrieve the input colorspace of the media file
+     */
+    inline virtual ColorSpace InputColorSpace() const override { return ColorSpace::sRGB; }
 
 private: /* Members */
     std::string m_Path;

--- a/src/VoidCore/Readers/OIIOReader.cpp
+++ b/src/VoidCore/Readers/OIIOReader.cpp
@@ -12,6 +12,7 @@ OIIOPixReader::OIIOPixReader(const std::string& path)
     , m_Width(0)
     , m_Height(0)
     , m_Channels(0)
+    , m_InputColorSpace(ColorSpace::sRGB)
 {
 }
 
@@ -60,6 +61,14 @@ void OIIOPixReader::Read(const std::string& path, int framenumber)
     m_Height = spec.height;
     m_Channels = spec.nchannels;
 
+    /* Get the colorspace from the image spec {{{ */
+    std::string colorspace = spec.get_string_attribute("oiio:ColorSpace");
+
+    /* Our default Input ColorSpace points at sRGB, only cases where we want to update that */
+    if (colorspace.find("Rec.709") != std::string::npos)
+        m_InputColorSpace = ColorSpace::Rec709;
+    /* }}} */
+
     VOID_LOG_INFO("OIIOPixReader ( Width: {0}, Height: {1}, Channels: {2} )", m_Width, m_Height, m_Channels);
 
     /* Read requisites */
@@ -77,6 +86,5 @@ void OIIOPixReader::Read(const std::string& path, int framenumber)
     /* Close the image after reading */
     input->close();
 }
-
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Readers/OIIOReader.h
+++ b/src/VoidCore/Readers/OIIOReader.h
@@ -67,7 +67,12 @@ public:
     /**
      * Returns if the underlying struct has any pixel data
      */
-    inline virtual bool Empty() override { return m_Pixels.empty(); }
+    inline virtual bool Empty() const override { return m_Pixels.empty(); }
+
+    /**
+     * Retrieve the input colorspace of the media file
+     */
+    inline virtual ColorSpace InputColorSpace() const { return m_InputColorSpace; }
 
 private: /* Methods */
     std::string m_Path;
@@ -76,6 +81,9 @@ private: /* Methods */
     int m_Width, m_Height;
     /* Number of channels in the image */
     int m_Channels;
+
+    /* Colorspace of the Media */
+    ColorSpace m_InputColorSpace;
 
     /* Internal data store */
     std::vector<unsigned char> m_Pixels;

--- a/src/VoidCore/Readers/OpenEXRReader.h
+++ b/src/VoidCore/Readers/OpenEXRReader.h
@@ -67,7 +67,12 @@ public:
     /**
      * Returns if the underlying struct has any pixel data
      */
-    inline virtual bool Empty() override { return m_Pixels.empty(); }
+    inline virtual bool Empty() const override { return m_Pixels.empty(); }
+
+    /**
+     * Retrieve the input colorspace of the media file
+     */
+    inline virtual ColorSpace InputColorSpace() const override { return ColorSpace::Linear; }
 
 private: /* Methods */
     std::string m_Path;

--- a/src/VoidRenderer/Gears/ImageRenderGear.cpp
+++ b/src/VoidRenderer/Gears/ImageRenderGear.cpp
@@ -20,6 +20,7 @@ ImageRenderGear::ImageRenderGear()
     , m_UGamma(-1)
     , m_UGain(-1)
     , m_UChannelMode(-1)
+    , m_UInputColorSpace(-1)
 {
 }
 
@@ -49,6 +50,7 @@ void ImageRenderGear::Initialize()
     m_UGamma = glGetUniformLocation(m_Shader->ProgramId(), "gamma");
     m_UGain = glGetUniformLocation(m_Shader->ProgramId(), "gain");
     m_UChannelMode = glGetUniformLocation(m_Shader->ProgramId(), "channelMode");
+    m_UInputColorSpace = glGetUniformLocation(m_Shader->ProgramId(), "inputColorSpace");
 }
 
 void ImageRenderGear::SetupBuffers()
@@ -147,6 +149,12 @@ void ImageRenderGear::Draw(const void* data)
      * Update the channels to be displayed on the renderer
      */
     glUniform1i(m_UChannelMode, d->channelMode);
+
+    /**
+     * Update the input colorspace on the shader to ensure output is linear before applying the final
+     * view tranform for the viewer
+     */
+    glUniform1i(m_UInputColorSpace, d->inputColorSpace);
 
     /**
      * Draw triangles as bound in the Index buffer as defined earlier

--- a/src/VoidRenderer/Gears/ImageRenderGear.h
+++ b/src/VoidRenderer/Gears/ImageRenderGear.h
@@ -69,6 +69,7 @@ private: /* Members */
     int m_UGamma;
     int m_UGain;
     int m_UChannelMode;
+    int m_UInputColorSpace;
 
 };
 

--- a/src/VoidRenderer/Layers/ImageRenderLayer.cpp
+++ b/src/VoidRenderer/Layers/ImageRenderLayer.cpp
@@ -64,6 +64,9 @@ void ImageRenderLayer::SetImage(const SharedPixels& image)
      */
     glTexImage2D(GL_TEXTURE_2D, 0, image->GLFormat(), image->Width(), image->Height(), 0, image->GLFormat(), image->GLType(), image->Pixels());
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+
+    /* Update the colorspace on the Image Data */
+    m_ImageData->inputColorSpace = static_cast<int>(image->InputColorSpace());
 }
 
 void ImageRenderLayer::Render(const glm::mat4& projection)

--- a/src/VoidRenderer/Programs/ImageShaderProgram.cpp
+++ b/src/VoidRenderer/Programs/ImageShaderProgram.cpp
@@ -41,15 +41,55 @@ uniform float gain;
 // Channels to display
 uniform int channelMode;
 
-vec3 inverseGamma(vec3 c)
+// Input Colorspace
+uniform int inputColorSpace;
+
+float Rec709ToLinear(float value)
+{
+    return (value <= 0.081) ? value / 4.5 : pow((value + 0.099) / 1.099, 1.0 / 0.45);
+}
+
+float SRGBToLinear(float value)
+{
+    return (value <= 0.04045) ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4);
+}
+
+vec3 inverseRec709(vec3 c)
 {
     vec3 linear;
 
-    linear.r = (c.r <= 0.081) ? c.r / 4.5 : pow((c.r + 0.099) / 1.099, 1.0 / 0.45);
-    linear.g = (c.g <= 0.081) ? c.g / 4.5 : pow((c.g + 0.099) / 1.099, 1.0 / 0.45);
-    linear.b = (c.b <= 0.081) ? c.b / 4.5 : pow((c.b + 0.099) / 1.099, 1.0 / 0.45);
+    linear.r = Rec709ToLinear(c.r);
+    linear.g = Rec709ToLinear(c.g);
+    linear.b = Rec709ToLinear(c.b);
 
     return linear;
+}
+
+vec3 inverseSRGB(vec3 c)
+{
+    vec3 linear;
+
+    linear.r = SRGBToLinear(c.r);
+    linear.g = SRGBToLinear(c.g);
+    linear.b = SRGBToLinear(c.b);
+
+    return linear;
+}
+
+// Converts into Linear Colorspace from the input colorspace
+// Returns the converted vec4 color
+vec4 Linearize(vec4 color, int colorspace)
+{
+    // No Conversion as the Colorspace is already Linear
+    if (colorspace == 0)                                    // Linear
+        return color;
+    else if (colorspace == 1)                               // Rec.709
+        return vec4(inverseRec709(color.rgb), color.a);
+    else if (colorspace == 2)                               // standard RGB
+        return vec4(inverseSRGB(color.rgb), color.a);
+
+    // Default
+    return color;
 }
 
 void main() {
@@ -67,30 +107,31 @@ void main() {
     // Apply gamma correction
     color.rgb = pow(color.rgb, vec3(1.0 / gamma));
 
-    vec3 linear = inverseGamma(color.rgb); 
+    // Ensure we have linear output depending on the input colorspace
+    vec4 linear = Linearize(color, inputColorSpace);
 
     // Render a channel based on the color
     // 0 = R; 1 = G; 2 = B; 3 = A; 4 = RGB; 5 = RGBA (All)
     switch (channelMode)
     {
         case 0: // Red Channels only 
-            FragColor = vec4(color.r, color.r, color.r, 1.f);
+            FragColor = vec4(linear.r, linear.r, linear.r, 1.f);
             break;
         case 1: // Green Channels only
-            FragColor = vec4(color.g, color.g, color.g, 1.f);
+            FragColor = vec4(linear.g, linear.g, linear.g, 1.f);
             break;
         case 2: // Blue Channels only
-            FragColor = vec4(color.b, color.b, color.b, 1.f);
+            FragColor = vec4(linear.b, linear.b, linear.b, 1.f);
             break;
         case 3: // Only Alpha
-            FragColor = vec4(color.a, color.a, color.a, 1.f);
+            FragColor = vec4(linear.a, linear.a, linear.a, 1.f);
             break;
         case 4: // RGB without alpha
-            FragColor = vec4(color.rgb, 1.f);
+            FragColor = vec4(linear.rgb, 1.f);
             break;
         case 5:
         default: // Show all channels -- default
-            FragColor = vec4(linear, color.a);
+            FragColor = linear;
     }
 }
 )";

--- a/src/VoidRenderer/RenderTypes.h
+++ b/src/VoidRenderer/RenderTypes.h
@@ -195,6 +195,8 @@ struct ImageRenderData
     float gain;
 
     int channelMode;
+
+    int inputColorSpace;
 };
 
 /**

--- a/src/include/Colorspace.h
+++ b/src/include/Colorspace.h
@@ -1,0 +1,32 @@
+#ifndef _VOID_COLORSPACE_H
+#define _VOID_COLORSPACE_H
+
+/* Internal */
+#include "Definition.h"
+
+VOID_NAMESPACE_OPEN
+
+enum class ColorSpace
+{
+    /* Linear */
+    Linear,
+
+    /* Display Rec.709 */
+    Rec709,
+
+    /* Gamma encoding ~2.2 */
+    sRGB,
+
+    /* ACES Color Grading Space */
+    ACEScg,
+
+    /* Arri LogC */
+    LogC,
+
+    /* Custom, LUT Baked */
+    Custom,
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _VOID_COLORSPACE_H

--- a/src/include/PixReader.h
+++ b/src/include/PixReader.h
@@ -6,6 +6,7 @@
 #include <string>
 
 /* Internal */
+#include "Colorspace.h"
 #include "Definition.h"
 #include "FrameRange.h"
 
@@ -94,13 +95,18 @@ public:
     /**
      * Returns if the underlying struct has any pixel data
      */
-    virtual bool Empty() = 0;
+    virtual bool Empty() const = 0;
 
     /**
      * Reads the image at the given path
      * updates the underlying struct with the data
      */
     virtual void Read(const std::string& path, int framenumber) = 0;
+
+    /**
+     * Retrieve the input colorspace of the media file
+     */
+    virtual ColorSpace InputColorSpace() const = 0;
 };
 
 class VoidMPixReader : public VoidPixReader


### PR DESCRIPTION
### Feat: Linearize Input Colorspace
* Added conversion functions from sRGB and Rec709 toLinear at the shader level
* Added base virtual method allowing the reader plugin to supply the input colorspace of the media.
* Added Base enum describing common Input Colorspaces.
* Linear colorspace is untouched while rendering on viewport.

## Note:
Currently the input colorspace is a property for only the ImageData and the renderer is relying on the Image Data to retrieve the input colorspace.
In future this might need to be a part of Media (when we decide to have a conversion function) this function would apply the selected input/OCIO based colorspace to apply the colorspace directly on the media using an OCIO::ConstProcessorRcPtr (CPU)

For now, going with the shader based conversion to Linear (before applying Viewer Transform) to it seems a faster and simpler solution as GPU processing is quite performant. (This change will be coming in the upcoming PRs).