### PR TITLE
[VOID] FFmpegReader: Improved time for Processing

### DIFF
--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -4,6 +4,7 @@
 /* Internal */
 #include "FFmpegReader.h"
 #include "VoidCore/Logging.h"
+#include "VoidCore/Profiler.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -302,7 +303,10 @@ void FFmpegPixReader::ProcessInformation()
         for (unsigned int i = 0; i < formatContext->nb_streams; ++i)
         {
             if (formatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
-                vidStream = formatContext->streams[i]; break;
+            {
+                vidStream = formatContext->streams[i];
+                break;
+            }
         }
 
         /* This always has been 2 less than the total number of frames, need a bit more information here... */


### PR DESCRIPTION
### Fix: Improvement of Movie Media Import time.
* Improved processing time which was taken to read endframe and framerate from the movie file prior to constructing media.

* Previous average: 0.02 seconds (Debug Mode)
* Current average: 0.003 seconds (Debug Mode)

### Details:
* Importing a movie media on its own is quite fast and takes around 0.02 seconds, but this is quite slower with additional time over what is spent on Image sequence (0.00028) and when loading around 1000 files, this comes out to be 20 seconds.

* A better way to process information was needed to speed up media import when bulk importing.

### TODO: (For later)
* A custom metadata reader can be implemented based on movie atoms which can be even faster than this. But that needs a wide variety of media to be tested on before that can be done. (Something for when we have access to tons of different types of codes and movies).