### PR TITLE
[VOID] Cmake: Fix for windows build with playlist update

### DIFF
--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -102,8 +102,9 @@ if (WIN32)
         ../VoidObjects/Sequence/Track.h
         ../VoidObjects/Sequence/TrackItem.h
 
-        ../VoidObjects/Models/ProjectModel.h
         ../VoidObjects/Models/MediaModel.h
+        ../VoidObjects/Models/PlaylistModel.h
+        ../VoidObjects/Models/ProjectModel.h
         # TODO: Find a better way around this....
     )
 endif()


### PR DESCRIPTION
### Fix for Windows Build after Playlist Update
* Fixes:  error LNK2001: unresolved external symbol "public: static struct QMetaObject const voidplayer::PlaylistProxyModel::staticMetaObject" (?staticMetaObject@PlaylistProxyModel@voidplayer@@2UQMetaObject@@B)