### PR TITLE
[VOID] Improvements

### DIFF
--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -19,3 +19,8 @@ target_link_libraries(
     Qt::Widgets
     Freetype::Freetype
 )
+
+# Qt6 needs OpenGLWidgets be included/linked separately
+if (QT_MAJOR_VERSION EQUAL 6)
+    target_link_libraries(voidpy PRIVATE Qt::OpenGLWidgets)
+endif()

--- a/src/VoidUi/BaseWindow/PlayerWindow.cpp
+++ b/src/VoidUi/BaseWindow/PlayerWindow.cpp
@@ -484,7 +484,7 @@ void VoidMainWindow::RegisterDocks()
     m_MediaLister = new VoidMediaLister(this);
 
     /* Python Script Editor */
-    m_ScriptEditor = new PyScriptEditor(this);
+    m_ScriptEditor = new PyScriptEditor();
 
     manager.RegisterDock(m_MediaLister, "Media View");
     manager.RegisterDock(m_Player, "Viewer");

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -91,7 +91,11 @@ void VoidMediaLister::Build()
     m_RemoveAction = new QAction("Remove Selected");
 
     /* Shortcuts */
+#ifdef __APPLE__
+    m_DeleteShortcut = new QShortcut(QKeySequence(Qt::Key_Backspace), this);
+#else
     m_DeleteShortcut = new QShortcut(QKeySequence(Qt::Key_Delete), this);
+#endif
 
     /* Base */
     m_layout = new QVBoxLayout(this);

--- a/src/VoidUi/ScriptEditor/ScriptConsole.h
+++ b/src/VoidUi/ScriptEditor/ScriptConsole.h
@@ -20,7 +20,7 @@ class LineNumberArea : public QWidget
 {
 public:
     explicit LineNumberArea(InputScriptConsole* console);
-    QSize sizeHint() const;
+    QSize sizeHint() const override;
 
 protected:
     void paintEvent(QPaintEvent* event) override;

--- a/src/VoidUi/ScriptEditor/SyntaxHighlighter.cpp
+++ b/src/VoidUi/ScriptEditor/SyntaxHighlighter.cpp
@@ -52,17 +52,6 @@ void PySyntaxHighlighter::SetupRules()
     }
 
     /**
-     * Comments starting with #
-     */
-    QRegularExpression commentPattern("#[^\n]*");
-    QTextCharFormat commentFormat;
-    commentFormat.setForeground(QColor(130, 130, 130));      // Grey;
-    commentFormat.setFontItalic(true);
-    commentFormat.setFontWeight(QFont::Bold);
-
-    m_Rules.emplace_back(commentPattern, commentFormat);
-
-    /**
      * Self
      */
     QRegularExpression selfPattern("\\bself\\b");
@@ -83,6 +72,17 @@ void PySyntaxHighlighter::SetupRules()
     m_Rules.emplace_back(QRegularExpression("\"[^\"]*\""), stringFormat);
     /* '' */
     m_Rules.emplace_back(QRegularExpression("'[^']*'"), stringFormat);
+
+    /**
+     * Comments starting with #
+     */
+    QRegularExpression commentPattern("#[^\n]*");
+    QTextCharFormat commentFormat;
+    commentFormat.setForeground(QColor(130, 130, 130));      // Grey;
+    commentFormat.setFontItalic(true);
+    commentFormat.setFontWeight(QFont::Bold);
+
+    m_Rules.emplace_back(commentPattern, commentFormat);
 }
 
 VOID_NAMESPACE_CLOSE


### PR DESCRIPTION
* Bindings to link with QOpenGLWidget for Qt6.
* Comment Expression is last to ensure comments with Quoted strings are still marked as comments in the highlight.
* MacOS has backspace rather than delete on standard keyboards.
* Script Editor is initialized without a parent to stop it from showing in the main window by default.