### PR TITLE
[VOID] MediaView: Added support for dragging multiple items from view

### DIFF
--- a/src/VoidUi/Media/MediaBridge.h
+++ b/src/VoidUi/Media/MediaBridge.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 /* Qt */
+#include <QByteArray>
 #include <QObject>
 #include <QUndoGroup>
 #include <QUndoStack>
@@ -15,6 +16,7 @@
 /* Internal */
 #include "Definition.h"
 #include "VoidObjects/Media/MediaClip.h"
+#include "VoidObjects/Sequence/Track.h"
 #include "VoidObjects/Models/MediaModel.h"
 #include "VoidObjects/Models/ProjectModel.h"
 #include "VoidUi/Project/Project.h"
@@ -56,10 +58,14 @@ public:
     void AddMedia(const std::string& filepath);
     void RemoveMedia(const QModelIndex& index);
     void RemoveMedia(const std::vector<QModelIndex>& indexes);
+
     void AddToPlaylist(const QModelIndex& index);
     void AddToPlaylist(const std::vector<QModelIndex>& indexes);
     void AddToPlaylist(const QModelIndex& index, Playlist* playlist);
     void AddToPlaylist(const std::vector<QModelIndex>& indexes, Playlist* playlist);
+    void AddToPlaylist(QByteArray& data);
+    void AddToPlaylist(QByteArray& data, Playlist* playlist);
+
     void RemoveFromPlaylist(const QModelIndex& index);
     void RemoveFromPlaylist(const std::vector<QModelIndex>& indexes);
     void RemoveFromPlaylist(const QModelIndex& index, Playlist* playlist);
@@ -111,6 +117,18 @@ public:
     inline SharedMediaClip MediaAt(int row, int column) const { return m_Project->MediaAt(row, column); }
     inline SharedMediaClip PlaylistMediaAt(const QModelIndex& index) const { return m_Project->PlaylistMediaAt(index); }
     inline SharedMediaClip PlaylistMediaAt(int row, int column) const { return m_Project->PlaylistMediaAt(row, column); }
+
+    /**
+     * Packs the media indexes from the project/playlist into a byteArray which can be sent
+     * over to other components this data is packed for use in drag-drop operations and any other places required
+     */
+    QByteArray PackIndexes(const std::vector<QModelIndex>& indexes) const;
+    /* Unpacks incoming ByteArray stream to fetch media based on the indexes from the current project */
+    std::vector<SharedMediaClip> UnpackProjectMedia(QByteArray& data) const;
+    /* Unpacks incoming ByteArray stream to fetch media based on the indexes from the current active playlist */
+    std::vector<SharedMediaClip> UnpackPlaylistMedia(QByteArray& data) const;
+    /* Creates a track with the provided set of media */
+    SharedPlaybackTrack AsTrack(const std::vector<SharedMediaClip>& media) const;
 
     /* Push an Undo Command on to the stack */
     void PushCommand(QUndoCommand* command);

--- a/src/VoidUi/Player/PlayerWidget.h
+++ b/src/VoidUi/Player/PlayerWidget.h
@@ -76,6 +76,7 @@ public:
 
     /* Loads a Playable Track on the Player */
     void Load(const SharedPlaybackTrack& track);
+    void Load(const SharedPlaybackTrack& track, const PlayerViewBuffer& buffer);
 
     /* Load a Sequence to be played on the Player */
     void Load(const SharedPlaybackSequence& sequence);
@@ -104,11 +105,12 @@ public:
 
     /**
      * Sets the provided viewer buffer on the player
+     * @param buffer: The play buffer to set on the viewer
      */
-    void SetViewBuffer(const PlayerViewBuffer& buffer);
+    void ResetViewBuffer(const PlayerViewBuffer& buffer);
 
     inline void Refresh() { SetFrame(m_Timeline->Frame()); }
-    inline void ResetCacheMedia() { m_CacheProcessor.SetMedia(m_ActiveViewBuffer->GetMediaClip()); }
+    void ResetCacheMedia();
     void CacheBuffer();
 
     /* Zoom on the Viewport */

--- a/src/VoidUi/Playlist/Views/PlaylistMediaView.cpp
+++ b/src/VoidUi/Playlist/Views/PlaylistMediaView.cpp
@@ -5,10 +5,11 @@
 #include <QByteArray>
 #include <QDataStream>
 #include <QDrag>
+#include <QDragEnterEvent>
 #include <QIODevice>
 #include <QMenu>
 #include <QMimeData>
-#include <QDragEnterEvent>
+#include <QPainter>
 
 /* Internal */
 #include "PlaylistMediaView.h"
@@ -54,23 +55,36 @@ PlaylistMediaView::~PlaylistMediaView()
 
 void PlaylistMediaView::startDrag(Qt::DropActions supportedActions)
 {
-    QModelIndex index = currentIndex();
-    if (!index.isValid())
+    std::vector<QModelIndex> indexes = SelectedIndexes();
+    if (indexes.empty())
         return;
 
     QMimeData* data = new QMimeData();
-
-    QByteArray transferData;
-    QDataStream stream(&transferData, QIODevice::WriteOnly);
-    stream << index.row() << index.column();
-
-    data->setData(MimeTypes::PlaylistItem, transferData);
+    data->setData(MimeTypes::PlaylistItem, _MediaBridge.PackIndexes(indexes));
 
     QDrag* drag = new QDrag(this);
     drag->setMimeData(data);
-    QPixmap p = index.data(static_cast<int>(MediaModel::MRoles::Thumbnail)).value<QPixmap>();
-    drag->setPixmap(p.scaledToWidth(100, Qt::SmoothTransformation));
 
+    /* Stacked pixmaps */
+    const int count = std::min(static_cast<int>(indexes.size()), 4);
+    const int thumbsize = 100;
+    const int offset = 10;
+
+    QSize canvas(thumbsize + offset * (count - 1), thumbsize + offset * (count - 1));
+
+    QPixmap stack(canvas);
+    stack.fill(Qt::transparent);
+
+    QPainter painter(&stack);
+    for (int i = 0; i < count; ++i)
+    {
+        QPoint pos(i * offset, i * offset);
+        QPixmap p = indexes.at(i).data(static_cast<int>(MediaModel::MRoles::Thumbnail)).value<QPixmap>();
+        painter.drawPixmap(pos, p.scaled(thumbsize, thumbsize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+    }
+    painter.end();
+
+    drag->setPixmap(stack);
     drag->exec();
 }
 
@@ -100,20 +114,7 @@ void PlaylistMediaView::dropEvent(QDropEvent* event)
             return;
 
         QByteArray data = event->mimeData()->data(MimeTypes::MediaItem);
-
-        /* Read Input data */
-        QDataStream stream(&data, QIODevice::ReadOnly);
-        int row, column;
-        stream >> row >> column;
-
-        /**
-         * Media from the Media Bridge
-         * The media is always retrieved from the active project
-         * the assumption is that a drag-drop event would always happen when the project is active
-         */
-        SharedMediaClip media = _MediaBridge.MediaAt(row, column);
-
-        playlist->AddMedia(media);
+        _MediaBridge.AddToPlaylist(data, playlist);
     }
 }
 

--- a/src/VoidUi/Playlist/Views/PlaylistView.cpp
+++ b/src/VoidUi/Playlist/Views/PlaylistView.cpp
@@ -107,18 +107,7 @@ void PlaylistView::dropEvent(QDropEvent* event)
             return;
 
         QByteArray data = event->mimeData()->data(MimeTypes::MediaItem);
-        
-        /* Read Input data */
-        QDataStream stream(&data, QIODevice::ReadOnly);
-        int row, column;
-        stream >> row >> column;
-        
-        /**
-         * Media from the Media Bridge
-         * The media is always retrieved from the active project
-         * the assumption is that a drag-drop event would always happen when the project is active
-         */
-        _MediaBridge.AddToPlaylist(_MediaBridge.DataModel()->index(row, column), playlist);
+        _MediaBridge.AddToPlaylist(data, playlist);
     }
 }
 


### PR DESCRIPTION
* Updated Media View to select and drag multiple media items.
* Updated Playlist Media View to select and drag multiple items.
* Updated Playlist View to accept incoming media through bytedata and add to the selected/active or dragged upon playlist.
* Updated Player widget to decompose incoming bytedata through media bridge and set dropped media on player.
* Updated Metadata viewer to decompose incoming data through media bride and show metadata for the first entity always.