### PR TITLE
[VOID] Default Icon Size across OS'

### DIFF
--- a/src/VoidUi/BaseWindow/TitleBar.cpp
+++ b/src/VoidUi/BaseWindow/TitleBar.cpp
@@ -72,12 +72,12 @@ void VoidTitleBar::Build()
     m_MinimizeButton = new QToolButton();
     m_MinimizeButton->setFixedSize(16, 16);
     m_MinimizeButton->setAutoRaise(true);
-    m_MinimizeButton->setIcon(IconForge::GetIcon(IconType::icon_minimize, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_MinimizeButton->setIcon(IconForge::GetIcon(IconType::icon_minimize, _DARK_COLOR(QPalette::Text, 150)));
 
     m_MaximizeButton = new QToolButton();
     m_MaximizeButton->setFixedSize(16, 16);
     m_MaximizeButton->setAutoRaise(true);
-    m_MaximizeButton->setIcon(IconForge::GetIcon(IconType::icon_square, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_MaximizeButton->setIcon(IconForge::GetIcon(IconType::icon_square, _DARK_COLOR(QPalette::Text, 150)));
 
     m_CloseButton = new CloseButton;
     m_CloseButton->setFixedSize(15, 15);

--- a/src/VoidUi/Dock/Docker.cpp
+++ b/src/VoidUi/Dock/Docker.cpp
@@ -168,7 +168,7 @@ void DockWidget::SetupOptions()
 {
 	/* Options Button */
 	m_PanelOptions = new MenuToolButton;
-	m_PanelOptions->setIcon(IconForge::GetIcon(IconType::icon_browse, _DARK_COLOR(QPalette::Text, 140), 18));
+	m_PanelOptions->setIcon(IconForge::GetIcon(IconType::icon_browse, _DARK_COLOR(QPalette::Text, 140)));
 	m_PanelOptions->setAutoRaise(true);
 	m_PanelOptions->setPopupMode(QToolButton::InstantPopup);
 

--- a/src/VoidUi/Engine/IconForge.h
+++ b/src/VoidUi/Engine/IconForge.h
@@ -21,6 +21,12 @@ VOID_NAMESPACE_OPEN
 #define _DARK_COLOR(x, y) palette().color(x).darker(y)
 #define _LIGHT_COLOR(x, y) palette().color(x).lighter(y)
 
+#ifdef __APPLE__
+constexpr int _default_size = 38;
+#else
+constexpr int _default_size = 18;
+#endif
+
 class IconForge
 {
 private:
@@ -31,8 +37,8 @@ public:
     QPixmap Pixmap(const IconType& icon, int size = 24, const QColor& color = Qt::black);
     QIcon Icon(const IconType& icon, int size = 24, const QColor& color = Qt::black);
 
-    static QPixmap GetPixmap(const IconType& icon, const QColor& color = Qt::black, int size = 26);
-    static QIcon GetIcon(const IconType& icon, const QColor& color = Qt::black, int size = 26);
+    static QPixmap GetPixmap(const IconType& icon, const QColor& color = Qt::black, int size = _default_size);
+    static QIcon GetIcon(const IconType& icon, const QColor& color = Qt::black, int size = _default_size);
 
 private: /* Members */  
     QString m_FontFamily;

--- a/src/VoidUi/Engine/IconForge.h
+++ b/src/VoidUi/Engine/IconForge.h
@@ -22,9 +22,9 @@ VOID_NAMESPACE_OPEN
 #define _LIGHT_COLOR(x, y) palette().color(x).lighter(y)
 
 #ifdef __APPLE__
-constexpr int _default_size = 38;
+static constexpr int _default_size = 38;
 #else
-constexpr int _default_size = 18;
+static constexpr int _default_size = 18;
 #endif
 
 class IconForge

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -127,7 +127,7 @@ void VoidMediaLister::Build()
 
     /* View Toggle Buttons */
     m_ListViewToggle = new HighlightToggleButton(this);
-    m_ListViewToggle->setIcon(IconForge::GetIcon(IconType::icon_lists, _DARK_COLOR(QPalette::Text, 150), 14));
+    m_ListViewToggle->setIcon(IconForge::GetIcon(IconType::icon_lists, _DARK_COLOR(QPalette::Text, 150)));
     m_ListViewToggle->setToolTip(
         ToolTipString(
             "Detailed List View",
@@ -136,7 +136,7 @@ void VoidMediaLister::Build()
     );
 
     m_ThumbnailViewToggle = new HighlightToggleButton(this);
-    m_ThumbnailViewToggle->setIcon(IconForge::GetIcon(IconType::icon_grid_view, _DARK_COLOR(QPalette::Text, 150), 14));
+    m_ThumbnailViewToggle->setIcon(IconForge::GetIcon(IconType::icon_grid_view, _DARK_COLOR(QPalette::Text, 150)));
     m_ThumbnailViewToggle->setToolTip(
         ToolTipString(
             "Thumbnail View",
@@ -148,7 +148,7 @@ void VoidMediaLister::Build()
     m_ViewButtonGroup->addButton(m_ThumbnailViewToggle, 1);
 
     m_SortButton = new HighlightToggleButton(this);
-    m_SortButton->setIcon(IconForge::GetIcon(IconType::icon_sort_by_alpha, _DARK_COLOR(QPalette::Text, 150), 14));
+    m_SortButton->setIcon(IconForge::GetIcon(IconType::icon_sort_by_alpha, _DARK_COLOR(QPalette::Text, 150)));
     m_SortButton->setFixedWidth(26);
     m_SortButton->setToolTip(
         ToolTipString(

--- a/src/VoidUi/Media/MediaSearchBar.cpp
+++ b/src/VoidUi/Media/MediaSearchBar.cpp
@@ -29,7 +29,7 @@ void MediaSearchBar::Setup()
     setPlaceholderText("Search");
 
     /* Add the Clear Action */
-    m_ClearAction = new QAction(IconForge::GetIcon(IconType::icon_close, _DARK_COLOR(QPalette::Text, 150), 16), "", this);
+    m_ClearAction = new QAction(IconForge::GetIcon(IconType::icon_close, _DARK_COLOR(QPalette::Text, 150)), "", this);
     m_ClearAction->setToolTip("Clears Search field");
 
     /* Add at the end */

--- a/src/VoidUi/Playlist/PlayLister.cpp
+++ b/src/VoidUi/Playlist/PlayLister.cpp
@@ -102,10 +102,10 @@ void VoidPlayLister::Build()
     );
 
     m_CreateButton = new QPushButton;
-    m_CreateButton->setIcon(IconForge::GetIcon(IconType::icon_library_add, palette().color(QPalette::Text).darker(150), 16));
+    m_CreateButton->setIcon(IconForge::GetIcon(IconType::icon_library_add, palette().color(QPalette::Text).darker(150)));
     m_CreateButton->setFixedWidth(26);
     m_DeleteButton = new QPushButton;
-    m_DeleteButton->setIcon(IconForge::GetIcon(IconType::icon_delete, palette().color(QPalette::Text).darker(150), 16));
+    m_DeleteButton->setIcon(IconForge::GetIcon(IconType::icon_delete, palette().color(QPalette::Text).darker(150)));
     m_DeleteButton->setFixedWidth(26);
 
     m_OptionsLayout->addWidget(m_SearchBar);

--- a/src/VoidUi/ScriptEditor/ScriptEditor.cpp
+++ b/src/VoidUi/ScriptEditor/ScriptEditor.cpp
@@ -50,23 +50,23 @@ void PyScriptEditor::Build()
     m_ButtonLayout = new QHBoxLayout();
 
     m_ExecAllButton = new QPushButton;
-    m_ExecAllButton->setIcon(IconForge::GetIcon(IconType::icon_play_arrow, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_ExecAllButton->setIcon(IconForge::GetIcon(IconType::icon_play_arrow, _DARK_COLOR(QPalette::Text, 150)));
     m_ExecAllButton->setToolTip(ToolTipString("Execute", "Execute all code.").c_str());
 
     m_ExecSelectionButton = new QPushButton;
-    m_ExecSelectionButton->setIcon(IconForge::GetIcon(IconType::icon_segment, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_ExecSelectionButton->setIcon(IconForge::GetIcon(IconType::icon_segment, _DARK_COLOR(QPalette::Text, 150)));
     m_ExecSelectionButton->setToolTip(ToolTipString("Execute Selected", "Execute selected code.").c_str());
 
     m_SaveScriptButton = new QPushButton;
-    m_SaveScriptButton->setIcon(IconForge::GetIcon(IconType::icon_save, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_SaveScriptButton->setIcon(IconForge::GetIcon(IconType::icon_save, _DARK_COLOR(QPalette::Text, 150)));
     m_SaveScriptButton->setToolTip(ToolTipString("Save Script", "Saves current Script.").c_str());
 
     m_LoadScriptButton = new QPushButton;
-    m_LoadScriptButton->setIcon(IconForge::GetIcon(IconType::icon_file_open, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_LoadScriptButton->setIcon(IconForge::GetIcon(IconType::icon_file_open, _DARK_COLOR(QPalette::Text, 150)));
     m_LoadScriptButton->setToolTip(ToolTipString("Open Script", "Open a python script.").c_str());
 
     m_ClearOutputButton = new QPushButton;
-    m_ClearOutputButton->setIcon(IconForge::GetIcon(IconType::icon_computer_cancel, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_ClearOutputButton->setIcon(IconForge::GetIcon(IconType::icon_computer_cancel, _DARK_COLOR(QPalette::Text, 150)));
     m_ClearOutputButton->setToolTip(ToolTipString("Clear Output", "Clears the output window.").c_str());
 
     m_ButtonLayout->addWidget(m_ExecAllButton);

--- a/src/VoidUi/ScriptEditor/ScriptEditor.cpp
+++ b/src/VoidUi/ScriptEditor/ScriptEditor.cpp
@@ -111,11 +111,15 @@ void PyScriptEditor::Connect()
 
 void PyScriptEditor::Setup()
 {
-    QFont courier("Courier");
-    m_InputConsole->setFont(courier);
+    #ifdef __APPLE__
+    QFont scriptf("Arial");
+    #else
+    QFont scriptf("Courier");
+    #endif
+    m_InputConsole->setFont(scriptf);
 
     /* Outconsole formatting */
-    m_OutputConsole->setFont(courier);
+    m_OutputConsole->setFont(scriptf);
     m_OutputConsole->setReadOnly(true);
 
     QPalette p = m_OutputConsole->palette();

--- a/src/VoidUi/Timeline/Timeline.cpp
+++ b/src/VoidUi/Timeline/Timeline.cpp
@@ -126,7 +126,7 @@ void Timeline::Build()
 
 	/* Fullscreen Button */
 	m_FullscreenButton = new QPushButton;
-	m_FullscreenButton->setIcon(IconForge::GetIcon(IconType::icon_pageless, _DARK_COLOR(QPalette::Text, 150), 18));
+	m_FullscreenButton->setIcon(IconForge::GetIcon(IconType::icon_pageless, _DARK_COLOR(QPalette::Text, 150)));
 	m_FullscreenButton->setFlat(true);
 	m_FullscreenButton->setFixedWidth(SMALL_BUTTON_WIDTH);
 	m_FullscreenButton->setToolTip(ToolTipString("Fullscreen", "Plays media in fullscreen.").c_str());

--- a/src/VoidUi/Timeline/TimelineElements.cpp
+++ b/src/VoidUi/Timeline/TimelineElements.cpp
@@ -75,7 +75,7 @@ void LoopTypeButton::Build()
 
 void LoopTypeButton::Update()
 {
-	setIcon(IconForge::GetIcon(m_LoopState.at(m_LoopType).icon, _DARK_COLOR(QPalette::Text, 140), 20));
+	setIcon(IconForge::GetIcon(m_LoopState.at(m_LoopType).icon, _DARK_COLOR(QPalette::Text, 140)));
 }
 
 /* }}} */

--- a/src/VoidUi/Toolkit/AnnotationController.cpp
+++ b/src/VoidUi/Toolkit/AnnotationController.cpp
@@ -53,30 +53,30 @@ void AnnotationsController::Build()
 
     /* Buttons */
     m_PointerButton = new HighlightToggleButton;
-    m_PointerButton->setIcon(IconForge::GetIcon(IconType::icon_arrow_selector, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_PointerButton->setIcon(IconForge::GetIcon(IconType::icon_arrow_selector, _DARK_COLOR(QPalette::Text, 150)));
     m_PointerButton->setToolTip("<b>Pointer</b>");
 
     m_BrushButton = new HighlightToggleButton;
-    m_BrushButton->setIcon(IconForge::GetIcon(IconType::icon_brush, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_BrushButton->setIcon(IconForge::GetIcon(IconType::icon_brush, _DARK_COLOR(QPalette::Text, 150)));
     m_BrushButton->setToolTip(ToolTipString("Brush Tool", "Annotate free hand using the Brush tool.").c_str());
 
     m_TextButton = new HighlightToggleButton;
-    m_TextButton->setIcon(IconForge::GetIcon(IconType::icon_title, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_TextButton->setIcon(IconForge::GetIcon(IconType::icon_title, _DARK_COLOR(QPalette::Text, 150)));
     m_TextButton->setToolTip(ToolTipString("Text Tool", "Annotate by typing where clicked.").c_str());
 
     m_EraserButton = new HighlightToggleButton;
-    m_EraserButton->setIcon(IconForge::GetIcon(IconType::icon_ink_eraser, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_EraserButton->setIcon(IconForge::GetIcon(IconType::icon_ink_eraser, _DARK_COLOR(QPalette::Text, 150)));
     m_EraserButton->setToolTip(ToolTipString("Eraser Tool", "Erase Text Characters or Annotation Stroke by dragging over.").c_str());
 
     m_ClearButton = new QPushButton;
-    m_ClearButton->setIcon(IconForge::GetIcon(IconType::icon_delete, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_ClearButton->setIcon(IconForge::GetIcon(IconType::icon_delete, _DARK_COLOR(QPalette::Text, 150)));
     m_ClearButton->setToolTip(ToolTipString("Delete Annotation", "Deletes the annotation from the current frame.").c_str());
 
     m_ColorButton = new ColorSelectionButton({255, 255, 255}, this);
     m_ColorButton->setToolTip(ToolTipString("Color Selector", "Selects Color for Annotation.").c_str());
 
     m_SizeAdjuster = new QPushButton;
-    m_SizeAdjuster->setIcon(IconForge::GetIcon(IconType::icon_adjust, _DARK_COLOR(QPalette::Text, 150), 18));
+    m_SizeAdjuster->setIcon(IconForge::GetIcon(IconType::icon_adjust, _DARK_COLOR(QPalette::Text, 150)));
     m_SizeAdjuster->setToolTip(ToolTipString("Adjust Size", "Adjust size of the Brush/Eraser.").c_str());
 
     /* Add to the button group */

--- a/src/VoidUi/Toolkit/ControlBar.cpp
+++ b/src/VoidUi/Toolkit/ControlBar.cpp
@@ -126,7 +126,7 @@ void ControlBar::Build()
 
     /* Annotation */
     m_AnnotationButton = new HighlightToggleButton;
-    m_AnnotationButton->setIcon(IconForge::GetIcon(IconType::icon_draw, _DARK_COLOR(QPalette::Text, 140), 18));
+    m_AnnotationButton->setIcon(IconForge::GetIcon(IconType::icon_draw, _DARK_COLOR(QPalette::Text, 140)));
     m_AnnotationButton->setFixedWidth(26);
     m_AnnotationButton->setToolTip(ToolTipString("Annotations Toolkit", "Toggles Annotation tools for the Viewer.").c_str());
 


### PR DESCRIPTION
### Fix: Standardize Icons for use across OS'
* Windows and Linux work fine with 18x18 Icons while macOS shows icons from 28x28 to 38x38 better.

### Additional Fix:
* MacOS does not have Courier installed by default, switching to Arial on MacOS for Script editor unless a better alternative is found.