### PR TITLE
[VOID] Timeline: Use std::async based playback loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.7.0)
 
-project(VOID VERSION 0.0.1 LANGUAGES CXX)
+project(VOID VERSION 0.2.0 LANGUAGES CXX)
 
 # C++17 and Above
-# Using std::filesystem
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -11,6 +10,12 @@ set(CMAKE_AUTOMOC ON)
 
 # USE CXX11 ABI
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+
+# For macOS, GL has been marked deprecated
+# till we move to Metal specifically on apple, silence all of GL_DEPRECATION warnings
+if (APPLE)
+    add_definitions(-DGL_SILENCE_DEPRECATION=1)
+endif()
 
 # An explicit option to allow compiling the GUI frameless or with Window borders
 # it's a debate about whether the feature should be inbuilt and an option to switch to either

--- a/src/VoidUi/Timeline/Timeline.h
+++ b/src/VoidUi/Timeline/Timeline.h
@@ -5,6 +5,9 @@
 #define _VOID_TIMELINE_H
 
 /* STD */
+#include <atomic>
+#include <future>
+#include <thread>
 #include <vector>
 #include <unordered_map>
 
@@ -12,7 +15,6 @@
 #include <QComboBox>
 #include <QLayout>
 #include <QPushButton>
-#include <QTimer>
 #include <QWidget>
 
 /* Internal */
@@ -130,9 +132,6 @@ private: /* Members */
 
 	QDoubleValidator* m_DoubleValidator;
 
-	QTimer* m_ForwardsTimer;
-	QTimer* m_BackwardsTimer;
-
 	/**
 	 * Timeslider Min - Max
 	 * This is additionally maintained as to reduce the amount of overhead when
@@ -142,6 +141,12 @@ private: /* Members */
 
 	/* Loop mode for playback */
 	LoopType m_LoopType;
+
+	std::future<void> m_Worker;
+	std::atomic<bool> m_Playing;
+	int m_FrameInterval;
+
+	PlayState m_Playstate;
 
 protected: /* Methods */
 	void Build();
@@ -155,6 +160,9 @@ protected: /* Methods */
 	void Play(const PlayState& state = PlayState::FORWARDS);
 	void Stop();
 	void Replay();
+
+	void StartPlayback();
+	void PlaybackLoop();
 
 	void NextFrame();
 	void PreviousFrame();

--- a/src/VoidUi/Timeline/Timeline.h
+++ b/src/VoidUi/Timeline/Timeline.h
@@ -8,8 +8,6 @@
 #include <atomic>
 #include <future>
 #include <thread>
-#include <vector>
-#include <unordered_map>
 
 /* Qt */
 #include <QComboBox>


### PR DESCRIPTION
### Improvement: std::async based playback
* Use std::async based playback loop for playing continuously.
* Removed existing QTimer based approach in favour of the change.

### Details:
Qt based Timer timeout to continuously call play next/play previous methods would work fine for slower/standard frame rates like around ~45fps, over that it would continuously get capped at around ~50fps.
This seems most likely due to OS-scheduling policies which vary, since QT uses queue based events, the events might not be processed at the expected rate, and even a 1ms wait time actually comes around to be ~10-15ms which is fine but with higher frame rate, this 15ms wait might not be sufficient for the check to happen and the next/previous frame to be played.
Making the whole experience sluggish as the playback rate was capped.

The current change with std::async allows the event callback (play next frame/play forward frame) to be called much more instantaneously thereby giving playback with higher frame rate.

### Additional: Fix
[CMAKE] Added GL_SILENCE_DEPRECATIONS for macOS