### PR TITLE
[VOID] Fix for MediaClip Size when Importing

### DIFF
--- a/src/VoidObjects/Media/MediaClip.cpp
+++ b/src/VoidObjects/Media/MediaClip.cpp
@@ -75,10 +75,12 @@ QPixmap MediaClip::Thumbnail()
     if (m_Thumbnail.isNull())
     {
         /* Grab the pointer to the image data for the first frame to be used as a thumbnail */
-        const SharedPixels im = Media::FirstImage();
+        SharedPixels im = Media::FirstImage();
         QImage::Format format = (im->Channels() == 3) ? QImage::Format_RGB888 : QImage::Format_RGBA8888;
 
-        m_Thumbnail = QPixmap::fromImage(QImage(im->ThumbnailPixels(), im->Width(), im->Height(), format));
+        m_Thumbnail = QPixmap::fromImage(QImage(im->ThumbnailPixels(), im->Width(), im->Height(), format)).scaledToWidth(400, Qt::SmoothTransformation);
+        /* Clear the data for when required */
+        im->Clear();
     }
 
     return m_Thumbnail;


### PR DESCRIPTION
* Clear Media Frame data after thumbnail is generated.

### Details
When media is imported it's first frame is read and cached for Thumbnail generation. This data used to be retained. But when importing multiple media clips, if this data is retained, we will end up consuming memory which is not needed,
if as an example first frame of 10 clips is 10 MB, (4K frames roughly with data type unsigned char) and we import all of them at the same time, we end up taking 100 MB of the memory. Now if we import 100, we end up taking 1 GB additional to the thumbnail and others, which is something this change helps avoiding.