### PR TITLE
[VOID] Player: Load media along with annotations when setting on player

### DIFF
--- a/src/VoidUi/Player/PlayerWidget.cpp
+++ b/src/VoidUi/Player/PlayerWidget.cpp
@@ -234,8 +234,8 @@ void Player::Load(const SharedMediaClip& media)
     m_Timeline->SetRange(media->FirstFrame(), media->LastFrame());
     /* Clear any cached frame markings from the timeline */
     m_Timeline->ClearCachedFrames();
-    /* Then set the First Image on the Player */
-    m_Renderer->Render(media->FirstImage());
+
+    SetMediaFrame(m_Timeline->Frame());
 }
 
 void Player::Load(const SharedMediaClip& media, const PlayerViewBuffer& buffer)


### PR DESCRIPTION
### Fix:
* The annotations were not getting set when media is set on the player, if the media has annotations on the first frame.