### PR TITLE
[VOID] Playlist Serialization

### DIFF
--- a/src/VoidObjects/Playlist/Playlist.h
+++ b/src/VoidObjects/Playlist/Playlist.h
@@ -15,13 +15,18 @@
 
 VOID_NAMESPACE_OPEN
 
+/* Forward Decl for Project as the parent entity */
+namespace Core {
+    class Project;
+} // namespace Core
+
 class VOID_API Playlist : public VoidObject
 {
     Q_OBJECT
 
 public:
-    Playlist(const std::string& name, QObject* parent = nullptr);
-    Playlist(QObject* parent = nullptr);
+    Playlist(const std::string& name, Core::Project* parent);
+    Playlist(Core::Project* parent);
     ~Playlist();
 
     inline bool Active() const { return m_Active; }
@@ -43,6 +48,12 @@ public:
     std::string Name() const { return m_Name; }
     void SetName(const std::string& name) { m_Name = name; }
 
+    void Serialize(rapidjson::Value& out, rapidjson::Document::AllocatorType& allocator) const override;
+    void Serialize(std::ostream& out) const override;
+    void Deserialize(const rapidjson::Value& in) override;
+    void Deserialize(std::istream& in) override;
+    inline const char* TypeName() const override { return "Playlist"; }
+
 signals:
     void updated(const Playlist*);
 
@@ -51,6 +62,7 @@ protected: /* Members */
     std::string m_Name;
     bool m_Modified;
     bool m_Active;
+    Core::Project* m_Project;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Project/Project.h
+++ b/src/VoidObjects/Project/Project.h
@@ -64,7 +64,7 @@ public:
     void Serialize(std::ostream& out) const override;
     void Deserialize(const rapidjson::Value& in) override;
     void Deserialize(std::istream& in) override;
-    const char* TypeName() const override { return "Project"; }
+    inline const char* TypeName() const override { return "Project"; }
     
     /**
      * Serialize the Project into a string which can be saved anywhere

--- a/src/VoidUi/Media/MediaBridge.cpp
+++ b/src/VoidUi/Media/MediaBridge.cpp
@@ -498,6 +498,7 @@ void MBridge::Load(const std::string& path)
     m_Project->SetSavePath(path);
 
     emit projectCreated(m_Project);
+    emit updated();
 }
 
 bool MBridge::CloseProject(bool force)
@@ -523,6 +524,8 @@ bool MBridge::CloseProject(bool force)
     else
         SetCurrentProject(m_Projects->index(row == 0 ? ++row : --row, 0));
 
+    emit updated();
+
     return true;
 }
 
@@ -547,6 +550,8 @@ bool MBridge::CloseProject(Project* project, bool force)
 
     if (create)
         NewProject();
+
+    emit updated();
 
     return true;
 }

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -256,6 +256,7 @@ void VoidMediaLister::Connect()
         RebuildPlaylistMenu();
     });
     connect(&_MediaBridge, &MBridge::playlistCreated, this, &VoidMediaLister::RebuildPlaylistMenu);
+    connect(&_MediaBridge, &MBridge::updated, this, &VoidMediaLister::RebuildPlaylistMenu);
 
     /* Shortcut */
     connect(m_DeleteShortcut, &QShortcut::activated, this, &VoidMediaLister::RemoveSelectedMedia);


### PR DESCRIPTION
## Feat: Serialize Contents of the Playlist in the Project
* Playlist is included in the serialized project.
* Added playlist serialization methods to include references to media clip indexes from the project.
* MediaLister is connected to updated signal from the MediaBridge.