### PR TITLE
[VOID] Cmake: Setup dll copy for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ if (Qt6_FOUND)
     add_library(Qt::Core ALIAS Qt6::Core)
     add_library(Qt::Widgets ALIAS Qt6::Widgets)
     add_library(Qt::OpenGLWidgets ALIAS Qt6::OpenGLWidgets)
+    # Format c:\some\path\to\qt\cmake -> c:/some/path/to/qt/cmake
+    file(TO_CMAKE_PATH ${Qt6_DIR} QT_CMAKE_PATH)
 else()
     find_package(Qt5 REQUIRED COMPONENTS Widgets Core)
 
@@ -53,6 +55,8 @@ else()
     set(QT_MAJOR_VERSION 5)
     add_library(Qt::Core ALIAS Qt5::Core)
     add_library(Qt::Widgets ALIAS Qt5::Widgets)
+    # Format c:\some\path\to\qt\cmake -> c:/some/path/to/qt/cmake
+    file(TO_CMAKE_PATH ${Qt5_DIR} QT_CMAKE_PATH)
 endif()
 
 # GL

--- a/cmake/Modules/FindFFmpeg.cmake
+++ b/cmake/Modules/FindFFmpeg.cmake
@@ -275,3 +275,17 @@ find_package_handle_standard_args(FFMPEG
   VERSION_VAR FFMPEG_VERSION
   HANDLE_COMPONENTS)
 unset(_ffmpeg_required_vars)
+
+if (WIN32 AND DEFINED FFMPEG_ROOT AND FFMPEG_ROOT)
+  file(TO_CMAKE_PATH "${FFMPEG_ROOT}" _FFMPEG_DIR)
+
+  # Since ffmpeg dlls are named -version that version varies per dll file
+  # eg. avformat-60.dll, avformat-62.dll, avutil-60.dll
+  file(GLOB FFmpeg_dlls
+        "${_FFMPEG_DIR}/bin/avcodec-*.dll"
+        "${_FFMPEG_DIR}/bin/avformat-*.dll"
+        "${_FFMPEG_DIR}/bin/avutil-*.dll"
+        "${_FFMPEG_DIR}/bin/swresample-*.dll"
+        "${_FFMPEG_DIR}/bin/swscale-*.dll"
+    )
+endif()

--- a/cmake/Modules/FreetypeInstallHelpers.cmake
+++ b/cmake/Modules/FreetypeInstallHelpers.cmake
@@ -1,0 +1,15 @@
+# Sets a few freetype paths in windows and more importantly sets the FREETYPE_DLL variable with
+# the path to freetype.dll which is required by the player at runtime
+
+if (WIN32 AND FREETYPE_FOUND)
+    # Freetype DLL
+    get_target_property(FREETYPE_LIB_PATH Freetype::Freetype LOCATION)
+    # Get Parent dir path
+    get_filename_component(FREETYPE_LIB_DIR ${FREETYPE_LIB_PATH} DIRECTORY) # ..
+    get_filename_component(FREETYPE_DIR ${FREETYPE_LIB_DIR} DIRECTORY) # ..
+    # Freetype BIN directory
+    set(FREETYPE_BIN_DIR "${FREETYPE_DIR}/bin")
+
+    # Find the freetype.dll from the BIN directory
+    file(GLOB FREETYPE_DLL "${FREETYPE_BIN_DIR}/freetype*.dll")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Package Config
 include(CMakePackageConfigHelpers)
+include(FreetypeInstallHelpers)
 
 # Build Core Library
 add_subdirectory(VoidCore)
@@ -169,3 +170,33 @@ install(
     DESTINATION ${VOID_INSTALL_CMAKE_DIR}
 )
 
+# Dll copier for windows
+if (WIN32)
+    set(DEPENDENCY_TARGETS
+        OpenEXR::OpenEXR
+        OpenEXR::OpenEXRCore
+        OpenImageIO::OpenImageIO
+        OpenImageIO::OpenImageIO_Util
+        OpenColorIO::OpenColorIO
+        GLEW::GLEW
+        zstd::libzstd_shared
+        OpenEXR::IlmThread
+        OpenEXR::Iex
+        Imath::Imath
+    )
+
+    # Install dlls for each of the dependency targets
+    foreach(dep ${DEPENDENCY_TARGETS})
+        install(FILES "$<TARGET_FILE:${dep}>" DESTINATION bin)
+    endforeach()
+
+    # FFmpeg dlls
+    install(FILES ${FFmpeg_dlls} DESTINATION bin)
+
+    # Freetype DLL
+    install(FILES "${FREETYPE_DLL}" DESTINATION bin)
+
+    # windeployqt.exe /path/to/install/dir/bin
+    set(QT_DEPLOY_TOOL "${QT_CMAKE_PATH}/../../../bin/windeployqt.exe")
+    install(CODE "execute_process(COMMAND ${QT_DEPLOY_TOOL} ${CMAKE_INSTALL_PREFIX}/bin)")
+endif()


### PR DESCRIPTION
## DLL Copy for Windows
* Setup DLL Copy on windows, which copies all of the directly required dlls onto the bin directory.
* Runs windeployqt to copy and setup QT dlls over at bin directory.

