### PR TITLE
[VOID] Timeline: Marked Frames Refresh

### DIFF
--- a/src/VoidObjects/Media/MediaClip.cpp
+++ b/src/VoidObjects/Media/MediaClip.cpp
@@ -123,6 +123,17 @@ void MediaClip::RemoveAnnotation(const v_frame_t frame)
     VOID_LOG_INFO("Annotation Removed. Frame {0}", frame);
 }
 
+std::vector<int> MediaClip::AnnotatedFrames() const
+{
+    std::vector<int> frames;
+    frames.reserve(m_Annotations.size());
+
+    for (const auto& [key, _] : m_Annotations)
+        frames.emplace_back(key);
+
+    return frames;
+}
+
 void MediaClip::CacheFrame(v_frame_t frame)
 {
     m_Mediaframes.at(frame).Cache();

--- a/src/VoidObjects/Media/MediaClip.h
+++ b/src/VoidObjects/Media/MediaClip.h
@@ -108,6 +108,7 @@ public:
      */
     Renderer::SharedAnnotation Annotation(const v_frame_t frame) const;
     inline v_frame_t Duration() const { return (m_LastFrame - m_FirstFrame) + 1; }
+    std::vector<int> AnnotatedFrames() const;
 
     QPixmap Thumbnail();
 

--- a/src/VoidUi/Player/PlayerWidget.cpp
+++ b/src/VoidUi/Player/PlayerWidget.cpp
@@ -215,6 +215,7 @@ void Player::Clear()
      * Clear the data from the player
      */
     m_Timeline->SetRange(0, 1);
+    m_Timeline->Clear();
     m_Renderer->Clear();
 }
 
@@ -233,7 +234,8 @@ void Player::Load(const SharedMediaClip& media)
      */
     m_Timeline->SetRange(media->FirstFrame(), media->LastFrame());
     /* Clear any cached frame markings from the timeline */
-    m_Timeline->ClearCachedFrames();
+    m_Timeline->Clear();
+    m_Timeline->SetAnnotatedFrames(std::move(media->AnnotatedFrames()));
 
     SetMediaFrame(m_Timeline->Frame());
 }
@@ -263,7 +265,7 @@ void Player::Load(const SharedPlaybackTrack& track)
      */
     m_Timeline->SetRange(track->StartFrame(), track->EndFrame());
     /* Clear any cached frame markings from the timeline */
-    m_Timeline->ClearCachedFrames();
+    m_Timeline->Clear();
     /* Then set the First Image on the Player */
     SetTrackFrame(m_Timeline->Frame());
 }
@@ -279,7 +281,7 @@ void Player::Load(const SharedPlaybackSequence& sequence)
      */
     m_Timeline->SetRange(sequence->StartFrame(), sequence->EndFrame());
     /* Clear any cached frame markings from the timeline */
-    m_Timeline->ClearCachedFrames();
+    m_Timeline->Clear();
 
     /* Render the current frame from the seqeunce */
     SetSequenceFrame(m_Timeline->Frame());

--- a/src/VoidUi/Timeline/Timeline.cpp
+++ b/src/VoidUi/Timeline/Timeline.cpp
@@ -307,6 +307,12 @@ void Timeline::ResetRange()
 	m_OutFrameButton->Toggle(false);
 }
 
+void Timeline::Clear()
+{
+	m_Timeslider->ClearAnnotatedFrames();
+	m_Timeslider->ClearCachedFrames();
+}
+
 void Timeline::SetUserFirstframe(int frame)
 {
 	/* Check if the end frame is lesser than the provided start frame */

--- a/src/VoidUi/Timeline/Timeline.h
+++ b/src/VoidUi/Timeline/Timeline.h
@@ -85,6 +85,10 @@ public:
 	inline void AddAnnotatedFrame(int frame) { m_Timeslider->AddAnnotatedFrame(frame); }
 	inline void RemoveAnnotatedFrame(int frame) { m_Timeslider->RemoveAnnotatedFrame(frame); }
 	inline void ClearAnnotatedFrames() { m_Timeslider->ClearAnnotatedFrames(); }
+	inline void SetAnnotatedFrames(const std::vector<int>& frames) { m_Timeslider->SetAnnotatedFrames(frames); }
+	inline void SetAnnotatedFrames(std::vector<int>&& frames) { m_Timeslider->SetAnnotatedFrames(std::move(frames)); }
+
+	void Clear();
 
 signals:
 	void Played(const PlayState& type = PlayState::FORWARDS);

--- a/src/VoidUi/Timeline/Timeslider.cpp
+++ b/src/VoidUi/Timeline/Timeslider.cpp
@@ -412,6 +412,20 @@ void Timeslider::RemoveAnnotatedFrame(int frame)
 	}
 }
 
+void Timeslider::SetAnnotatedFrames(const std::vector<int>& frames)
+{
+	m_AnnotatedFrames = frames;
+	/* Redraw */
+	update();
+}
+
+void Timeslider::SetAnnotatedFrames(std::vector<int>&& frames)
+{
+	m_AnnotatedFrames = std::move(frames);
+	/* Redraw */
+	update();
+}
+
 void Timeslider::ClearAnnotatedFrames()
 {
 	/* Clear All frames that were marked annotated */

--- a/src/VoidUi/Timeline/Timeslider.h
+++ b/src/VoidUi/Timeline/Timeslider.h
@@ -48,6 +48,8 @@ public:
 	void AddAnnotatedFrame(int frame);
 	void RemoveAnnotatedFrame(int frame);
 	void ClearAnnotatedFrames();
+	void SetAnnotatedFrames(const std::vector<int>& frames);
+	void SetAnnotatedFrames(std::vector<int>&& frame);
 
 	/**
 	 * Checks whether a given frame is in Playable range


### PR DESCRIPTION
### Fix: Marked frames Refresh
* Cleanup annotated markings when switching clips and load clip's annotation markings on the timeline.
