### PR TITLE
[VOID] ScriptEditor: Minor Updates

### DIFF
--- a/src/VoidUi/ScriptEditor/ScriptEditor.cpp
+++ b/src/VoidUi/ScriptEditor/ScriptEditor.cpp
@@ -92,6 +92,10 @@ void PyScriptEditor::Build()
 
 void PyScriptEditor::Connect()
 {
+    /* Needed when queueing singals from thread to write on the output console */
+    qRegisterMetaType<QTextBlock>("QTextBlock");
+    qRegisterMetaType<QTextCursor>("QTextCursor");
+
     connect(m_ExecAllButton, &QPushButton::clicked, this, &PyScriptEditor::ExecuteAll);
     connect(m_InputConsole, &InputScriptConsole::execute, this, &PyScriptEditor::ExecuteAll);
 

--- a/src/VoidUi/ScriptEditor/ScriptEditor.h
+++ b/src/VoidUi/ScriptEditor/ScriptEditor.h
@@ -68,7 +68,7 @@ private: /* Methods */
      */
     inline bool PotentialStatement(const std::string& code) const
     { 
-        return code.find_first_of(" \t\n\r()[]{}.+-*/=<>!&|^,:") != std::string::npos;
+        return code.find_first_of(" \t\n\r{}+-*/=<>!&|^,:") != std::string::npos;
     }
 };
 


### PR DESCRIPTION
* Updated the cases for which py::exec can be invoked
* Registered QTextBlock | QTextCursor to get fix issue with queueing multiple outputs (threaded)

### Note:
The issue with python editor running threaded output correctly is still there and needs to be fixed.