### PR TITLE
[VOID] TImeline: Revert to Timer playback

### DIFF
--- a/src/VoidUi/Timeline/Timeline.h
+++ b/src/VoidUi/Timeline/Timeline.h
@@ -13,6 +13,7 @@
 #include <QComboBox>
 #include <QLayout>
 #include <QPushButton>
+#include <QTimer>
 #include <QWidget>
 
 /* Internal */
@@ -130,6 +131,8 @@ private: /* Members */
 
 	QDoubleValidator* m_DoubleValidator;
 
+	QTimer m_PlayTimer;
+
 	/**
 	 * Timeslider Min - Max
 	 * This is additionally maintained as to reduce the amount of overhead when
@@ -161,6 +164,7 @@ protected: /* Methods */
 
 	void StartPlayback();
 	void PlaybackLoop();
+	void TimerPlaybackLoop();
 
 	void NextFrame();
 	void PreviousFrame();


### PR DESCRIPTION
### Fix: Timeline playback issues
* std::async playback though is better at higher framerate but it can cause issues when media is not cached and takes time to read/cache media.

### Note: 
* To be re-implemented at a later stage.