### PR TITLE
[VOID] Media & Timeline: Added requisites for Cache 'ChronoFlux'

### DIFF
--- a/src/VoidCore/Readers/FFmpegReader.h
+++ b/src/VoidCore/Readers/FFmpegReader.h
@@ -172,6 +172,11 @@ public:
      */
     inline virtual ColorSpace InputColorSpace() const override { return ColorSpace::sRGB; }
 
+    /**
+     * Returns the Size of the frame data
+     */
+    virtual size_t FrameSize() const override { return sizeof(unsigned char) * m_Pixels.size(); }
+
 private: /* Members */
     /* Image specifications */
     int m_Width, m_Height;

--- a/src/VoidCore/Readers/OIIOReader.h
+++ b/src/VoidCore/Readers/OIIOReader.h
@@ -82,6 +82,11 @@ public:
      */
     inline virtual ColorSpace InputColorSpace() const override { return m_InputColorSpace; }
 
+    /**
+     * Returns the Size of the frame data
+     */
+    virtual size_t FrameSize() const override { return sizeof(unsigned char) * m_Pixels.size(); }
+
 private: /* Members */
     /* Image specifications */
     int m_Width, m_Height;

--- a/src/VoidCore/Readers/OpenEXRReader.h
+++ b/src/VoidCore/Readers/OpenEXRReader.h
@@ -81,6 +81,11 @@ public:
      */
     inline virtual ColorSpace InputColorSpace() const override { return ColorSpace::Linear; }
 
+    /**
+     * Returns the Size of the frame data
+     */
+    virtual size_t FrameSize() const override { return sizeof(float) * m_Pixels.size(); }
+
 private: /* Methods */
     /* Image specifications */
     int m_Width, m_Height;

--- a/src/VoidUi/Timeline/Timeline.h
+++ b/src/VoidUi/Timeline/Timeline.h
@@ -76,6 +76,7 @@ public:
 	 * Mark Cached frames on the Timeslider visually
 	 */
 	inline void AddCacheFrame(int frame) { m_Timeslider->AddCacheFrame(frame); }
+	inline void RemoveCachedFrame(int frame) { m_Timeslider->RemoveCachedFrame(frame); }
 	inline void ClearCachedFrames() { m_Timeslider->ClearCachedFrames(); }
 
 	/**

--- a/src/VoidUi/Timeline/Timeslider.cpp
+++ b/src/VoidUi/Timeline/Timeslider.cpp
@@ -356,6 +356,22 @@ void Timeslider::AddCacheFrame(int frame)
 	update();
 }
 
+void Timeslider::RemoveCachedFrame(int frame)
+{
+	std::vector<int>::iterator it = std::find(m_CachedFrames.begin(), m_CachedFrames.end(), frame);
+
+	/*
+	 * If the value is not present in cached frames already
+	 * Add it to the set
+	 */
+	if (it != m_CachedFrames.end())
+	{
+		m_CachedFrames.erase(it);
+		/* Repaint after a frame has been cached to redraw the cache line */
+		update();
+	}
+}
+
 void Timeslider::ClearCachedFrames()
 {
 	/* Clears the contents of the cached frames */

--- a/src/VoidUi/Timeline/Timeslider.h
+++ b/src/VoidUi/Timeline/Timeslider.h
@@ -41,6 +41,7 @@ public:
 
 	/* Adds a cache marker on the frame */
 	void AddCacheFrame(int frame);
+	void RemoveCachedFrame(int frame);
 	void ClearCachedFrames();
 
 	/* Adds an annotation marker on the frame */

--- a/src/include/PixReader.h
+++ b/src/include/PixReader.h
@@ -130,6 +130,11 @@ public:
     virtual void Read() = 0;
 
     /**
+     * Returns the Size of the frame data
+     */
+    virtual size_t FrameSize() const = 0;
+
+    /**
      * Retrieve the input colorspace of the media file
      */
     virtual ColorSpace InputColorSpace() const = 0;


### PR DESCRIPTION
### Details
* With the Prototype for the Cache Engine in place and understanding around its working, a few things needed to be in place to ensure a better and a robust cache system in place which uses media details and References memory pointing to each frame possibly to directly cache or clear cache, making the overall system smoother.

This is just the initial design on the Cache System, which most likely is going to be called "Chrono Flux" -> Media flowing through time.