### PR TITLE
[VOID] Import Directories onto Player

### DIFF
--- a/src/VoidCore/MediaFilesystem.h
+++ b/src/VoidCore/MediaFilesystem.h
@@ -331,6 +331,7 @@ public:
      * Provides a vector of MediaStructs for a provided Directory
      */
     std::vector<MediaStruct> FromDirectory(const std::string& directory);
+    static std::vector<MediaStruct> GetAllMedia(const std::string& directory, int level = 0, int maxLevel = 4);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/MediaFilesystem.h
+++ b/src/VoidCore/MediaFilesystem.h
@@ -129,7 +129,7 @@ private: /* Methods */
     bool ValidFrame(const std::string& framestring) const;
 };
 
-struct MHelper
+struct VOID_API MHelper
 {
     static MediaType GetMediaType(const MEntry& entry);
 

--- a/src/VoidUi/BaseWindow/PlayerWindow.cpp
+++ b/src/VoidUi/BaseWindow/PlayerWindow.cpp
@@ -168,6 +168,7 @@ void VoidMainWindow::Build()
     m_ImportAction->setShortcut(QKeySequence("Ctrl+I"));
 
     m_ImportDirectoryAction = new QAction("Import Directory...", m_FileMenu);
+    m_ImportDirectoryAction->setShortcut(QKeySequence("Ctrl+Alt+I"));
     
     m_NewProjectAction = new QAction("New Project", m_FileMenu);
     m_NewProjectAction->setShortcut(QKeySequence("Ctrl+N"));

--- a/src/VoidUi/BaseWindow/PlayerWindow.cpp
+++ b/src/VoidUi/BaseWindow/PlayerWindow.cpp
@@ -423,14 +423,7 @@ void VoidMainWindow::ImportMedia(const MediaStruct& mstruct)
 
 void VoidMainWindow::ImportDirectory(const std::string& path)
 {
-    std::vector<MediaStruct> medias = MediaFS().FromDirectory(path);
-
-    /**
-     * Import all the media struct retrived from the Filesystem 
-     * the ImportMedia function itself validates if the item is not a valid media and logs information
-     */
-    for (const MediaStruct& m: medias)
-        ImportMedia(m);
+    m_Bridge.ImportDirectory(path);
 }
 
 void VoidMainWindow::RegisterDocks()

--- a/src/VoidUi/BaseWindow/PlayerWindow.cpp
+++ b/src/VoidUi/BaseWindow/PlayerWindow.cpp
@@ -166,6 +166,8 @@ void VoidMainWindow::Build()
 
     m_ImportAction = new QAction("Import Media...", m_FileMenu);
     m_ImportAction->setShortcut(QKeySequence("Ctrl+I"));
+
+    m_ImportDirectoryAction = new QAction("Import Directory...", m_FileMenu);
     
     m_NewProjectAction = new QAction("New Project", m_FileMenu);
     m_NewProjectAction->setShortcut(QKeySequence("Ctrl+N"));
@@ -176,6 +178,7 @@ void VoidMainWindow::Build()
     m_CloseAction->setShortcut(QKeySequence("Ctrl+Q"));
 
     m_FileMenu->addAction(m_ImportAction);
+    m_FileMenu->addAction(m_ImportDirectoryAction);
 
     /* -------------------------------- */
     m_FileMenu->addSeparator();
@@ -342,6 +345,7 @@ void VoidMainWindow::Connect()
     /* File Menu {{{ */
     connect(m_CloseAction, &QAction::triggered, this, &QCoreApplication::quit);
     connect(m_ImportAction, &QAction::triggered, this, &VoidMainWindow::Load);
+    connect(m_ImportDirectoryAction, &QAction::triggered, this, &VoidMainWindow::LoadDirectory);
     connect(m_NewProjectAction, &QAction::triggered, this, [this]() { MBridge::Instance().NewProject(); });
     connect(m_ClearAction, &QAction::triggered, m_Player, &Player::Clear);
     /* }}} */
@@ -461,6 +465,20 @@ void VoidMainWindow::Load()
 
     /* Read the File from the FileDialog */
     m_Bridge.AddMedia(mediaBrowser.GetSelectedFile());
+}
+
+void VoidMainWindow::LoadDirectory()
+{
+    VoidMediaBrowser mediaBrowser;
+
+    if (!mediaBrowser.BrowseDirectory())
+    {
+        VOID_LOG_INFO("User Cancelled Importing");
+        return;
+    }
+
+    /* Import the Media from the directory */
+    m_Bridge.ImportDirectory(mediaBrowser.SelectedDirectory());
 }
 
 void VoidMainWindow::SetMedia(const SharedMediaClip& media)

--- a/src/VoidUi/BaseWindow/PlayerWindow.h
+++ b/src/VoidUi/BaseWindow/PlayerWindow.h
@@ -97,6 +97,7 @@ private: /* Members */
     /* File Menu */
     QMenu* m_FileMenu;
     QAction* m_ImportAction;
+    QAction* m_ImportDirectoryAction;
     QAction* m_ClearAction;
     QAction* m_NewProjectAction;
     QAction* m_CloseAction;
@@ -158,6 +159,7 @@ private: /* Members */
 
 public:
     void Load();
+    void LoadDirectory();
     /* Clears and sets the provided media on the player */
     void SetMedia(const SharedMediaClip& media);
     /* Adds media onto the existing track */

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SOURCES
     # QExtensions
     QExtensions/Frame.cpp
     QExtensions/Label.cpp
+    QExtensions/ProgressTask.cpp
     QExtensions/PushButton.cpp
     QExtensions/Slider.cpp
     QExtensions/SpinBox.cpp

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCES
 
     # Project
     Project/Project.cpp
+    Project/Importer.cpp
     Project/Views/ProjectView.cpp
     Project/Delegates/ListDelegate.cpp
 

--- a/src/VoidUi/Media/Browser.cpp
+++ b/src/VoidUi/Media/Browser.cpp
@@ -19,6 +19,13 @@ VoidMediaBrowser::~VoidMediaBrowser()
 
 bool VoidMediaBrowser::Browse()
 {
+    setFileMode(QFileDialog::FileMode::ExistingFile);
+    return exec();
+}
+
+bool VoidMediaBrowser::BrowseDirectory()
+{
+    setFileMode(QFileDialog::FileMode::Directory);
     return exec();
 }
 

--- a/src/VoidUi/Media/Browser.cpp
+++ b/src/VoidUi/Media/Browser.cpp
@@ -9,7 +9,7 @@ VOID_NAMESPACE_OPEN
 VoidMediaBrowser::VoidMediaBrowser(QWidget* parent)
     : QFileDialog(parent)
 {
-
+    setOption(QFileDialog::DontUseNativeDialog);
 }
 
 VoidMediaBrowser::~VoidMediaBrowser()

--- a/src/VoidUi/Media/Browser.h
+++ b/src/VoidUi/Media/Browser.h
@@ -25,9 +25,11 @@ public:
      * will wait executing other instructions below and returns back a bool value telling if the browse
      * was successful or not.
      */
-    [[nodiscard]] bool Browse();     
+    [[nodiscard]] bool Browse();
+    [[nodiscard]] bool BrowseDirectory();
 
     inline std::string GetDirectory() const { return directory().absolutePath().toStdString(); }
+    inline std::string SelectedDirectory() const { return selectedFiles().first().toStdString(); }
     std::string GetSelectedFile() const;
     MediaStruct GetMediaStruct() const;
 };

--- a/src/VoidUi/Media/MediaBridge.h
+++ b/src/VoidUi/Media/MediaBridge.h
@@ -52,6 +52,7 @@ public:
 
     void AddMedia(const std::string& filepath);
     void RemoveMedia(const std::vector<QModelIndex>& media);
+    void ImportDirectory(const std::string& directory) { m_Project->ImportDirectory(directory); }
 
     /**
      * Projects
@@ -67,7 +68,7 @@ public:
     /**
      * Adds Media to the Graph
      */
-    bool AddMedia(const MediaStruct& mstruct);
+    bool AddMedia(const MediaStruct& mstruct);    
     bool InsertMedia(const MediaStruct& mstruct, const int index);
 
     /**

--- a/src/VoidUi/Project/Delegates/ListDelegate.cpp
+++ b/src/VoidUi/Project/Delegates/ListDelegate.cpp
@@ -33,7 +33,7 @@ void ProjectItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
     painter->save();
 
     /* Default background */
-    QColor bg = index.data(static_cast<int>(ProjectModel::Roles::Active)).toBool() ? option.palette.color(QPalette::Window).lighter(350) : option.palette.color(QPalette::Window).lighter(150);
+    QColor bg = index.data(static_cast<int>(ProjectModel::Roles::Active)).toBool() ? option.palette.color(QPalette::Window).lighter(250) : option.palette.color(QPalette::Window).lighter(150);
     painter->fillRect(rect, bg);
 
     /* Selected */
@@ -59,7 +59,7 @@ void ProjectItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
 
     /* Side Bar */
     QRect siderect = QRect(rect.left(), rect.top(), 6, rect.height());
-    painter->fillRect(siderect, bg.lighter(150));
+    painter->fillRect(siderect, bg.lighter(250));
 
     /* Name */
     QRect namerect = QRect(rect.left() + 10, rect.top(), rect.right(), rect.height());

--- a/src/VoidUi/Project/Importer.cpp
+++ b/src/VoidUi/Project/Importer.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Internal */
+#include "Importer.h"
+#include "Project.h"
+#include "VoidCore/Logging.h"
+#include "VoidCore/Profiler.h"
+#include "VoidUi/Commands/MediaCommands.h"
+
+VOID_NAMESPACE_OPEN
+
+DirectoryImporter::DirectoryImporter(Project* project, const std::string& directory, int maxLevel)
+    : QRunnable()
+    , m_Project(project)
+    , m_Directory(directory)
+    , m_MaxLevel(maxLevel)
+{
+}
+
+void DirectoryImporter::run()
+{
+    const std::vector<MediaStruct> media = std::move(GetMedia(m_Directory));
+
+    if (media.empty())
+        return;
+
+    m_Project->m_UndoStack->beginMacro("Import Directory");
+    for (MediaStruct m : media)
+    {
+        m_Project->m_UndoStack->push(new MediaImportCommand(m.FirstPath()));
+    }
+    m_Project->m_UndoStack->endMacro();
+}
+
+std::vector<MediaStruct> DirectoryImporter::GetMedia(const std::string& directory, int level) const
+{
+    std::vector<MediaStruct> vec;
+
+    Tools::VoidProfiler<std::chrono::duration<double>> p("Recursive Media Search");
+    VOID_LOG_INFO("Searching Directory {0} at Level: {1}/{2}", directory, level, m_MaxLevel);
+
+    try
+    {
+        for (std::filesystem::directory_entry entry : std::filesystem::directory_iterator(directory))
+        {
+            /* Recurse through the directory if the level allows */
+            if (entry.is_directory() && level <= m_MaxLevel)
+            {
+                /* Get all media inside the directory */
+                std::vector<MediaStruct> out = std::move(GetMedia(entry.path().string(), level + 1));
+
+                vec.reserve(vec.size() + out.size());
+                vec.insert(vec.end(), std::make_move_iterator(out.begin()), std::make_move_iterator(out.end()));
+            }
+
+            MEntry e(entry.path().string());
+
+            /* Flag to control what happens with the entry */
+            bool new_entry = true;
+
+            /**
+             * Iterate over what we have in our vector currently
+             * i.e. the media structs to see if this entry belongs to any one of them
+             * if so, this gets added there, else we create a new media struct from it
+             */
+            for (MediaStruct& m : vec)
+            {
+                /**
+                 * The entry belongs to this Media Struct don't have to add it again
+                 * this search is going to be used to import media via the UndoQueue
+                 * which only needs path of a single media from it
+                 */
+                if (m.Validate(e))
+                {
+                    new_entry = false;
+                    break;
+                }
+            }
+
+            /* Check if no entry in the MediaStruct adopted our newly created Media entry */
+            if (new_entry)
+            {
+                vec.push_back(MediaStruct(e, MHelper::GetMediaType(e)));
+            }
+        }
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+        VOID_LOG_ERROR(e.what());
+    }
+
+    return vec;
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Project/Importer.cpp
+++ b/src/VoidUi/Project/Importer.cpp
@@ -17,17 +17,35 @@ DirectoryImporter::DirectoryImporter(const std::string& directory, int maxLevel,
 {
 }
 
+DirectoryImporter::~DirectoryImporter()
+{
+    m_ProgressTask->deleteLater();
+    delete m_ProgressTask;
+    m_ProgressTask = nullptr;
+}
+
 void DirectoryImporter::process()
 {
+    m_ProgressTask = new ProgressTask;
+    m_ProgressTask->show();
+
+    m_ProgressTask->SetTaskType("Searching");
+    m_ProgressTask->SetMaximum(0);
+
     const std::vector<MediaStruct> media = std::move(GetMedia(m_Directory));
 
     if (media.empty())
         return;
 
+    m_ProgressTask->SetTaskType("Importing");
     emit started();
+
     for (MediaStruct m : media)
     {
-        emit mediaFound(m.FirstPath());
+        const std::string path = m.FirstPath();
+
+        m_ProgressTask->SetCurrentTask(path.c_str());
+        emit mediaFound(path);
     }
     emit finished();
 }

--- a/src/VoidUi/Project/Importer.cpp
+++ b/src/VoidUi/Project/Importer.cpp
@@ -26,9 +26,13 @@ void DirectoryImporter::Process()
     const std::vector<MediaStruct> media = std::move(GetMedia(m_Directory));
 
     if (media.empty() || m_Cancelled)
+    {
+        emit finished();
         return;
+    }
 
-    emit started();
+    emit startedImporting();
+    /* Sets up the progress maximum count */
     emit maxCount(media.size());
 
     int count = 0;
@@ -41,9 +45,10 @@ void DirectoryImporter::Process()
         emit mediaFound(QString::fromStdString(m.FirstPath()));
 
         /* Add delay to make it look like the media is imported as is being shown */
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
+    emit finishedImporting();
     emit finished();
 }
 

--- a/src/VoidUi/Project/Importer.cpp
+++ b/src/VoidUi/Project/Importer.cpp
@@ -10,27 +10,26 @@
 
 VOID_NAMESPACE_OPEN
 
-DirectoryImporter::DirectoryImporter(Project* project, const std::string& directory, int maxLevel)
-    : QRunnable()
-    , m_Project(project)
+DirectoryImporter::DirectoryImporter(const std::string& directory, int maxLevel, QObject* parent)
+    : QObject(parent)
     , m_Directory(directory)
     , m_MaxLevel(maxLevel)
 {
 }
 
-void DirectoryImporter::run()
+void DirectoryImporter::process()
 {
     const std::vector<MediaStruct> media = std::move(GetMedia(m_Directory));
 
     if (media.empty())
         return;
 
-    m_Project->m_UndoStack->beginMacro("Import Directory");
+    emit started();
     for (MediaStruct m : media)
     {
-        m_Project->m_UndoStack->push(new MediaImportCommand(m.FirstPath()));
+        emit mediaFound(m.FirstPath());
     }
-    m_Project->m_UndoStack->endMacro();
+    emit finished();
 }
 
 std::vector<MediaStruct> DirectoryImporter::GetMedia(const std::string& directory, int level) const

--- a/src/VoidUi/Project/Importer.h
+++ b/src/VoidUi/Project/Importer.h
@@ -27,10 +27,13 @@ public:
     inline void Cancel() { m_Cancelled = true; }
 
 signals:
-    void started();
     void maxCount(int);
     void progressUpdated(int);
     void mediaFound(const QString&);
+
+    void startedImporting();
+    void finishedImporting();
+
     void finished();
 
 private: /* Members */

--- a/src/VoidUi/Project/Importer.h
+++ b/src/VoidUi/Project/Importer.h
@@ -13,7 +13,6 @@
 /* Internal */
 #include "Definition.h"
 #include "VoidCore/MediaFilesystem.h"
-#include "VoidUi/QExtensions/ProgressTask.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -28,13 +27,14 @@ public:
 
 signals:
     void started();
-    void mediaFound(const std::string&);
+    void maxCount(int);
+    void progressUpdated(int);
+    void mediaFound(const QString&);
     void finished();
 
 private: /* Members */
     std::string m_Directory;
     int m_MaxLevel;
-    ProgressTask* m_ProgressTask;
 
 private: /* Methods */
     std::vector<MediaStruct> GetMedia(const std::string& directory, int level = 0) const;

--- a/src/VoidUi/Project/Importer.h
+++ b/src/VoidUi/Project/Importer.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _VOID_MEDIA_DIRECTORY_IMPORTER_H
+#define _VOID_MEDIA_DIRECTORY_IMPORTER_H
+
+/* STD */
+#include <vector>
+
+/* Qt */
+#include <QRunnable>
+
+/* Internal */
+#include "Definition.h"
+#include "VoidCore/MediaFilesystem.h"
+
+VOID_NAMESPACE_OPEN
+
+/* Forward Declaration of Project */
+class Project;
+
+class DirectoryImporter : public QRunnable
+{
+public:
+    DirectoryImporter(Project* project, const std::string& directory, int maxLevel = 5);
+    void run() override;
+
+private: /* Members */
+    Project* m_Project;
+    std::string m_Directory;
+    int m_MaxLevel;
+
+private: /* Methods */
+    std::vector<MediaStruct> GetMedia(const std::string& directory, int level = 0) const;
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _VOID_MEDIA_DIRECTORY_IMPORTER_H

--- a/src/VoidUi/Project/Importer.h
+++ b/src/VoidUi/Project/Importer.h
@@ -13,6 +13,7 @@
 /* Internal */
 #include "Definition.h"
 #include "VoidCore/MediaFilesystem.h"
+#include "VoidUi/QExtensions/ProgressTask.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -22,6 +23,7 @@ class DirectoryImporter : public QObject
 
 public:
     DirectoryImporter(const std::string& directory, int maxLevel = 5, QObject* parent = nullptr);
+    ~DirectoryImporter();
     void process();
 
 signals:
@@ -32,6 +34,7 @@ signals:
 private: /* Members */
     std::string m_Directory;
     int m_MaxLevel;
+    ProgressTask* m_ProgressTask;
 
 private: /* Methods */
     std::vector<MediaStruct> GetMedia(const std::string& directory, int level = 0) const;

--- a/src/VoidUi/Project/Importer.h
+++ b/src/VoidUi/Project/Importer.h
@@ -23,7 +23,8 @@ class DirectoryImporter : public QObject
 public:
     DirectoryImporter(const std::string& directory, int maxLevel = 5, QObject* parent = nullptr);
     ~DirectoryImporter();
-    void process();
+    void Process();
+    inline void Cancel() { m_Cancelled = true; }
 
 signals:
     void started();
@@ -35,6 +36,7 @@ signals:
 private: /* Members */
     std::string m_Directory;
     int m_MaxLevel;
+    bool m_Cancelled;
 
 private: /* Methods */
     std::vector<MediaStruct> GetMedia(const std::string& directory, int level = 0) const;

--- a/src/VoidUi/Project/Importer.h
+++ b/src/VoidUi/Project/Importer.h
@@ -8,7 +8,7 @@
 #include <vector>
 
 /* Qt */
-#include <QRunnable>
+#include <QObject>
 
 /* Internal */
 #include "Definition.h"
@@ -16,17 +16,20 @@
 
 VOID_NAMESPACE_OPEN
 
-/* Forward Declaration of Project */
-class Project;
-
-class DirectoryImporter : public QRunnable
+class DirectoryImporter : public QObject
 {
+    Q_OBJECT
+
 public:
-    DirectoryImporter(Project* project, const std::string& directory, int maxLevel = 5);
-    void run() override;
+    DirectoryImporter(const std::string& directory, int maxLevel = 5, QObject* parent = nullptr);
+    void process();
+
+signals:
+    void started();
+    void mediaFound(const std::string&);
+    void finished();
 
 private: /* Members */
-    Project* m_Project;
     std::string m_Directory;
     int m_MaxLevel;
 

--- a/src/VoidUi/Project/Project.cpp
+++ b/src/VoidUi/Project/Project.cpp
@@ -42,18 +42,17 @@ void Project::ImportDirectory(const std::string& directory)
     /* Thread */
     connect(thread, &QThread::started, m_DirectoryImporter, &DirectoryImporter::Process);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
-    // connect(thread, &QThread::finished, this, &Project::DeleteProgressTask);
 
     /* Importer */
-    connect(m_DirectoryImporter, &DirectoryImporter::started, this, [this]()
+    connect(m_DirectoryImporter, &DirectoryImporter::startedImporting, this, [this]()
     {
         m_UndoStack->beginMacro("Import Directory");
-        m_ProgressTask->SetTaskType("Importing");
+        m_ProgressTask->SetTaskType("Importing...");
     });
+    connect(m_DirectoryImporter, &DirectoryImporter::finishedImporting, this, [this]() { m_UndoStack->endMacro(); });
 
     connect(m_DirectoryImporter, &DirectoryImporter::finished, this, [this]()
     {
-        m_UndoStack->endMacro();
         DeleteProgressTask();
         DeleteImporter();
     });
@@ -76,7 +75,7 @@ void Project::SetupProgressTask()
     m_ProgressTask = new ProgressTask;
     m_ProgressTask->show();
 
-    m_ProgressTask->SetTaskType("Searching");
+    m_ProgressTask->SetTaskType("Searching...");
     m_ProgressTask->SetMaximum(0);
 
     connect(m_ProgressTask, &ProgressTask::cancelled, this, &Project::CancelImporting);

--- a/src/VoidUi/Project/Project.cpp
+++ b/src/VoidUi/Project/Project.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* Qt */
+#include <QThreadPool>
+
 /* Internal */
 #include "Project.h"
 
@@ -20,6 +23,31 @@ Project::Project(bool active, QObject* parent)
 Project::~Project()
 {
     m_UndoStack->deleteLater();
+}
+
+// void AddMedia(const std::string& directory)
+// {
+//     for (MediaStruct mstruct : MediaFS::FromDirectory(directory))
+//     {
+
+//     }
+// }
+
+void Project::ImportDirectory(const std::string& directory)
+{
+    // std::vector<MediaStruct> media = MediaFS().FromDirectory(directory);
+    // std::vector<MediaStruct> media = MediaFS::GetAllMedia(directory);
+
+    // if (media.empty())
+    //     return;
+    
+    // m_UndoStack->beginMacro("Import Directory");
+    // for (MediaStruct m : media)
+    // {
+    //     m_UndoStack->push(new MediaImportCommand(m.FirstPath()));
+    // }
+    // m_UndoStack->endMacro();
+    QThreadPool::globalInstance()->start(new DirectoryImporter(this, directory, 5));
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Project/Project.cpp
+++ b/src/VoidUi/Project/Project.cpp
@@ -18,58 +18,56 @@ Project::Project(const std::string& name, bool active, QObject* parent)
 }
 
 Project::Project(bool active, QObject* parent)
-    : Core::Project(active, parent)
+    : Project("", active, parent)
 {
 }
 
 Project::~Project()
 {
     m_UndoStack->deleteLater();
+
     DeleteProgressTask();
+    DeleteImporter();
 }
-
-// void AddMedia(const std::string& directory)
-// {
-//     for (MediaStruct mstruct : MediaFS::FromDirectory(directory))
-//     {
-
-//     }
-// }
 
 void Project::ImportDirectory(const std::string& directory)
 {
     SetupProgressTask();
 
     QThread* thread = new QThread;
-    DirectoryImporter* importer = new DirectoryImporter(directory, 5);
+    m_DirectoryImporter = new DirectoryImporter(directory, 5);
 
-    importer->moveToThread(thread);
+    m_DirectoryImporter->moveToThread(thread);
 
     /* Thread */
-    connect(thread, &QThread::started, importer, &DirectoryImporter::process);
+    connect(thread, &QThread::started, m_DirectoryImporter, &DirectoryImporter::Process);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+    // connect(thread, &QThread::finished, this, &Project::DeleteProgressTask);
 
     /* Importer */
-    connect(importer, &DirectoryImporter::started, this, [this]()
+    connect(m_DirectoryImporter, &DirectoryImporter::started, this, [this]()
     {
         m_UndoStack->beginMacro("Import Directory");
+        m_ProgressTask->SetTaskType("Importing");
     });
 
-    connect(importer, &DirectoryImporter::finished, this, [this]()
+    connect(m_DirectoryImporter, &DirectoryImporter::finished, this, [this]()
     {
         m_UndoStack->endMacro();
         DeleteProgressTask();
+        DeleteImporter();
     });
 
-    connect(importer, &DirectoryImporter::finished, importer, &DirectoryImporter::deleteLater);
-    connect(importer, &DirectoryImporter::mediaFound, this, [this](const QString& path)
+    connect(m_DirectoryImporter, &DirectoryImporter::mediaFound, this, [this](const QString& path)
     {
         m_ProgressTask->SetCurrentTask(path.toStdString().c_str());
         m_UndoStack->push(new MediaImportCommand(path.toStdString()));
     });
-    connect(importer, &DirectoryImporter::maxCount, m_ProgressTask, &ProgressTask::SetMaximum);
-    connect(importer, &DirectoryImporter::progressUpdated, m_ProgressTask, &ProgressTask::SetValue);
 
+    connect(m_DirectoryImporter, &DirectoryImporter::maxCount, m_ProgressTask, &ProgressTask::SetMaximum);
+    connect(m_DirectoryImporter, &DirectoryImporter::progressUpdated, m_ProgressTask, &ProgressTask::SetValue);
+
+    /* Start Import process */
     thread->start();
 }
 
@@ -80,6 +78,8 @@ void Project::SetupProgressTask()
 
     m_ProgressTask->SetTaskType("Searching");
     m_ProgressTask->SetMaximum(0);
+
+    connect(m_ProgressTask, &ProgressTask::cancelled, this, &Project::CancelImporting);
 }
 
 void Project::DeleteProgressTask()
@@ -90,6 +90,22 @@ void Project::DeleteProgressTask()
         delete m_ProgressTask;
         m_ProgressTask = nullptr;
     }
+}
+
+void Project::DeleteImporter()
+{
+    if (m_DirectoryImporter)
+    {
+        m_DirectoryImporter->deleteLater();
+        delete m_DirectoryImporter;
+        m_DirectoryImporter = nullptr;
+    }
+}
+
+void Project::CancelImporting()
+{
+    if (m_DirectoryImporter)
+        m_DirectoryImporter->Cancel();
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Project/Project.h
+++ b/src/VoidUi/Project/Project.h
@@ -11,6 +11,7 @@
 #include "Definition.h"
 #include "Importer.h"
 #include "VoidObjects/Project/Project.h"
+#include "VoidUi/QExtensions/ProgressTask.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -36,9 +37,11 @@ public:
 
 private: /* Members */
     QUndoStack* m_UndoStack;
+    ProgressTask* m_ProgressTask;
 
-private: /* Friends */
-    friend class DirectoryImporter;
+private: /* Methods */
+    void SetupProgressTask();
+    void DeleteProgressTask();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Project/Project.h
+++ b/src/VoidUi/Project/Project.h
@@ -9,6 +9,7 @@
 
 /* Internal */
 #include "Definition.h"
+#include "Importer.h"
 #include "VoidObjects/Project/Project.h"
 
 VOID_NAMESPACE_OPEN
@@ -31,8 +32,13 @@ public:
     inline void PushCommand(QUndoCommand* command) { m_UndoStack->push(command); }
     inline QUndoStack* UndoStack() const { return m_UndoStack; }
 
+    void ImportDirectory(const std::string& directory);
+
 private: /* Members */
     QUndoStack* m_UndoStack;
+
+private: /* Friends */
+    friend class DirectoryImporter;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Project/Project.h
+++ b/src/VoidUi/Project/Project.h
@@ -38,10 +38,13 @@ public:
 private: /* Members */
     QUndoStack* m_UndoStack;
     ProgressTask* m_ProgressTask;
+    DirectoryImporter* m_DirectoryImporter;
 
 private: /* Methods */
     void SetupProgressTask();
     void DeleteProgressTask();
+    void DeleteImporter();
+    void CancelImporting();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/ProgressTask.cpp
+++ b/src/VoidUi/QExtensions/ProgressTask.cpp
@@ -49,6 +49,7 @@ void ProgressTask::Build()
 void ProgressTask::Setup()
 {
     m_ProgressBar->setAlignment(Qt::AlignCenter);
+    m_CurrentTaskLabel->setFixedWidth(180);
 }
 
 void ProgressTask::Cancel()
@@ -64,6 +65,12 @@ void ProgressTask::Cancel()
 void ProgressTask::Connect()
 {
     connect(m_CancelButton, &QPushButton::clicked, this, &ProgressTask::Cancel);
+}
+
+void ProgressTask::SetLabelTask(const char* text)
+{
+    QFontMetrics fm = m_CurrentTaskLabel->fontMetrics();
+    m_CurrentTaskLabel->setText(fm.elidedText(text, Qt::ElideLeft, m_CurrentTaskLabel->width()));
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/ProgressTask.cpp
+++ b/src/VoidUi/QExtensions/ProgressTask.cpp
@@ -7,7 +7,7 @@
 VOID_NAMESPACE_OPEN
 
 ProgressTask::ProgressTask(QWidget* parent)
-    : QWidget(parent)
+    : QDialog(parent)
 {
     Build();
     Setup();

--- a/src/VoidUi/QExtensions/ProgressTask.cpp
+++ b/src/VoidUi/QExtensions/ProgressTask.cpp
@@ -36,7 +36,6 @@ void ProgressTask::Build()
     m_TaskLayout->addWidget(m_CurrentTaskLabel);
 
     m_ProgressBar = new QProgressBar;
-
     m_CancelButton = new QPushButton("Cancel");
 
     m_ButtonLayout->addStretch(1);
@@ -52,15 +51,19 @@ void ProgressTask::Setup()
     m_ProgressBar->setAlignment(Qt::AlignCenter);
 }
 
+void ProgressTask::Cancel()
+{
+    m_Cancelled = true;
+    
+    m_TaskTypeLabel->setText("Cancelling...");
+    m_CancelButton->setEnabled(false);
+
+    emit cancelled();
+}
+
 void ProgressTask::Connect()
 {
-    connect(m_CancelButton, &QPushButton::clicked, this, [this]()
-    {
-        m_Cancelled = true;
-        
-        m_TaskTypeLabel->setText("Cancelling...");
-        m_CancelButton->setEnabled(false);
-    });
+    connect(m_CancelButton, &QPushButton::clicked, this, &ProgressTask::Cancel);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/ProgressTask.cpp
+++ b/src/VoidUi/QExtensions/ProgressTask.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Internal */
+#include "ProgressTask.h"
+
+VOID_NAMESPACE_OPEN
+
+ProgressTask::ProgressTask(QWidget* parent)
+    : QWidget(parent)
+{
+    Build();
+    Setup();
+    Connect();
+}
+
+ProgressTask::~ProgressTask()
+{
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void ProgressTask::Build()
+{
+    m_Layout = new QVBoxLayout(this);
+
+    m_ButtonLayout = new QHBoxLayout;
+    m_TaskLayout = new QHBoxLayout;
+
+    m_TaskTypeLabel = new QLabel;
+    m_CurrentTaskLabel = new QLabel;
+
+    m_TaskLayout->addWidget(m_TaskTypeLabel);
+    m_TaskLayout->addStretch(1);
+    m_TaskLayout->addWidget(m_CurrentTaskLabel);
+
+    m_ProgressBar = new QProgressBar;
+
+    m_CancelButton = new QPushButton("Cancel");
+
+    m_ButtonLayout->addStretch(1);
+    m_ButtonLayout->addWidget(m_CancelButton);
+
+    m_Layout->addLayout(m_TaskLayout);
+    m_Layout->addWidget(m_ProgressBar);
+    m_Layout->addLayout(m_ButtonLayout);
+}
+
+void ProgressTask::Setup()
+{
+    m_ProgressBar->setAlignment(Qt::AlignCenter);
+}
+
+void ProgressTask::Connect()
+{
+    connect(m_CancelButton, &QPushButton::clicked, this, [this]()
+    {
+        m_Cancelled = true;
+        
+        m_TaskTypeLabel->setText("Cancelling...");
+        m_CancelButton->setEnabled(false);
+    });
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/ProgressTask.h
+++ b/src/VoidUi/QExtensions/ProgressTask.h
@@ -27,7 +27,7 @@ public:
     inline QSize sizeHint() const { return QSize(400, 40); }
 
     inline bool Cancelled() const { return m_Cancelled; }
-    inline void Cancel() { m_Cancelled = true; }
+    void Cancel();
 
     inline void SetTaskType(const char* text) { m_TaskTypeLabel->setText(text); }
     inline void SetCurrentTask(const char* text) { m_CurrentTaskLabel->setText(text); }
@@ -35,6 +35,9 @@ public:
     inline void SetMaximum(int max) { m_ProgressBar->setMaximum(max); }
     inline void SetValue(int value) { m_ProgressBar->setValue(value); }
     inline int Value() const { return m_ProgressBar->value(); }
+
+signals:
+    void cancelled();
 
 protected: /* Members */
     bool m_Cancelled;

--- a/src/VoidUi/QExtensions/ProgressTask.h
+++ b/src/VoidUi/QExtensions/ProgressTask.h
@@ -24,13 +24,13 @@ public:
     ProgressTask(QWidget* parent = nullptr);
     ~ProgressTask();
 
-    inline QSize sizeHint() const { return QSize(400, 40); }
+    inline QSize sizeHint() const { return QSize(500, 40); }
 
     inline bool Cancelled() const { return m_Cancelled; }
     void Cancel();
 
     inline void SetTaskType(const char* text) { m_TaskTypeLabel->setText(text); }
-    inline void SetCurrentTask(const char* text) { m_CurrentTaskLabel->setText(text); }
+    inline void SetCurrentTask(const char* text) { SetLabelTask(text); }
 
     inline void SetMaximum(int max) { m_ProgressBar->setMaximum(max); }
     inline void SetValue(int value) { m_ProgressBar->setValue(value); }
@@ -57,6 +57,13 @@ private: /* Methods */
     void Build();
     void Setup();
     void Connect();
+
+    /**
+     * The curren task label could be of any width, and we don't necessarily want to expand to those widths
+     * and the next task could be lesser in width making the UI too inconsistent all the time, hence a fixed
+     * label width is set, if the width goes beyond that, it gets elided from the left side
+     */
+    void SetLabelTask(const char* text);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/ProgressTask.h
+++ b/src/VoidUi/QExtensions/ProgressTask.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _VOID_Q_EXT_PROGRESS_TASK_H
+#define _VOID_Q_EXT_PROGRESS_TASK_H
+
+/* Qt */
+#include <QWidget>
+#include <QLabel>
+#include <QLayout>
+#include <QPushButton>
+#include <QProgressBar>
+
+/* Internal */
+#include "Definition.h"
+
+VOID_NAMESPACE_OPEN
+
+class ProgressTask : public QWidget
+{
+    Q_OBJECT
+
+public:
+    ProgressTask(QWidget* parent = nullptr);
+    ~ProgressTask();
+
+    inline QSize sizeHint() const { return QSize(400, 40); }
+
+    inline bool Cancelled() const { return m_Cancelled; }
+    inline void Cancel() { m_Cancelled = true; }
+
+    inline void SetTaskType(const char* text) { m_TaskTypeLabel->setText(text); }
+    inline void SetCurrentTask(const char* text) { m_CurrentTaskLabel->setText(text); }
+
+    inline void SetMaximum(int max) { m_ProgressBar->setMaximum(max); }
+    inline void SetValue(int value) { m_ProgressBar->setValue(value); }
+    inline int Value() const { return m_ProgressBar->value(); }
+
+protected: /* Members */
+    bool m_Cancelled;
+
+private: /* Members */
+    QVBoxLayout* m_Layout;
+    QHBoxLayout* m_TaskLayout;
+    QHBoxLayout* m_ButtonLayout;
+
+    QPushButton* m_CancelButton;
+    QLabel* m_TaskTypeLabel;
+    QLabel* m_CurrentTaskLabel;
+
+    QProgressBar* m_ProgressBar;
+
+    QActionGroup* m_RadioGroup;
+
+private: /* Methods */
+    void Build();
+    void Setup();
+    void Connect();
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _VOID_Q_EXT_PROGRESS_TASK_H

--- a/src/VoidUi/QExtensions/ProgressTask.h
+++ b/src/VoidUi/QExtensions/ProgressTask.h
@@ -5,7 +5,7 @@
 #define _VOID_Q_EXT_PROGRESS_TASK_H
 
 /* Qt */
-#include <QWidget>
+#include <QDialog>
 #include <QLabel>
 #include <QLayout>
 #include <QPushButton>
@@ -16,7 +16,7 @@
 
 VOID_NAMESPACE_OPEN
 
-class ProgressTask : public QWidget
+class ProgressTask : public QDialog
 {
     Q_OBJECT
 
@@ -49,8 +49,6 @@ private: /* Members */
     QLabel* m_CurrentTaskLabel;
 
     QProgressBar* m_ProgressBar;
-
-    QActionGroup* m_RadioGroup;
 
 private: /* Methods */
     void Build();


### PR DESCRIPTION
### Feat: Importing Directories into VOID
* Added Import Directory feature.
* Directory import runs in a threaded process.
* Added Resuable ProgressTask dialog.
* Added progress bar for the directory importer with option to cancel the import process at any stage.

### Other Improvements
* MediaList drag drop uses same media directory import.
* UI updates on delegate.
* Use Qt Browser and not native browser for consistent UI feel.
