### PR TITLE
[VOID] Media: Added Deserialisation constructors

### DIFF
--- a/src/Bindings/CoreModule.cpp
+++ b/src/Bindings/CoreModule.cpp
@@ -3,6 +3,7 @@
 
 /* Pybind11 */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 /* Internal */
 #include "Definition.h"
@@ -46,6 +47,10 @@ void BindCore(py::module_& m)
     /* MediaStruct */
     py::class_<MediaStruct>(m, "MediaStruct")
         .def(py::init<const MEntry&, const MediaType&>(), py::arg("media_entry"), py::arg("media_type"))
+    
+        .def(py::init<const std::string&, const std::string&, const std::string&, v_frame_t, v_frame_t>(), 
+                py::arg("basepath"), py::arg("name"), py::arg("extension"), py::arg("startframe"), py::arg("endframe"))
+
         .def_static("from_file", &MediaStruct::FromFile, py::arg("filepath"))
         .def("add", &MediaStruct::Add, py::arg("media_entry"))
         .def("validate", &MediaStruct::Validate, py::arg("media_entry"))
@@ -71,11 +76,30 @@ void BindCore(py::module_& m)
     /* Media */
     py::class_<Media>(m, "Media")
         .def(py::init<const MediaStruct&>(), py::arg("media_struct"))
+
+        .def(py::init<const std::string&, const std::string&, const std::string&, v_frame_t, v_frame_t>(),
+                py::arg("basepath"), py::arg("name"), py::arg("extension"), py::arg("startframe"), py::arg("endframe"))
+
         .def("get_frame", &Media::GetFrame, py::arg("frame"));
 
     /* MediaClip */
     py::class_<MediaClip, SharedMediaClip>(m, "MediaClip")
-        .def(py::init<const MediaStruct&>(), py::arg("media"));
+        .def(py::init<const MediaStruct&>(), py::arg("media"))
+
+        .def(py::init<const std::string&, const std::string&, const std::string&>(), py::arg("basepath"),
+                                                                                py::arg("name"), py::arg("extension"))
+
+        .def(py::init<const std::string&, const std::string&, const std::string&, v_frame_t, v_frame_t>(),
+                py::arg("basepath"), py::arg("name"), py::arg("extension"), py::arg("startframe"), py::arg("endframe"))
+
+        .def(py::init<const std::string&, const std::string&, const std::string&, v_frame_t, v_frame_t, const std::vector<v_frame_t>&>(),
+                py::arg("basepath"), py::arg("name"), py::arg("extension"), py::arg("startframe"), py::arg("endframe"), py::arg("missing"))
+
+        .def("basepath", &MediaClip::Path)
+        .def("name", &MediaClip::Name)
+        .def("extension", &MediaClip::Extension)
+        .def("startframe", &MediaClip::FirstFrame)
+        .def("endframe", &MediaClip::LastFrame);
 }
 
 } // namespace bindings

--- a/src/VoidCore/Media.cpp
+++ b/src/VoidCore/Media.cpp
@@ -144,6 +144,36 @@ Media::~Media()
 {
 }
 
+Media::Media(const std::string& basepath, const std::string& name, const std::string& extension)
+    : Media()
+{
+    Read(MediaStruct(basepath, name, extension));
+}
+
+Media::Media(const std::string& basepath,
+        const std::string& name,
+        const std::string& extension,
+        v_frame_t start,
+        v_frame_t end
+    )
+    : Media()
+{
+    Read(MediaStruct(basepath, name, extension, start, end));
+}
+
+Media::Media(const std::string& basepath,
+        const std::string& name,
+        const std::string& extension,
+        v_frame_t start,
+        v_frame_t end,
+        const std::vector<v_frame_t>& missing
+    )
+    : Media()
+{
+    Read(MediaStruct(basepath, name, extension, start, end, missing));
+}
+
+
 void Media::UpdateRange()
 {
     /* Check if we have any frames to arrange */

--- a/src/VoidCore/Media.h
+++ b/src/VoidCore/Media.h
@@ -84,6 +84,28 @@ public:
     Media();
     Media(const MediaStruct& mstruct);
 
+    /**
+     * Constructors that would mostly be used to construct Media from serialized data
+     * 1. Singlefile
+     * 2. Sequence without missing frames
+     * 3. Sequence with missing frames
+     */
+    Media(const std::string& basepath, const std::string& name, const std::string& extension);
+
+    Media(const std::string& basepath,
+        const std::string& name,
+        const std::string& extension,
+        v_frame_t start,
+        v_frame_t end
+    );
+    Media(const std::string& basepath,
+        const std::string& name,
+        const std::string& extension,
+        v_frame_t start,
+        v_frame_t end,
+        const std::vector<v_frame_t>& missing
+    );
+
     virtual ~Media();
 
     /**

--- a/src/VoidCore/MediaFilesystem.h
+++ b/src/VoidCore/MediaFilesystem.h
@@ -45,6 +45,12 @@ class VOID_API MEntry
 public:
     MEntry();
     MEntry(const std::string& path);
+    MEntry(const std::string& basepath,
+        const std::string& name,
+        const std::string& extension,
+        v_frame_t frame = 0,
+        bool singlefile = false
+    );
 
     ~MEntry();
 
@@ -176,6 +182,25 @@ public:
      * like comparison by the name, and extension
      */
     MediaStruct(const MEntry& entry, const MediaType& type);
+
+    /**
+     * Deserialization constructors
+     */
+    MediaStruct(const std::string& basepath, const std::string& name, const std::string& extension);
+
+    MediaStruct(const std::string& basepath,
+            const std::string& name,
+            const std::string& extension,
+            v_frame_t start,
+            v_frame_t end
+    );
+    MediaStruct(const std::string& basepath,
+            const std::string& name,
+            const std::string& extension,
+            v_frame_t start,
+            v_frame_t end,
+            const std::vector<v_frame_t>& missing
+    );
 
     ~MediaStruct();
 

--- a/src/VoidObjects/Media/MediaClip.cpp
+++ b/src/VoidObjects/Media/MediaClip.cpp
@@ -24,6 +24,48 @@ MediaClip::MediaClip(const MediaStruct& mstruct, QObject* parent)
     VOID_LOG_INFO("Clip Created: {0}", Vuid());
 }
 
+MediaClip::MediaClip(const std::string& basepath,
+        const std::string& name,
+        const std::string& extension,
+        QObject* parent
+    )
+    : VoidObject(parent)
+    , Media(basepath, name, extension)
+    , m_Thumbnail()
+{
+    VOID_LOG_INFO("Clip Created: {0}", Vuid());
+}
+
+MediaClip::MediaClip(const std::string& basepath,
+        const std::string& name,
+        const std::string& extension,
+        v_frame_t start,
+        v_frame_t end,
+        QObject* parent
+    )
+    : VoidObject(parent)
+    , Media(basepath, name, extension, start, end)
+    , m_Thumbnail()
+{
+    VOID_LOG_INFO("Clip Created: {0}", Vuid());
+}
+
+MediaClip::MediaClip(const std::string& basepath,
+        const std::string& name,
+        const std::string& extension,
+        v_frame_t start,
+        v_frame_t end,
+        const std::vector<v_frame_t>& missing,
+        QObject* parent
+    )
+    : VoidObject(parent)
+    , Media(basepath, name, extension, start, end, missing)
+    , m_Thumbnail()
+{
+    VOID_LOG_INFO("Clip Created: {0}", Vuid());
+}
+
+
 MediaClip::~MediaClip()
 {
 }

--- a/src/VoidObjects/Media/MediaClip.h
+++ b/src/VoidObjects/Media/MediaClip.h
@@ -31,6 +31,26 @@ class VOID_API MediaClip : public VoidObject, public Media
 public:
     MediaClip(QObject* parent = nullptr);
     MediaClip(const MediaStruct& mstruct, QObject* parent = nullptr);
+    MediaClip(const std::string& basepath,
+            const std::string& name,
+            const std::string& extension,
+            QObject* parent = nullptr
+    );
+    MediaClip(const std::string& basepath,
+            const std::string& name,
+            const std::string& extension,
+            v_frame_t start,
+            v_frame_t end,
+            QObject* parent = nullptr
+    );
+    MediaClip(const std::string& basepath,
+            const std::string& name,
+            const std::string& extension,
+            v_frame_t start,
+            v_frame_t end,
+            const std::vector<v_frame_t>& missing,
+            QObject* parent = nullptr
+    );
     virtual ~MediaClip();
 
     inline void SetColor(const QColor& color)


### PR DESCRIPTION
### Feat: Pre-Serialisation Updates
* Added deserialisation constructors.
* Deserialisation constructors are atleast 10x faster than the standard constructors.

### Details
As we move towards supporting Serialisation and Deserialisation of the project and entities underneath it, this change is a step towards allowing Media data to be constructed from as smaller data as possible with as fast as it can be to improve loading performance.
* Note: There is definitely room for improvement here with regards to how media is constructed but that can be done with some changes on Media structure so will be taken up during Optimisations/Media updates during stereo.