### PR TITLE
[VOID] Python Executor: Fix for SIGINT

### DIFF
--- a/src/VoidCore/PyExecutor.cpp
+++ b/src/VoidCore/PyExecutor.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* STD */
+#include <csignal>
+
 /* Internal */
 #include "PyExecutor.h"
 
@@ -13,6 +16,16 @@ PyExecutor::PyExecutor()
     , m_Globals(py::globals())
 {
     // py::initialize_interpreter();
+
+    /**
+     * When python is initialized/embedded within the application, it seems to hijack the SIGINT
+     * causing the app to not close when Ctrl+C (SIGINT) is triggered from the terminal
+     * this is caused as python isn't executing all the time and a signal received (SIGINT) is pushed
+     * to the queue rather than processed immediately causing the whole issue
+     * 
+     * The simplest fix is to restore the behaviour of the signal SIGINT after the scoped interpreter is initialized
+     */
+    signal(SIGINT, SIG_DFL);
 }
 
 PyExecutor::~PyExecutor()


### PR DESCRIPTION
### Fix
* Fix overriden signal SIGINT to exit when ctrl+C or SIGINT is invoked for the application

### Details
Introduced in https://github.com/waaake/VOID/pull/94
This is needed as embedding python interpreter with c takes control of the signals and any signals sent to the application gets queued up as python isn't being executed all of the time, causing nothing to happen when ctrl+C is invoked from the parent shell.
