### PR TITLE
[VOID] Project: Standard Directory import | No ProgressBar

### DIFF
--- a/src/VoidUi/BaseWindow/PlayerWindow.cpp
+++ b/src/VoidUi/BaseWindow/PlayerWindow.cpp
@@ -414,7 +414,6 @@ void VoidMainWindow::Connect()
 
     /* Media Lister */
     connect(m_MediaLister, &VoidMediaLister::mediaChanged, this, &VoidMainWindow::SetMedia);
-    connect(m_MediaLister, &VoidMediaLister::mediaDropped, this, &VoidMainWindow::ImportDirectory);
     connect(m_MediaLister, &VoidMediaLister::playlistChanged, this, &VoidMainWindow::PlayMedia);
 
     /* Sequence */
@@ -441,11 +440,6 @@ void VoidMainWindow::ImportMedia(const MediaStruct& mstruct)
 
     /* Add to the Media Bridge */
     MBridge::Instance().AddMedia(mstruct);
-}
-
-void VoidMainWindow::ImportDirectory(const std::string& path)
-{
-    m_Bridge.ImportDirectory(path);
 }
 
 void VoidMainWindow::RegisterDocks()

--- a/src/VoidUi/BaseWindow/PlayerWindow.h
+++ b/src/VoidUi/BaseWindow/PlayerWindow.h
@@ -63,10 +63,6 @@ public:
 
     /* Reads Media Directory and Loads Media onto the components */
     void ImportMedia(const MediaStruct& mstruct);
-    /**
-     * Allows all the media in a directory to be imported into the player
-     */
-    void ImportDirectory(const std::string& path);
     void PlayMedia(const std::vector<SharedMediaClip>& items);
 
     SharedPlaybackSequence ActiveSequence() const { return m_Sequence; }

--- a/src/VoidUi/Media/MediaBridge.h
+++ b/src/VoidUi/Media/MediaBridge.h
@@ -52,7 +52,7 @@ public:
 
     void AddMedia(const std::string& filepath);
     void RemoveMedia(const std::vector<QModelIndex>& media);
-    void ImportDirectory(const std::string& directory) { m_Project->ImportDirectory(directory); }
+    void ImportDirectory(const std::string& directory, bool progressive = true) { m_Project->ImportDirectory(directory, progressive); }
 
     /**
      * Projects

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -84,7 +84,7 @@ void VoidMediaLister::dropEvent(QDropEvent* event)
             VOID_LOG_INFO("Dropped Media Directory: {0}", path);
 
             /* Emit the media dropped signal */
-            emit mediaDropped(path);
+            MBridge::Instance().ImportDirectory(path, false);
         }
     }
 }

--- a/src/VoidUi/Project/Project.h
+++ b/src/VoidUi/Project/Project.h
@@ -33,7 +33,7 @@ public:
     inline void PushCommand(QUndoCommand* command) { m_UndoStack->push(command); }
     inline QUndoStack* UndoStack() const { return m_UndoStack; }
 
-    void ImportDirectory(const std::string& directory);
+    void ImportDirectory(const std::string& directory, bool progressive = true);
 
     /**
      * The serialized string for the project can be used to construct the project from it
@@ -54,6 +54,14 @@ private: /* Methods */
     void DeleteProgressTask();
     void DeleteImporter();
     void CancelImporting();
+    /**
+     * Imports Directory with progress and allowing users to cancel the operation
+     */
+    void ImportDirectoryP(const std::string& path);
+    /**
+     * Imports Directory without any progress or allowing cancellations
+     */
+    void ImportDirectory_(const std::string& path);
 };
 
 VOID_NAMESPACE_CLOSE


### PR DESCRIPTION
### Feat: Import Media Without ProgressBar
* Added implementation to import media without progress bar.
* This is directly used when dragging-dropping media directories.
* Updated Drag-Drop on MediaLister to invoke MBridge::ImportDirectory without progressbar rather than relying on signal.