### PR TITLE
[VOID] Binding: voidpy -> vortex

### DIFF
--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -9,10 +9,10 @@ set(SOURCES
 )
 
 # Create Python Module
-pybind11_add_module(voidpy "${SOURCES}")
+pybind11_add_module(vortex "${SOURCES}")
 
 target_link_libraries(
-    voidpy
+    vortex
     PRIVATE
     VoidCore
     VoidUi
@@ -22,5 +22,5 @@ target_link_libraries(
 
 # Qt6 needs OpenGLWidgets be included/linked separately
 if (QT_MAJOR_VERSION EQUAL 6)
-    target_link_libraries(voidpy PRIVATE Qt::OpenGLWidgets)
+    target_link_libraries(vortex PRIVATE Qt::OpenGLWidgets)
 endif()

--- a/src/Bindings/Module.cpp
+++ b/src/Bindings/Module.cpp
@@ -19,7 +19,7 @@ namespace bindings {
 
 } // namespace bindings
 
-PYBIND11_MODULE(voidpy, m)
+PYBIND11_MODULE(vortex, m)
 {
     m.doc() = "Void Python Binding";
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,7 +151,7 @@ endif()
 # )
 
 # Install Libraries and Binaries
-install(TARGETS VoidCore VoidObjects VoidRenderer VoidUi VOID voidpy
+install(TARGETS VoidCore VoidObjects VoidRenderer VoidUi VOID vortex
     EXPORT VOIDTargets
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib

--- a/src/VoidCore/PyExecutor.cpp
+++ b/src/VoidCore/PyExecutor.cpp
@@ -43,7 +43,7 @@ void PyExecutor::SetOutputCallback(std::function<void(const std::string&)> callb
 void PyExecutor::RedirectStdout()
 {
     py::module sys = py::module::import("sys");
-    py::class_<py::object> redirector(py::module::import("__main__"), "VoidPyStdout");
+    py::class_<py::object> redirector(py::module::import("__main__"), "VortexStdout");
 
     /**
      * Define the stdout methods


### PR DESCRIPTION
### Naming the Python Binding
* Binding which was initially called as voidpy is now named as vortex which kind of relates to VOID.

```
import vortex

vortex.core
vortex.ui
```

is the updated API