### PR TITLE
[VOID] OpenEXRReader: Imf::getCompressionNameFromId deprecated

### DIFF
--- a/src/VoidCore/Readers/OpenEXRReader.cpp
+++ b/src/VoidCore/Readers/OpenEXRReader.cpp
@@ -173,10 +173,10 @@ const std::map<std::string, std::string> OpenEXRReader::Metadata() const
     m["height"] = std::to_string(height);
     m["channels"] = std::to_string(channelCount);
 
-    const Imf::Compression& compression = header.compression();
-    std::string compressionType;
-    Imf::getCompressionNameFromId(compression, compressionType);
-    m["compression"] = compressionType;
+    // const Imf::Compression& compression = header.compression();
+    // std::string compressionType;
+    // Imf::getCompressionNameFromId(compression, compressionType);
+    // m["compression"] = compressionType;
 
     /* Specific metadata */
     for (Imf::Header::ConstIterator it = header.begin(); it != header.end(); ++it)


### PR DESCRIPTION
### Build Fix:
* Imf::getCompressionNameFromId is removed from OpenEXR later versions
* Commenting change for now. Will move to internal implementation with more detailed insights later