### PR TITLE
[VOID] Project level Undo-Redo Operations

### DIFF
--- a/src/VoidUi/Media/MediaBridge.cpp
+++ b/src/VoidUi/Media/MediaBridge.cpp
@@ -14,7 +14,7 @@ MBridge::MBridge(QObject* parent)
     : QObject(parent)
 {
     m_Projects = new ProjectModel(this);
-    m_UndoStack = new QUndoStack(this);
+    m_UndoGroup = new QUndoGroup(this);
 
     /* Setup a Default Project */
     NewProject();
@@ -76,6 +76,9 @@ void MBridge::SetActiveProject(Project* project)
 
     m_Project = project;
     m_Project->SetActive(true);
+
+    m_UndoGroup->addStack(m_Project->UndoStack());
+    m_UndoGroup->setActiveStack(m_Project->UndoStack());
 
     /* Force Update on the Model */
     m_Projects->Refresh();
@@ -163,8 +166,9 @@ bool MBridge::Remove(const QModelIndex& index)
 
 void MBridge::PushCommand(QUndoCommand* command)
 {
-    /* Push it on the Undo Stack */
-    m_UndoStack->push(command);
+    /* Push it on the Undo Stack of the active project */
+    if (m_Project)
+        m_Project->PushCommand(command);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/MediaBridge.h
+++ b/src/VoidUi/Media/MediaBridge.h
@@ -9,6 +9,7 @@
 
 /* Qt */
 #include <QObject>
+#include <QUndoGroup>
 #include <QUndoStack>
 
 /* Internal */
@@ -81,12 +82,9 @@ public:
     /* Push an Undo Command on to the stack */
     void PushCommand(QUndoCommand* command);
 
-    // bool CanRedo() const { return m_UndoStack->canRedo(); }
-    // bool CarUndo() const { return m_UndoStack->canUndo(); }
-
     /* Returns the Menu Actions for Undo and Redo */
-    QAction* CreateUndoAction(QObject* parent, const QString& prefix = QString()) const { return m_UndoStack->createUndoAction(parent, prefix); }
-    QAction* CreateRedoAction(QObject* parent, const QString& prefix = QString()) const { return m_UndoStack->createRedoAction(parent, prefix); }
+    QAction* CreateUndoAction(QObject* parent, const QString& prefix = QString()) const { return m_UndoGroup->createUndoAction(parent, prefix); }
+    QAction* CreateRedoAction(QObject* parent, const QString& prefix = QString()) const { return m_UndoGroup->createRedoAction(parent, prefix); }
 
 signals:
     /**
@@ -103,9 +101,7 @@ signals:
 private: /* Members */
     /* All the Available Projects */
     ProjectModel* m_Projects;
-
-    /* Undo Stack */
-    QUndoStack* m_UndoStack;
+    QUndoGroup* m_UndoGroup;
 
     /* Current Active Project */
     Project* m_Project;

--- a/src/VoidUi/Project/Project.cpp
+++ b/src/VoidUi/Project/Project.cpp
@@ -13,6 +13,7 @@ Project::Project(const std::string& name, bool active, QObject* parent)
     , m_Active(active)
 {
     m_Media = new MediaModel(this);
+    m_UndoStack = new QUndoStack(this);
     VOID_LOG_INFO("Project {0} Created: {1}", name, Vuid());
 }
 
@@ -23,6 +24,8 @@ Project::Project(bool active, QObject* parent)
 
 Project::~Project()
 {
+    m_UndoStack->deleteLater();
+
     m_Media->deleteLater();
     delete m_Media;
     m_Media = nullptr;

--- a/src/VoidUi/Project/Project.h
+++ b/src/VoidUi/Project/Project.h
@@ -5,6 +5,7 @@
 #define _VOID_PROJECT_H
 
 /* Qt */
+#include <QUndoStack>
 
 /* Internal */
 #include "Definition.h"
@@ -44,6 +45,9 @@ public:
         return m_Media->index(m_Media->MediaRow(clip), column); 
     }
 
+    inline void PushCommand(QUndoCommand* command) { m_UndoStack->push(command); }
+    inline QUndoStack* UndoStack() const { return m_UndoStack; }
+
 private: /* Members */
     /* The Project holds the media and anything linking to the media */
     MediaModel* m_Media;
@@ -53,6 +57,7 @@ private: /* Members */
 
     /* If the project is currently active */
     bool m_Active;
+    QUndoStack* m_UndoStack;
 };
 
 VOID_NAMESPACE_CLOSE


### PR DESCRIPTION
### Feat: Project Level Undo-Redo Operations - Part 1
* Added Parent UndoGroup and individual projects have their QUndoStack.
* Active undo stack is determined by the active project.

### Note
At present individual projects have their own undo stack and that determines the undo-redo for their underlying operations.
About the project themselves? being created or removed?
That is pending and will be looked at when the project serialization/deserialization is done.
Project can be removed when it has media content, so to be able to re-create that content, we need the project to be able to be serialized before removing and can be deserialized back when undo is called for it.

This logic will work together with a MediaBridge level undo stack for managing projects.
