### PR TITLE
[VOID] EXR Reader Crash Fix

### DIFF
--- a/src/VoidCore/Readers/FFmpegReader.h
+++ b/src/VoidCore/Readers/FFmpegReader.h
@@ -113,7 +113,13 @@ public:
     inline virtual unsigned int GLType() const override { return VOID_GL_UNSIGNED_BYTE; }
 
     /**
-     * Returns OpenGL channel format
+     * Specifies the number of color components in the texture
+     * e.g. GL_RGBA32F | GL_RGBA32I | GL_RGBA32UI | GL_RGBA16 | GL_RGBA16F | GL_RGBA16I
+     */
+    inline virtual unsigned int GLInternalFormat() const override { return GLFormat(); }
+
+    /**
+     * Returns OpenGL format of pixel data
      * GL_RGBA | GL_RGB
      */
     inline virtual unsigned int GLFormat() const override { return (m_Channels == 3) ? VOID_GL_RGB : VOID_GL_RGBA; }
@@ -131,7 +137,7 @@ public:
      * Not all frames will be used so this function can create a vector on the fly if unsigned char
      * is not the base datatype of the class
      */
-    inline virtual const unsigned char* ThumbnailPixels() const override { return m_Pixels.data(); }
+    inline virtual const unsigned char* ThumbnailPixels() override { return m_Pixels.data(); }
 
     /**
      * Image Specifications

--- a/src/VoidCore/Readers/OIIOReader.h
+++ b/src/VoidCore/Readers/OIIOReader.h
@@ -33,7 +33,13 @@ public:
     inline virtual unsigned int GLType() const override { return VOID_GL_UNSIGNED_BYTE; }
 
     /**
-     * Returns OpenGL channel format
+     * Specifies the number of color components in the texture
+     * e.g. GL_RGBA32F | GL_RGBA32I | GL_RGBA32UI | GL_RGBA16 | GL_RGBA16F | GL_RGBA16I
+     */
+    inline virtual unsigned int GLInternalFormat() const override { return GLFormat(); }
+
+    /**
+     * Returns OpenGL format of the pixel data
      * GL_RGBA | GL_RGB
      */
     inline virtual unsigned int GLFormat() const override { return (m_Channels == 3) ? VOID_GL_RGB : VOID_GL_RGBA; }
@@ -51,7 +57,7 @@ public:
      * Not all frames will be used so this function can create a vector on the fly if unsigned char
      * is not the base datatype of the class
      */
-    inline virtual const unsigned char* ThumbnailPixels() const override { return m_Pixels.data(); }
+    inline virtual const unsigned char* ThumbnailPixels() override { return m_Pixels.data(); }
 
     /**
      * Image Specifications

--- a/src/VoidCore/Readers/OpenEXRReader.h
+++ b/src/VoidCore/Readers/OpenEXRReader.h
@@ -30,13 +30,19 @@ public:
      * Returns the OpenGL data type
      * e.g. GL_UNSIGNED_BYTE, GL_FLOAT
      */
-    inline virtual unsigned int GLType() const override { return VOID_GL_UNSIGNED_BYTE; }
+    inline virtual unsigned int GLType() const override { return VOID_GL_FLOAT; }
 
     /**
-     * Returns OpenGL channel format
+     * Specifies the number of color components in the texture
+     * e.g. GL_RGBA32F | GL_RGBA32I | GL_RGBA32UI | GL_RGBA16 | GL_RGBA16F | GL_RGBA16I
+     */
+    inline virtual unsigned int GLInternalFormat() const override { return VOID_GL_RGBA32F; }
+
+    /**
+     * Returns OpenGL format of the pixel data
      * GL_RGBA | GL_RGB
      */
-    inline virtual unsigned int GLFormat() const override { return (m_Channels == 3) ? VOID_GL_RGB : VOID_GL_RGBA; }
+    inline virtual unsigned int GLFormat() const override { return VOID_GL_RGBA; }
 
     /**
      * Returns the Pointer to the underlying pixel data which will be rendered on the Renderer
@@ -51,7 +57,7 @@ public:
      * Not all frames will be used so this function can create a vector on the fly if unsigned char
      * is not the base datatype of the class
      */
-    inline virtual const unsigned char* ThumbnailPixels() const override { return m_Pixels.data(); }
+    virtual const unsigned char* ThumbnailPixels() override;
 
     /**
      * Image Specifications
@@ -86,7 +92,8 @@ private: /* Methods */
     int m_Channels;
 
     /* Internal data store */
-    std::vector<unsigned char> m_Pixels;
+    std::vector<unsigned char> m_TPixels;
+    std::vector<float> m_Pixels;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidRenderer/Layers/ImageRenderLayer.cpp
+++ b/src/VoidRenderer/Layers/ImageRenderLayer.cpp
@@ -65,8 +65,9 @@ void ImageRenderLayer::SetImage(const SharedPixels& image)
     /**
      * Load the image data onto the Texture 2D
      */
-    glTexImage2D(GL_TEXTURE_2D, 0, image->GLFormat(), image->Width(), image->Height(), 0, image->GLFormat(), image->GLType(), image->Pixels());
+    glTexImage2D(GL_TEXTURE_2D, 0, image->GLInternalFormat(), image->Width(), image->Height(), 0, image->GLFormat(), image->GLType(), image->Pixels());
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
     /* Update the colorspace on the Image Data */
     m_ImageData->inputColorSpace = static_cast<int>(image->InputColorSpace());

--- a/src/include/PixReader.h
+++ b/src/include/PixReader.h
@@ -41,6 +41,10 @@ VOID_NAMESPACE_OPEN
 #define VOID_GL_RGBA 0x1908
 #define VOID_GL_LUMINANCE 0x1909
 #define VOID_GL_LUMINANCE_ALPHA 0x190A
+#define VOID_GL_RGBA32F 0x8814
+#define VOID_GL_RGB32F 0x8815
+#define VOID_GL_RGBA16F 0x881A
+#define VOID_GL_RGB16F 0x881B
 
 
 /* Typedefs */
@@ -61,7 +65,13 @@ public:
     virtual unsigned int GLType() const = 0;
 
     /**
-     * Returns OpenGL channel format
+     * Specifies the number of color components in the texture
+     * e.g. GL_RGBA32F | GL_RGBA32I | GL_RGBA32UI | GL_RGBA16 | GL_RGBA16F | GL_RGBA16I
+     */
+    virtual unsigned int GLInternalFormat() const = 0;
+
+    /**
+     * Specifies the format of the pixel data
      * GL_RGBA | GL_RGB
      */
     virtual unsigned int GLFormat() const = 0;
@@ -79,7 +89,7 @@ public:
      * Not all frames will be used so this function can create a vector on the fly if unsigned char
      * is not the base datatype of the class
      */
-    virtual const unsigned char* ThumbnailPixels() const = 0;
+    virtual const unsigned char* ThumbnailPixels() = 0;
 
     /**
      * Image Specifications


### PR DESCRIPTION
### Fix: Crash on reading 4K+ exrs
* 4K exrs were crashing, using float data over unsigned char to reduce overhead of conversion.