### PR TITLE
[VOID] Playlist: Fixed compat and build warnings for Qt6

### DIFF
--- a/src/VoidUi/Playlist/Delegates/ListDelegate.h
+++ b/src/VoidUi/Playlist/Delegates/ListDelegate.h
@@ -22,8 +22,8 @@ public:
     void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
     QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
-    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const;
-    void setEditorData(QWidget* editor, const QModelIndex& index) const;
+    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+    void setEditorData(QWidget* editor, const QModelIndex& index) const override;
 };
 
 class PlaylistMediaItemDelegate : public QStyledItemDelegate

--- a/src/VoidUi/Playlist/Views/PlaylistView.cpp
+++ b/src/VoidUi/Playlist/Views/PlaylistView.cpp
@@ -93,7 +93,7 @@ void PlaylistView::dropEvent(QDropEvent* event)
     if (event->mimeData()->hasFormat(MimeTypes::MediaItem))
     {
         #if _QT6
-        QModelIndex index = indexAt(event->position());
+        QModelIndex index = indexAt(event->position().toPoint());
         #else
         QModelIndex index = indexAt(event->pos());
         #endif // _QT6


### PR DESCRIPTION
### Fix: Qt6 Compat Issues
* Fixed build error (using QPointF in QModelndex::indexAt)
* Fixed warnings from clang. not marking override to virtual functions.