### PR TITLE
[VOID] ViewerBuffer Updates: Return BufferData

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -4,6 +4,14 @@
 /* Internal */
 #include "VoidApplication/Engine/Engine.h"
 
+#ifdef _VOID_PLATFORM_WINDOWS
+extern "C" 
+{
+    __declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif // _VOID_PLATFORM_WINDOW
+
 int main(int argc, char* argv[])
 {
     VOID_NAMESPACE::VoidEngine engine;

--- a/src/VoidCore/Media/Media.cpp
+++ b/src/VoidCore/Media/Media.cpp
@@ -181,6 +181,15 @@ void Media::ProcessMovie()
     m_Type = Media::Type::MOVIE;
 }
 
+std::size_t Media::FrameSize()
+{
+    if (m_Framesize)
+        return m_Framesize;
+
+    m_Framesize = FirstImage()->FrameSize();
+    return m_Framesize;
+}
+
 void Media::ClearCache()
 {
     for (Frame& f : m_Mediaframes)

--- a/src/VoidCore/Media/Media.h
+++ b/src/VoidCore/Media/Media.h
@@ -107,7 +107,7 @@ public:
     inline Frame LastFrameData() const { return GetFrame(m_LastFrame); }
 
     inline SharedPixels Image(v_frame_t frame, bool cached = true) { return GetFrame(frame).Image(cached); }
-    inline std::size_t FrameSize() { return Image(m_FirstFrame)->FrameSize(); }
+    std::size_t FrameSize();
 
     inline SharedPixels FirstImage() { return Image(m_FirstFrame); }
     inline SharedPixels LastImage() { return Image(m_LastFrame); }
@@ -138,6 +138,7 @@ protected: /* Members */
     v_frame_t m_FirstFrame, m_LastFrame;
     int m_Samplerate;
     double m_Framerate;
+    std::size_t m_Framesize = {0};
 
     Type m_Type;
     std::vector<Frame> m_Mediaframes;

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -79,7 +79,7 @@ void TrackItem::UncacheFrame(v_frame_t frame)
         m_Media->UncacheFrame(f);
 }
 
-SharedPixels TrackItem::GetImage(const v_frame_t frame)
+SharedPixels TrackItem::Image(const v_frame_t frame)
 {
     /* Update the frame value with the offset so that we match the original media range */
     v_frame_t f = frame + m_Offset;

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -64,7 +64,7 @@ void TrackItem::Cache()
 void TrackItem::CacheFrame(v_frame_t frame)
 {
     /* Update the frame value with the offset so that we match the original media range */
-    v_frame_t f = frame + m_Offset;
+    const v_frame_t f = frame + m_Offset;
 
     if (m_Media->Contains(f))
         m_Media->CacheFrame(f);
@@ -73,7 +73,7 @@ void TrackItem::CacheFrame(v_frame_t frame)
 void TrackItem::UncacheFrame(v_frame_t frame)
 {
     /* Update the frame value with the offset so that we match the original media range */
-    v_frame_t f = frame + m_Offset;
+    const v_frame_t f = frame + m_Offset;
 
     if (m_Media->Contains(f))
         m_Media->UncacheFrame(f);

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -58,7 +58,7 @@ public:
 
     void CacheFrame(v_frame_t frame);
     void UncacheFrame(v_frame_t frame);
-    inline size_t FrameSize() { return m_Media->FrameSize(); }
+    inline std::size_t FrameSize() { return m_Media->FrameSize(); }
 
     /* Getters */
     inline v_frame_t GetOffset() const { return m_Offset; }

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -67,7 +67,7 @@ public:
     /**
      * Retrieves the image pointer from the media for a frame which has to be offsetted by the current offset
      */
-    SharedPixels GetImage(const v_frame_t frame);
+    SharedPixels Image(const v_frame_t frame);
 
     inline v_frame_t StartFrame() const { return m_StartFrame; }
     inline v_frame_t EndFrame() const { return m_EndFrame; }

--- a/src/VoidRenderer/Core/FontAtlas.h
+++ b/src/VoidRenderer/Core/FontAtlas.h
@@ -6,6 +6,7 @@
 
 /* STD */
 #include <unordered_map>
+#include <vector>
 
 /* Freetype */
 #include <ft2build.h>
@@ -79,7 +80,7 @@ private: /* Members */
     /**
      * Going with a vector over a map, due to the cache benefits
      * Plus the fonts used is just one at the moment, the varying factor is the size
-     * which is not more than 10, so all of the fonts can be fetched in a single cache line
+     * which is not more than 10, so all of the fonts can be fetched in a few cache lines
      */
     std::vector<FontAtlas> m_Fonts;
 };

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -324,7 +324,7 @@ void Player::Render(int frame)
 //      * based on where the trackitem is present in the sequence
 //      */
 //     m_ActiveViewBuffer->EnsureCached(frame);
-//     SharedPixels data = item->GetImage(frame);
+//     SharedPixels data = item->Image(frame);
 
 //     /* A standard frame which is available for any trackitem/media */
 //     if (data)

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -52,8 +52,16 @@ void Player::SetMedia(const SharedMediaClip& media)
 
 void Player::SetMedia(const std::vector<SharedMediaClip>& media)
 {
+    /* Reset timeline | Renderer */
+    m_Timeline->Clear();
+    m_Renderer->Clear();
+
     m_ActiveViewBuffer->Set(media);
-    SetTrack(m_ActiveViewBuffer->ActiveTrack());
+    m_Timeline->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+    Render(m_Timeline->Frame());
+
+    m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
+    m_ControlBar->SetZoom(m_Renderer->Zoom());
 }
 
 void Player::SetMedia(const std::vector<SharedMediaClip>& media, const PlayerViewBuffer& buffer)

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -469,6 +469,11 @@ void Player::SetComparisonMode(int mode)
     Refresh();
 }
 
+void Player::ToggleChannels(int channel)
+{
+    m_ControlBar->ToggleChannels(channel);
+}
+
 void Player::SetBlendMode(const int mode)
 {
     /* Update the blend mode */

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -34,11 +34,11 @@ void Player::SetMedia(const SharedMediaClip& media)
 
     /* Update what's currently being played on the viewer buffer */
     m_ActiveViewBuffer->Set(media);
-    
+
     m_Timeline->SetRange(media->FirstFrame(), media->LastFrame());
     m_Timeline->SetAnnotatedFrames(std::move(media->AnnotatedFrames()));
 
-    SetMediaFrame(m_Timeline->Frame());
+    Render(m_Timeline->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -94,7 +94,7 @@ void Player::SetMedia(const SharedMediaClip& media, const PlayerViewBuffer& buff
     inactive->SetActive(false);
 
     SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
-    SetMediaFrame(m_Timeline->Frame());
+    Render(m_Timeline->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -110,7 +110,7 @@ void Player::SetTrack(const SharedPlaybackTrack& track)
     m_ActiveViewBuffer->Set(track);
 
     m_Timeline->SetRange(track->StartFrame(), track->EndFrame());
-    SetTrackFrame(m_Timeline->Frame());
+    Render(m_Timeline->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -139,7 +139,7 @@ void Player::SetTrack(const SharedPlaybackTrack& track, const PlayerViewBuffer& 
     inactive->SetActive(false);
 
     SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
-    SetTrackFrame(m_Timeline->Frame());
+    Render(m_Timeline->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -155,7 +155,7 @@ void Player::SetSequence(const SharedPlaybackSequence& sequence)
     m_ActiveViewBuffer->Set(sequence);
 
     m_Timeline->SetRange(sequence->StartFrame(), sequence->EndFrame());
-    SetSequenceFrame(m_Timeline->Frame());
+    Render(m_Timeline->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -169,7 +169,7 @@ void Player::SetPlaylist(Playlist* playlist)
     /* Update what is being played on the Active Viewer Buffer */
     m_ActiveViewBuffer->SetPlaylist(playlist);
     SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
-    SetMediaFrame(m_Timeline->Frame());
+    Render(m_Timeline->Frame());
 }
 
 void Player::SetFrame(int frame)
@@ -181,16 +181,7 @@ void Player::SetFrame(int frame)
     if (Comparing())
         return CompareMediaFrame(frame);
 
-    /**
-     * Check what do we want to play
-     * if currently playing component on the Active ViewerBuffer is Sequence, meaning that was latest set on it
-     */
-    if (m_ActiveViewBuffer->PlayingComponent() == ViewerBuffer::PlayableComponent::Sequence)
-        return SetSequenceFrame(frame);
-    else if (m_ActiveViewBuffer->PlayingComponent() == ViewerBuffer::PlayableComponent::Track)
-        return SetTrackFrame(frame);
-
-    return SetMediaFrame(frame);
+    return Render(frame);
 }
 
 void Player::NextMedia()
@@ -236,14 +227,14 @@ void Player::Connect()
         state == Timeline::PlayState::FORWARDS ? NextMedia() : PreviousMedia();
     });
     connect(m_Timeline, &Timeline::seeked, this, [this](v_frame_t frame)
-    { 
+    {
         m_AudioDecoder.SeekTo((double)frame / m_Timeline->Framerate());
     });
 
     /* ControlBar */
     connect(m_ControlBar, &ControlBar::viewerBufferSwitched, this, &Player::ResetViewBuffer);
     connect(m_ControlBar, &ControlBar::comparisonModeChanged, this, &Player::SetComparisonMode);
-    connect(m_ControlBar, &ControlBar::blendModeChanged, this, &Player::SetBlendMode); 
+    connect(m_ControlBar, &ControlBar::blendModeChanged, this, &Player::SetBlendMode);
 }
 
 void Player::PauseCache()
@@ -280,131 +271,139 @@ void Player::ClearCache()
     m_ViewBufferB.ClearCache();
 }
 
-void Player::SetSequenceFrame(int frame)
+void Player::Render(int frame)
 {
-    /* Ensure We have Valid sequence with media to process before setting the frame */
-    if (m_ActiveViewBuffer->GetSequence()->IsEmpty())
-        return;
+    BufferData data = m_ActiveViewBuffer->MData(frame);
 
-    /* Try to get the trackItem at a given frame in the current sequence */
-    /**
-     * Instead of fetching the image data directly from the sequence, fetch the trackItem at any given point
-     * This for the time being (till we have a best case O(1) for finding a track item at any given available)
-     * is a better approach as the nearest frame logic causes a recursion which could end up looping over the same entity
-     * Multiple times in order to find the media first, then it's nearest frame and then the image data for that frame which is very costly
-     */
-    SharedTrackItem item = m_ActiveViewBuffer->TrackItem(frame);
-
-    if (item)
-        SetTrackItemFrame(item, frame);
-}
-
-void Player::SetTrackFrame(int frame)
-{
-    /* Ensure We have Valid sequence with media to process before setting the frame */
-    if (m_ActiveViewBuffer->GetTrack()->IsEmpty())
-        return;
-
-    /* Try to get the trackItem at a given frame in the current sequence */
-    /**
-     * Instead of fetching the image data directly from the sequence, fetch the trackItem at any given point
-     * This for the time being (till we have a best case O(1) for finding a track item at any given available)
-     * is a better approach as the nearest frame logic causes a recursion which could end up looping over the same entity
-     * Multiple times in order to find the media first, then it's nearest frame and then the image data for that frame which is very costly
-     */
-    SharedTrackItem item = m_ActiveViewBuffer->TrackItem(frame);
-
-    if (item)
-        SetTrackItemFrame(item, frame);
-}
-
-void Player::SetTrackItemFrame(SharedTrackItem item, const int frame)
-{
-    /**
-     * This GetImage itself runs a check if Media.Contains(frame) as it has to offset values internally
-     * based on where the trackitem is present in the sequence
-     */
-    m_ActiveViewBuffer->EnsureCached(frame);
-    SharedPixels data = item->GetImage(frame);
-
-    /* A standard frame which is available for any trackitem/media */
     if (data)
-    {
-        m_Renderer->Render(data);
-    }
-    else
-    {
-        /**
-         * This maybe a case where the given frame does not exist for the track item
-         * What happens next is based on how the missing frame handler is set
-         */
-        switch(m_MFrameHandler)
-        {
-            /* Show only black frame on the viewer */
-            case MissingFrameHandler::BLACK_FRAME:
-                m_Renderer->Clear();
-                break;
-            case MissingFrameHandler::ERROR_FRAME:
-                m_Renderer->Clear();
-                m_Renderer->SetMessage("Frame " + std::to_string(frame) + " not available.");
-                break;
-            case MissingFrameHandler::NEAREST:
-                /**
-                 * Recursively call the method but with the nearest available frame
-                 * For any given frame, this recursion should happen only once as the nearest frame is a valid frame
-                 * to read and render on the renderer
-                 */
-                SetTrackItemFrame(item, item->NearestFrame(frame));
-                break;
-        }
-    }
+        m_Renderer->Render(data.image, data.annotation);
 }
 
-void Player::SetMediaFrame(int frame)
-{
-    const SharedMediaClip& clip = m_ActiveViewBuffer->GetMediaClip();
-    /* Ensure we have a valid media to process before setting the frame */
-    if (clip->Empty())
-        return;
+// void Player::SetSequenceFrame(int frame)
+// {
+//     /* Ensure We have Valid sequence with media to process before setting the frame */
+//     if (m_ActiveViewBuffer->GetSequence()->IsEmpty())
+//         return;
 
-    /**
-     * If the frame does not have any data, this could mean that the frame is missing
-     * if the provided frame is in range of the Media
-     * How such a case is handled is based on the MissingFrameHandler
-     * This determines what to do when a frame data is not available
-     *
-     * ERROR: Display an error on the Viewport stating the frame is not available.
-     * BLACKFRAME: Display a black frame instead of anything else. No error is displayed.
-     * NEAREST: Don't do anything here, as we continue to show the last frame which was rendered.
-     */
-    if (clip->Contains(frame))
-    {
-        m_ActiveViewBuffer->EnsureCached(frame);
-        /* Read the image for the frame from the sequence and set it on the player */
-        m_Renderer->Render(clip->Image(frame), clip->Annotation(frame));
-    }
-    else
-    {
-        switch(m_MFrameHandler)
-        {
-            case MissingFrameHandler::BLACK_FRAME:
-                m_Renderer->Clear();
-                break;
-            case MissingFrameHandler::ERROR_FRAME:
-                m_Renderer->Clear();
-                m_Renderer->SetMessage("Frame " + std::to_string(frame) + " not available.");
-                break;
-            case MissingFrameHandler::NEAREST:
-                /**
-                 * Recursively call the method but with the nearest available frame
-                 * For any given frame, this recursion should happen only once as the nearest frame is a valid frame
-                 * to read and render on the renderer
-                 */
-                SetMediaFrame(clip->NearestFrame(frame));
-                break;
-        }
-    }
-}
+//     /* Try to get the trackItem at a given frame in the current sequence */
+//     /**
+//      * Instead of fetching the image data directly from the sequence, fetch the trackItem at any given point
+//      * This for the time being (till we have a best case O(1) for finding a track item at any given available)
+//      * is a better approach as the nearest frame logic causes a recursion which could end up looping over the same entity
+//      * Multiple times in order to find the media first, then it's nearest frame and then the image data for that frame which is very costly
+//      */
+//     SharedTrackItem item = m_ActiveViewBuffer->TrackItem(frame);
+
+//     if (item)
+//         SetTrackItemFrame(item, frame);
+// }
+
+// void Player::SetTrackFrame(int frame)
+// {
+//     /* Ensure We have Valid sequence with media to process before setting the frame */
+//     if (m_ActiveViewBuffer->GetTrack()->IsEmpty())
+//         return;
+
+//     /* Try to get the trackItem at a given frame in the current sequence */
+//     /**
+//      * Instead of fetching the image data directly from the sequence, fetch the trackItem at any given point
+//      * This for the time being (till we have a best case O(1) for finding a track item at any given available)
+//      * is a better approach as the nearest frame logic causes a recursion which could end up looping over the same entity
+//      * Multiple times in order to find the media first, then it's nearest frame and then the image data for that frame which is very costly
+//      */
+//     SharedTrackItem item = m_ActiveViewBuffer->TrackItem(frame);
+
+//     if (item)
+//         SetTrackItemFrame(item, frame);
+// }
+
+// void Player::SetTrackItemFrame(SharedTrackItem item, const int frame)
+// {
+//     /**
+//      * This GetImage itself runs a check if Media.Contains(frame) as it has to offset values internally
+//      * based on where the trackitem is present in the sequence
+//      */
+//     m_ActiveViewBuffer->EnsureCached(frame);
+//     SharedPixels data = item->GetImage(frame);
+
+//     /* A standard frame which is available for any trackitem/media */
+//     if (data)
+//     {
+//         m_Renderer->Render(data);
+//     }
+//     else
+//     {
+//         /**
+//          * This maybe a case where the given frame does not exist for the track item
+//          * What happens next is based on how the missing frame handler is set
+//          */
+//         switch(m_MFrameHandler)
+//         {
+//             /* Show only black frame on the viewer */
+//             case MissingFrameHandler::BLACK_FRAME:
+//                 m_Renderer->Clear();
+//                 break;
+//             case MissingFrameHandler::ERROR_FRAME:
+//                 m_Renderer->Clear();
+//                 m_Renderer->SetMessage("Frame " + std::to_string(frame) + " not available.");
+//                 break;
+//             case MissingFrameHandler::NEAREST:
+//                 /**
+//                  * Recursively call the method but with the nearest available frame
+//                  * For any given frame, this recursion should happen only once as the nearest frame is a valid frame
+//                  * to read and render on the renderer
+//                  */
+//                 SetTrackItemFrame(item, item->NearestFrame(frame));
+//                 break;
+//         }
+//     }
+// }
+
+// void Player::SetMediaFrame(int frame)
+// {
+//     const SharedMediaClip& clip = m_ActiveViewBuffer->GetMediaClip();
+//     /* Ensure we have a valid media to process before setting the frame */
+//     if (clip->Empty())
+//         return;
+
+//     /**
+//      * If the frame does not have any data, this could mean that the frame is missing
+//      * if the provided frame is in range of the Media
+//      * How such a case is handled is based on the MissingFrameHandler
+//      * This determines what to do when a frame data is not available
+//      *
+//      * ERROR: Display an error on the Viewport stating the frame is not available.
+//      * BLACKFRAME: Display a black frame instead of anything else. No error is displayed.
+//      * NEAREST: Don't do anything here, as we continue to show the last frame which was rendered.
+//      */
+//     if (clip->Contains(frame))
+//     {
+//         m_ActiveViewBuffer->EnsureCached(frame);
+//         /* Read the image for the frame from the sequence and set it on the player */
+//         m_Renderer->Render(clip->Image(frame), clip->Annotation(frame));
+//     }
+//     else
+//     {
+//         switch(m_MFrameHandler)
+//         {
+//             case MissingFrameHandler::BLACK_FRAME:
+//                 m_Renderer->Clear();
+//                 break;
+//             case MissingFrameHandler::ERROR_FRAME:
+//                 m_Renderer->Clear();
+//                 m_Renderer->SetMessage("Frame " + std::to_string(frame) + " not available.");
+//                 break;
+//             case MissingFrameHandler::NEAREST:
+//                 /**
+//                  * Recursively call the method but with the nearest available frame
+//                  * For any given frame, this recursion should happen only once as the nearest frame is a valid frame
+//                  * to read and render on the renderer
+//                  */
+//                 SetMediaFrame(clip->NearestFrame(frame));
+//                 break;
+//         }
+//     }
+// }
 
 void Player::Compare(const SharedMediaClip& first, const SharedMediaClip& second)
 {
@@ -507,7 +506,6 @@ void Player::ResetViewBuffer(const PlayerViewBuffer& buffer)
     Refresh();
     SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
 }
-
 
 void Player::dragEnterEvent(QDragEnterEvent* event)
 {

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -216,7 +216,7 @@ void Player::Connect()
         }
         else
         {
-            m_ActiveViewBuffer->StartPlaybackCache(static_cast<ViewerBuffer::Direction>(state));
+            m_ActiveViewBuffer->StartPlaybackCache(static_cast<ViewerBuffer::PlayState>(state));
             if (state == Timeline::PlayState::FORWARDS)
                 m_AudioDecoder.Start();
         }

--- a/src/VoidUi/Player/Player.h
+++ b/src/VoidUi/Player/Player.h
@@ -38,6 +38,7 @@ public:
     void SetSequence(const SharedPlaybackSequence& sequence);
     void SetPlaylist(Playlist* playlist);
 
+    void ToggleChannels(int channel);
     void SetBlendMode(int mode);
     void SetComparisonMode(int mode);
     /* Compare Media on the Player */

--- a/src/VoidUi/Player/Player.h
+++ b/src/VoidUi/Player/Player.h
@@ -68,10 +68,11 @@ private: /* Members */
     AudioDecoder m_AudioDecoder;
 
 private: /* Methods */
-    void SetMediaFrame(int frame);
-    void SetTrackFrame(int frame);
-    void SetSequenceFrame(int frame);
-    void SetTrackItemFrame(SharedTrackItem item, const int frame);
+    void Render(int frame);
+    // void SetMediaFrame(int frame);
+    // void SetTrackFrame(int frame);
+    // void SetSequenceFrame(int frame);
+    // void SetTrackItemFrame(SharedTrackItem item, const int frame);
     void CompareMediaFrame(v_frame_t frame);
 
     void ResetViewBuffer(const PlayerViewBuffer& buffer);

--- a/src/VoidUi/Player/PlayerBridge.cpp
+++ b/src/VoidUi/Player/PlayerBridge.cpp
@@ -93,12 +93,23 @@ void PlayerBridge::InitMenu(MenuSystem* menuSystem)
     /* Viewer Contols Menu {{{ */
     QMenu* viewerMenu = menuSystem->AddMenu("Viewer");
 
+    QAction* redToggleAction = menuSystem->AddAction(viewerMenu, "Toggle Red channel", QKeySequence(Qt::Key_R));
+    QAction* greenToggleAction = menuSystem->AddAction(viewerMenu, "Toggle Green channel", QKeySequence(Qt::Key_G));
+    QAction* blueToggleAction = menuSystem->AddAction(viewerMenu, "Toggle Blue channel", QKeySequence(Qt::Key_B));
+    QAction* alphaToggleAction = menuSystem->AddAction(viewerMenu, "Toggle Alpha channel", QKeySequence(Qt::Key_A));
+
+    viewerMenu->addSeparator();
+
     QAction* zoomInAction = menuSystem->AddAction(viewerMenu, "Zoom In", QKeySequence(Qt::Key_Plus));
     QAction* zoomOutAction = menuSystem->AddAction(viewerMenu, "Zoom Out", QKeySequence(Qt::Key_Minus));
     QAction* zoomToFitAction = menuSystem->AddAction(viewerMenu, "Zoom to Fit", QKeySequence(Qt::Key_F));
     QAction* fullscreenAction = menuSystem->AddAction(viewerMenu, "Show Fullscreen", QKeySequence("Ctrl+F"));
     QAction* exitFullscreenAction = menuSystem->AddAction(viewerMenu, "Exit Fullscreen");
 
+    connect(redToggleAction, &QAction::triggered, this, [&]() -> void { ToggleChannels(0); });
+    connect(greenToggleAction, &QAction::triggered, this, [&]() -> void { ToggleChannels(1); });
+    connect(blueToggleAction, &QAction::triggered, this, [&]() -> void { ToggleChannels(2); });
+    connect(alphaToggleAction, &QAction::triggered, this, [&]() -> void { ToggleChannels(3); });
     connect(zoomInAction, &QAction::triggered, this, &PlayerBridge::ZoomIn);
     connect(zoomOutAction, &QAction::triggered, this, &PlayerBridge::ZoomOut);
     connect(zoomToFitAction, &QAction::triggered, this, &PlayerBridge::ZoomToFit);

--- a/src/VoidUi/Player/PlayerBridge.h
+++ b/src/VoidUi/Player/PlayerBridge.h
@@ -68,6 +68,7 @@ public:
     inline void ResetRange() { m_Player->ResetRange(); }
 
     inline void InspectCurrentMetadata() { m_Player->InspectCurrentMetadata(); }
+    inline void ToggleChannels(int channel) { m_Player->ToggleChannels(channel); }
 
     inline void ZoomIn() { m_Player->ZoomIn(); }
     inline void ZoomOut() { m_Player->ZoomOut(); }

--- a/src/VoidUi/Player/PlayerWidget.h
+++ b/src/VoidUi/Player/PlayerWidget.h
@@ -112,6 +112,8 @@ public:
 
     inline void Stop() { m_Timeline->Stop(); }
 
+    inline v_frame_t Startframe() const { return m_Timeline->Minimum(); }
+    inline v_frame_t Endframe() const { return m_Timeline->Maximum(); }
     inline v_frame_t Frame() const { return m_Timeline->Frame(); }
     inline void NextFrame() { m_Timeline->NextFrame(); }
     inline void PreviousFrame() { m_Timeline->PreviousFrame(); }

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -17,8 +17,7 @@ ViewerBuffer::ViewerBuffer(QObject* parent)
     , m_Playlist(nullptr)
     , m_CachedTrackItem(nullptr)
     , m_PlayingComponent(PlayableComponent::Clip)
-    , m_Direction(Direction::Forwards)
-    , m_State(State::Enabled)
+    , m_State(PlayState::Forwards)
     , m_Name("Viewer")
     , m_Color(130, 110, 190)    // Purple
     , m_Player(nullptr)
@@ -27,7 +26,6 @@ ViewerBuffer::ViewerBuffer(QObject* parent)
     , m_FrameSize(0)
     , m_Startframe(0)
     , m_Endframe(1)
-    , m_Duration(2)
     , m_LastCached(0)
     , m_BackBuffer(3)
     , m_Active(false)
@@ -399,34 +397,41 @@ bool ViewerBuffer::PreviousMedia()
     return false;
 }
 
-void ViewerBuffer::StartPlaybackCache(const Direction& direction)
+// void ViewerBuffer::StartPlaybackCache(const Direction& direction)
+void ViewerBuffer::StartPlaybackCache(const PlayState& state)
 {
-    m_Direction = direction;
-    if (m_Framenumbers.size() >= m_Duration || m_State != State::Enabled)
+    // m_Direction = direction;
+    if (Completed() || m_State == PlayState::Disabled)
         return;
-
+    
+    m_State = state;
     m_CacheTimer.start(10);
 
+    // if (!m_ThreadPool.activeThreadCount() && !m_Framenumbers.empty())
+    //     m_LastCached = m_Direction == Direction::Forwards ? m_Framenumbers.back() : m_Framenumbers.front();
     if (!m_ThreadPool.activeThreadCount() && !m_Framenumbers.empty())
-        m_LastCached = m_Direction == Direction::Forwards ? m_Framenumbers.back() : m_Framenumbers.front();
+        m_LastCached = m_State == PlayState::Forwards ? m_Framenumbers.back() : m_Framenumbers.front();
 }
 
 void ViewerBuffer::StopPlaybackCache()
 {
-    m_Direction = Direction::None;
+    // m_Direction = Direction::None;
+    // m_State = PlayState::Paused;
     m_CacheTimer.stop();
 }
 
 void ViewerBuffer::PauseCaching()
 {
     StopCaching();
-    m_State = State::Paused;
+    // m_State = State::Paused;
+    m_State = PlayState::Paused;
 }
 
 void ViewerBuffer::DisableCaching()
 {
     StopCaching();
-    m_State = State::Disabled;
+    // m_State = State::Disabled;
+    m_State = PlayState::Disabled;
 }
 
 void ViewerBuffer::StopCaching()
@@ -442,7 +447,8 @@ void ViewerBuffer::StopCaching()
 
 void ViewerBuffer::ResumeCaching()
 {
-    m_State = State::Enabled;
+    // m_State = State::Enabled;
+    m_State = PlayState::Forwards;
     CacheAvailable();
 }
 
@@ -458,9 +464,9 @@ void ViewerBuffer::Update()
         return;
     }
 
-    else if (m_Direction == Direction::Forwards && m_Framenumbers.size() != m_Duration)
+    else if (m_State == PlayState::Forwards && !Completed())
         CacheNext();
-    else if (m_Direction == Direction::Backwards && m_Framenumbers.size() != m_Duration)
+    else if (m_State == PlayState::Backwards && !Completed())
         CachePrevious();
     else
         m_CacheTimer.stop();
@@ -472,14 +478,13 @@ void ViewerBuffer::UpdateRange(v_frame_t start, v_frame_t end)
 {
     m_Startframe = start;
     m_Endframe = end;
-    m_Duration = (m_Endframe - m_Startframe) + 1;
 
     /**
      * The Back buffer refers to the amount of frames which stay behind the playhead
      * This needs to be between 3 - 10 depending on the overall size of the entity
      * being played
      */
-    m_BackBuffer = std::min(10, std::max(3, static_cast<int>(m_Duration * 0.02)));
+    m_BackBuffer = std::min(10, std::max(3, static_cast<int>(((m_Endframe - m_Startframe) + 1) * 0.02)));
 }
 
 bool ViewerBuffer::Request(v_frame_t frame, bool evict)
@@ -491,7 +496,7 @@ bool ViewerBuffer::Request(v_frame_t frame, bool evict)
      */
     if (!m_FrameSize)
     {
-        m_Direction == Direction::Backwards ? m_Framenumbers.push_front(frame) : m_Framenumbers.push_back(frame);
+        m_State == PlayState::Backwards ? m_Framenumbers.push_front(frame) : m_Framenumbers.push_back(frame);
         return true;
     }
 
@@ -499,7 +504,7 @@ bool ViewerBuffer::Request(v_frame_t frame, bool evict)
      * Check if we've cached all of our frames
      * if so, then there is no need to cache any further
      */
-    if (m_Framenumbers.size() >= m_Duration)
+    if (Completed())
     {
         m_CacheTimer.stop();
         return false;
@@ -509,7 +514,7 @@ bool ViewerBuffer::Request(v_frame_t frame, bool evict)
     {
         if (evict)
         {
-            if (m_Direction == Direction::Backwards)
+            if (m_State == PlayState::Backwards)
             {
                 EvictBack();
                 m_Framenumbers.push_front(frame);
@@ -529,7 +534,7 @@ bool ViewerBuffer::Request(v_frame_t frame, bool evict)
     }
 
     m_UsedMemory += m_FrameSize;
-    m_Direction == Direction::Backwards ? m_Framenumbers.push_front(frame) : m_Framenumbers.push_back(frame);
+    m_State == PlayState::Backwards ? m_Framenumbers.push_front(frame) : m_Framenumbers.push_back(frame);
     return true;
 }
 
@@ -660,7 +665,7 @@ void ViewerBuffer::Recache()
 
 void ViewerBuffer::CacheAvailable()
 {
-    if (m_State == State::Disabled)
+    if (m_State == PlayState::Disabled)
         return;
 
     int count = 0;
@@ -669,7 +674,7 @@ void ViewerBuffer::CacheAvailable()
      * This is invoked whenever the media is set/changed on the player buffer
      * so the usual direction is Forwards, unless we were going backwards
      */
-    if (m_Direction == Direction::Backwards)
+    if (m_State == PlayState::Backwards)
     {
         for (v_frame_t frame = m_Endframe; frame >= m_Startframe; --frame)
         {
@@ -697,14 +702,41 @@ void ViewerBuffer::CacheAvailable()
     }
 }
 
+v_frame_t ViewerBuffer::InternalStartframe() const
+{
+    return (m_Player) ? std::max(m_Startframe, m_Player->Startframe()) : m_Startframe;
+    // return m_Startframe;
+}
+
+v_frame_t ViewerBuffer::InternalEndframe() const
+{
+    return (m_Player) ? std::min(m_Endframe, m_Player->Endframe()) : m_Endframe;
+    // return m_Endframe;
+}
+
+int ViewerBuffer::InternalDuration() const
+{
+    return InternalEndframe() - InternalStartframe() + 1;
+}
+
+bool ViewerBuffer::Completed() const
+{
+    /**
+     * The cache/buffer is said to be completed if the internal frame store has the start
+     * and the end frames present
+     * 
+     */
+    return m_Framenumbers.size() >= InternalDuration();
+}
+
 v_frame_t ViewerBuffer::GetNextFrame()
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
     v_frame_t frame = 0;
 
-    if (m_LastCached > m_Endframe)
-        frame = m_Startframe;
+    if (m_LastCached > InternalEndframe())
+        frame = InternalStartframe();
     else
         frame = ++m_LastCached;
 
@@ -719,8 +751,8 @@ v_frame_t ViewerBuffer::GetPreviousFrame()
 
     v_frame_t frame = 0;
 
-    if (m_LastCached <= m_Startframe)
-        frame = m_Endframe;
+    if (m_LastCached <= InternalStartframe())
+        frame = InternalEndframe();
     else
         frame = --m_LastCached;
 
@@ -753,8 +785,8 @@ void ViewerBuffer::CacheNext()
 
         frame++;
 
-        if (frame > m_Endframe)
-            frame = m_Startframe;
+        if (frame > InternalEndframe())
+            frame = InternalStartframe();
 
         Request(frame, true);
         AddTask(new CacheNextFrameTask(this));
@@ -774,8 +806,8 @@ void ViewerBuffer::CachePrevious()
 
         frame--;
 
-        if (frame < m_Startframe)
-            frame = m_Endframe;
+        if (frame < InternalStartframe())
+            frame = InternalEndframe();
 
         Request(frame, true);
         AddTask(new CachePreviousFrameTask(this));

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -198,7 +198,7 @@ SharedPixels ViewerBuffer::Image(const v_frame_t frame)
         return nullptr;
 
     /* The pixels from the track item */
-    return item->GetImage(frame);
+    return item->Image(frame);
 }
 
 BufferData ViewerBuffer::MData(const v_frame_t frame, bool nearest)
@@ -252,7 +252,7 @@ BufferData ViewerBuffer::TrackData(const v_frame_t frame, bool nearest)
         if (item->InRange(frame))
         {
             EnsureCached(frame);
-            d.image = item->GetImage(frame);
+            d.image = item->Image(frame);
             return d;
         }
     }
@@ -268,7 +268,7 @@ BufferData ViewerBuffer::SequenceData(const v_frame_t frame, bool nearest)
         if (item->InRange(frame))
         {
             EnsureCached(frame);
-            d.image = item->GetImage(frame);
+            d.image = item->Image(frame);
             return d;
         }
     }
@@ -397,40 +397,32 @@ bool ViewerBuffer::PreviousMedia()
     return false;
 }
 
-// void ViewerBuffer::StartPlaybackCache(const Direction& direction)
 void ViewerBuffer::StartPlaybackCache(const PlayState& state)
 {
-    // m_Direction = direction;
     if (Completed() || m_State == PlayState::Disabled)
         return;
     
     m_State = state;
     m_CacheTimer.start(10);
 
-    // if (!m_ThreadPool.activeThreadCount() && !m_Framenumbers.empty())
-    //     m_LastCached = m_Direction == Direction::Forwards ? m_Framenumbers.back() : m_Framenumbers.front();
     if (!m_ThreadPool.activeThreadCount() && !m_Framenumbers.empty())
         m_LastCached = m_State == PlayState::Forwards ? m_Framenumbers.back() : m_Framenumbers.front();
 }
 
 void ViewerBuffer::StopPlaybackCache()
 {
-    // m_Direction = Direction::None;
-    // m_State = PlayState::Paused;
     m_CacheTimer.stop();
 }
 
 void ViewerBuffer::PauseCaching()
 {
     StopCaching();
-    // m_State = State::Paused;
     m_State = PlayState::Paused;
 }
 
 void ViewerBuffer::DisableCaching()
 {
     StopCaching();
-    // m_State = State::Disabled;
     m_State = PlayState::Disabled;
 }
 
@@ -447,7 +439,6 @@ void ViewerBuffer::StopCaching()
 
 void ViewerBuffer::ResumeCaching()
 {
-    // m_State = State::Enabled;
     m_State = PlayState::Forwards;
     CacheAvailable();
 }
@@ -464,7 +455,7 @@ void ViewerBuffer::Update()
         return;
     }
 
-    else if (m_State == PlayState::Forwards && !Completed())
+    if (m_State == PlayState::Forwards && !Completed())
         CacheNext();
     else if (m_State == PlayState::Backwards && !Completed())
         CachePrevious();
@@ -504,7 +495,7 @@ bool ViewerBuffer::Request(v_frame_t frame, bool evict)
      * Check if we've cached all of our frames
      * if so, then there is no need to cache any further
      */
-    if (Completed())
+    if (evict && Completed())
     {
         m_CacheTimer.stop();
         return false;
@@ -545,8 +536,8 @@ void ViewerBuffer::Cache(v_frame_t frame)
         SharedTrackItem item = ItemFromTrack(frame);
         if (item)
         {
-            item->CacheFrame(frame);
-            m_FrameSize = item->FrameSize();
+            auto image = item->Image(frame);
+            m_FrameSize = image->FrameSize();
 
             {
                 std::lock_guard<std::mutex> lock(m_Mutex);
@@ -562,8 +553,8 @@ void ViewerBuffer::Cache(v_frame_t frame)
         SharedTrackItem item = ItemFromSequence(frame);
         if (item)
         {
-            item->CacheFrame(frame);
-            m_FrameSize = item->FrameSize();
+            auto image = item->Image(frame);
+            m_FrameSize = image->FrameSize();
 
             {
                 std::lock_guard<std::mutex> lock(m_Mutex);
@@ -576,8 +567,8 @@ void ViewerBuffer::Cache(v_frame_t frame)
 
     if (m_Clip->Valid() && m_Clip->Contains(frame))
     {
-        m_Clip->CacheFrame(frame);
-        m_FrameSize = m_Clip->FrameSize();
+        auto image = m_Clip->Image(frame);
+        m_FrameSize = image->FrameSize();
 
         {
             std::lock_guard<std::mutex> lock(m_Mutex);
@@ -705,13 +696,11 @@ void ViewerBuffer::CacheAvailable()
 v_frame_t ViewerBuffer::InternalStartframe() const
 {
     return (m_Player) ? std::max(m_Startframe, m_Player->Startframe()) : m_Startframe;
-    // return m_Startframe;
 }
 
 v_frame_t ViewerBuffer::InternalEndframe() const
 {
     return (m_Player) ? std::min(m_Endframe, m_Player->Endframe()) : m_Endframe;
-    // return m_Endframe;
 }
 
 int ViewerBuffer::InternalDuration() const
@@ -735,7 +724,7 @@ v_frame_t ViewerBuffer::GetNextFrame()
 
     v_frame_t frame = 0;
 
-    if (m_LastCached > InternalEndframe())
+    if (m_LastCached >= InternalEndframe())
         frame = InternalStartframe();
     else
         frame = ++m_LastCached;
@@ -779,6 +768,10 @@ void ViewerBuffer::CacheNext()
     /* Determine how many frames are used up and can be removed */
     while (!m_Framenumbers.empty())
     {
+        // This might be a good idea to keep? in case all the frames are cached?
+        // if (Completed())
+        //     break;
+        
         /* Ensure the cached frame is just between the current frame and the back buffer */
         if (m_Player->Frame() - m_BackBuffer < m_Framenumbers.front() && m_Framenumbers.front() <= m_Player->Frame())
             break;
@@ -801,7 +794,7 @@ void ViewerBuffer::CachePrevious()
     while (!m_Framenumbers.empty())
     {
         /* Ensure the cached frame is just between the current frame and the back buffer */
-        if (m_Player->Frame() + m_BackBuffer > m_Framenumbers.back() && m_Framenumbers.back() >= m_Player->Frame())
+        if (m_Player->Frame() + m_BackBuffer >= m_Framenumbers.back() && m_Framenumbers.back() >= m_Player->Frame())
             break;
 
         frame--;

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -9,6 +9,16 @@
 
 VOID_NAMESPACE_OPEN
 
+// std::ostream& operator<<(std::ostream& stream, const std::unordered_set<v_frame_t>& s)
+// {
+//     stream << "unordered_set<v_frame_t> [";
+//     for (v_frame_t frame : s)
+//         stream << frame << ", ";
+//     stream << "]";
+
+//     return stream;
+// }
+
 ViewerBuffer::ViewerBuffer(QObject* parent)
     : QObject(parent)
     , m_Clip(std::make_shared<MediaClip>())
@@ -72,7 +82,7 @@ void ViewerBuffer::Set(const SharedPlaybackTrack& track)
 void ViewerBuffer::Set(const SharedPlaybackSequence& sequence)
 {
     Refresh();
-    
+
     m_Sequence = sequence;
     m_PlayingComponent = PlayableComponent::Sequence;
     UpdateRange(m_Sequence->StartFrame(), m_Sequence->EndFrame());
@@ -212,7 +222,7 @@ BufferData ViewerBuffer::MData(const v_frame_t frame, bool nearest)
 }
 
 SharedMediaClip ViewerBuffer::Media(const v_frame_t frame)
-{   
+{
     if (m_PlayingComponent == PlayableComponent::Track)
     {
         if (SharedTrackItem item = ItemFromTrack(frame))
@@ -247,14 +257,12 @@ BufferData ViewerBuffer::ClipData(const v_frame_t frame, bool nearest)
 BufferData ViewerBuffer::TrackData(const v_frame_t frame, bool nearest)
 {
     BufferData d;
-    if (SharedTrackItem item = ItemFromTrack(frame))
+    SharedTrackItem item = ItemFromTrack(frame);
+    if (item && item ->InRange(frame))
     {
-        if (item->InRange(frame))
-        {
-            EnsureCached(frame);
-            d.image = item->Image(frame);
-            return d;
-        }
+        EnsureCached(frame);
+        d.image = item->Image(frame);
+        return d;
     }
 
     return d;
@@ -263,14 +271,12 @@ BufferData ViewerBuffer::TrackData(const v_frame_t frame, bool nearest)
 BufferData ViewerBuffer::SequenceData(const v_frame_t frame, bool nearest)
 {
     BufferData d;
-    if (SharedTrackItem item = ItemFromSequence(frame))
+    SharedTrackItem item = ItemFromSequence(frame);
+    if (item && item->InRange(frame))
     {
-        if (item->InRange(frame))
-        {
-            EnsureCached(frame);
-            d.image = item->Image(frame);
-            return d;
-        }
+        EnsureCached(frame);
+        d.image = item->Image(frame);
+        return d;
     }
 
     return d;
@@ -401,7 +407,7 @@ void ViewerBuffer::StartPlaybackCache(const PlayState& state)
 {
     if (Completed() || m_State == PlayState::Disabled)
         return;
-    
+
     m_State = state;
     m_CacheTimer.start(10);
 
@@ -536,13 +542,10 @@ void ViewerBuffer::Cache(v_frame_t frame)
         SharedTrackItem item = ItemFromTrack(frame);
         if (item)
         {
-            auto image = item->Image(frame);
-            m_FrameSize = image->FrameSize();
+            item->CacheFrame(frame);
+            m_FrameSize = item->FrameSize();
 
-            {
-                std::lock_guard<std::mutex> lock(m_Mutex);
-                m_Player->AddCacheFrame(frame);
-            }
+            Store(frame);
         }
 
         return;
@@ -550,16 +553,14 @@ void ViewerBuffer::Cache(v_frame_t frame)
 
     if (m_PlayingComponent == PlayableComponent::Sequence)
     {
-        SharedTrackItem item = ItemFromSequence(frame);
-        if (item)
+        if (SharedTrackItem item = ItemFromSequence(frame))
         {
-            auto image = item->Image(frame);
-            m_FrameSize = image->FrameSize();
+            // auto image = item->Image(frame);
+            // m_FrameSize = image->FrameSize();
+            item->CacheFrame(frame);
+            m_FrameSize = item->FrameSize();
 
-            {
-                std::lock_guard<std::mutex> lock(m_Mutex);
-                m_Player->AddCacheFrame(frame);
-            }
+            Store(frame);
         }
 
         return;
@@ -567,18 +568,13 @@ void ViewerBuffer::Cache(v_frame_t frame)
 
     if (m_Clip->Valid() && m_Clip->Contains(frame))
     {
-        auto image = m_Clip->Image(frame);
-        m_FrameSize = image->FrameSize();
+        // auto image = m_Clip->Image(frame);
+        // m_FrameSize = image->FrameSize();
+        m_Clip->CacheFrame(frame);
+        m_FrameSize = m_Clip->FrameSize();
 
-        {
-            std::lock_guard<std::mutex> lock(m_Mutex);
-            m_Player->AddCacheFrame(frame);
-        }
+        Store(frame);
     }
-
-    // Now that the frame is cached/buffered, insert it to the set so that can be used to check
-    // whether a frame is cached or not
-    m_Buffered.insert(frame);
 }
 
 void ViewerBuffer::EvictFront()
@@ -632,6 +628,14 @@ void ViewerBuffer::EvictBack()
     m_Player->RemoveCachedFrame(frame);
 }
 
+void ViewerBuffer::Store(v_frame_t frame)
+{
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
+    m_Buffered.insert(frame);
+    m_Player->AddCacheFrame(frame);
+}
+
 void ViewerBuffer::EnsureCached(v_frame_t frame)
 {
     if (m_Buffered.find(frame) == m_Buffered.end())
@@ -642,7 +646,6 @@ void ViewerBuffer::EnsureCached(v_frame_t frame)
             m_LastCached = frame;
         }
 
-        /* Evict a frame if necessary as this needs to be cached */
         Request(frame, true);
         Cache(frame);
     }
@@ -658,8 +661,6 @@ void ViewerBuffer::CacheAvailable()
 {
     if (m_State == PlayState::Disabled)
         return;
-
-    int count = 0;
 
     /**
      * This is invoked whenever the media is set/changed on the player buffer
@@ -705,7 +706,8 @@ v_frame_t ViewerBuffer::InternalEndframe() const
 
 int ViewerBuffer::InternalDuration() const
 {
-    return InternalEndframe() - InternalStartframe() + 1;
+    // return InternalEndframe() - InternalStartframe() + 1;
+    return m_Endframe - m_Startframe + 1;
 }
 
 bool ViewerBuffer::Completed() const
@@ -713,7 +715,7 @@ bool ViewerBuffer::Completed() const
     /**
      * The cache/buffer is said to be completed if the internal frame store has the start
      * and the end frames present
-     * 
+     *
      */
     return m_Framenumbers.size() >= InternalDuration();
 }
@@ -724,8 +726,8 @@ v_frame_t ViewerBuffer::GetNextFrame()
 
     v_frame_t frame = 0;
 
-    if (m_LastCached >= InternalEndframe())
-        frame = InternalStartframe();
+    if (m_LastCached >= m_Endframe)
+        frame = m_Startframe;
     else
         frame = ++m_LastCached;
 
@@ -740,8 +742,8 @@ v_frame_t ViewerBuffer::GetPreviousFrame()
 
     v_frame_t frame = 0;
 
-    if (m_LastCached <= InternalStartframe())
-        frame = InternalEndframe();
+    if (m_LastCached <= m_Startframe)
+        frame = m_Endframe;
     else
         frame = --m_LastCached;
 
@@ -771,7 +773,7 @@ void ViewerBuffer::CacheNext()
         // This might be a good idea to keep? in case all the frames are cached?
         // if (Completed())
         //     break;
-        
+
         /* Ensure the cached frame is just between the current frame and the back buffer */
         if (m_Player->Frame() - m_BackBuffer < m_Framenumbers.front() && m_Framenumbers.front() <= m_Player->Frame())
             break;

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -188,16 +188,10 @@ SharedPixels ViewerBuffer::Image(const v_frame_t frame)
     /* The active element is a clip */
     if (m_PlayingComponent == PlayableComponent::Clip)
     {
-        /* Nothing being played at the moment */
-        if (m_Clip->Empty())
+        if (m_Clip->Empty() || !m_Clip->InRange(frame))
             return nullptr;
 
-        /* Check if we have the frame available in the Clip */
-        if (m_Clip->InRange(frame))
-            return m_Clip->Image(frame);
-
-        /* Return the nearest frame */
-        return m_Clip->Image(m_Clip->NearestFrame(frame));
+        return m_Clip->Image(frame);
     }
 
     SharedTrackItem item = ItemFromTrack(frame);
@@ -207,6 +201,81 @@ SharedPixels ViewerBuffer::Image(const v_frame_t frame)
 
     /* The pixels from the track item */
     return item->GetImage(frame);
+}
+
+BufferData ViewerBuffer::MData(const v_frame_t frame, bool nearest)
+{
+    switch (m_PlayingComponent)
+    {
+        case PlayableComponent::Track: return TrackData(frame, nearest);
+        case PlayableComponent::Sequence: return SequenceData(frame, nearest);
+        default: return ClipData(frame, nearest);
+    }
+}
+
+SharedMediaClip ViewerBuffer::Media(const v_frame_t frame)
+{   
+    if (m_PlayingComponent == PlayableComponent::Track)
+    {
+        if (SharedTrackItem item = ItemFromTrack(frame))
+            return item->GetMedia();
+        return nullptr;
+    }
+
+    if (m_PlayingComponent == PlayableComponent::Sequence)
+    {
+        if (SharedTrackItem item = ItemFromSequence(frame))
+            return item->GetMedia();
+        return nullptr;
+    }
+
+    return m_Clip;
+}
+
+BufferData ViewerBuffer::ClipData(const v_frame_t frame, bool nearest)
+{
+    BufferData d;
+    if (m_Clip->InRange(frame) && m_Clip->Contains(frame))
+    {
+        EnsureCached(frame);
+        d.image = m_Clip->Image(frame);
+        d.annotation = m_Clip->Annotation(frame);
+        return d;
+    }
+
+    return (nearest) ? ClipData(m_Clip->NearestFrame(frame), false) : d;
+}
+
+BufferData ViewerBuffer::TrackData(const v_frame_t frame, bool nearest)
+{
+    BufferData d;
+    if (SharedTrackItem item = ItemFromTrack(frame))
+    {
+        if (item->InRange(frame))
+        {
+            EnsureCached(frame);
+            d.image = item->GetImage(frame);
+            return d;
+        }
+    }
+
+    return d;
+}
+
+BufferData ViewerBuffer::SequenceData(const v_frame_t frame, bool nearest)
+{
+    BufferData d;
+    if (SharedTrackItem item = ItemFromSequence(frame))
+    {
+        if (item->InRange(frame))
+        {
+            EnsureCached(frame);
+            d.image = item->GetImage(frame);
+            return d;
+        }
+    }
+
+    return d;
 }
 
 SharedTrackItem ViewerBuffer::ItemFromSequence(const v_frame_t frame)

--- a/src/VoidUi/Player/ViewerBuffer.h
+++ b/src/VoidUi/Player/ViewerBuffer.h
@@ -31,7 +31,7 @@ class Player;
 
 /**
  * Enum decribing which viewer buffer is currently active and can be used to set an
- * active viewer buffer for the 
+ * active viewer buffer for the
  */
 enum class VOID_API PlayerViewBuffer
 {
@@ -92,18 +92,13 @@ public: /* Enums */
         Playlist
     };
 
-    enum class Direction
-    {
-        None,
-		Forwards,
-		Backwards
-    };
-
-    enum class State
+    enum class PlayState
     {
         Paused,
+        Forwards,
+        Backwards,
         Enabled,
-        Disabled,
+        Disabled
     };
 
 public:
@@ -122,8 +117,8 @@ public:
     inline void SetMaxMemory(unsigned long long gigs) { m_MaxMemory = gigs * 1024 * 1024 * 1024; }
     inline void SetMaxThreads(unsigned int count) { m_ThreadPool.setMaxThreadCount(count); }
 
-    void StartPlaybackCache(const Direction& direction = Direction::Forwards);
-    inline void RestartPlaybackCache() { StartPlaybackCache(m_Direction); }
+    void StartPlaybackCache(const PlayState& state = PlayState::Forwards);
+    inline void RestartPlaybackCache() { StartPlaybackCache(m_State); }
     void StopPlaybackCache();
 
     /**
@@ -166,7 +161,7 @@ public:
     /**
      * @brief Returns the active media's buffer data which includes the image data
      * and the annotations if available on the media
-     * 
+     *
      * @param frame Frame number.
      * @param nearest If the frame does not exist, whether a nearest available frame's data is required
      * @return BufferData Media data from the active media.
@@ -175,7 +170,7 @@ public:
 
     /**
      * @brief Returns the Media from the active component.
-     * 
+     *
      * @param frame Frame number.
      * @return SharedMediaClip Media clip from the active component at the given frame.
      */
@@ -190,7 +185,7 @@ public:
      * Returns the shared media track instance
      */
     inline SharedPlaybackTrack GetTrack() const { return m_Track; }
-    
+
     /**
      * Returns the shared sequence instance
      */
@@ -256,7 +251,7 @@ signals:
 
 private: /* Members */
     /**
-     * Playable Entities 
+     * Playable Entities
      * Obviously one will get played at a time but can be governed what gets played
      */
     SharedMediaClip m_Clip;
@@ -275,8 +270,7 @@ private: /* Members */
     SharedTrackItem m_CachedTrackItem;
 
     PlayableComponent m_PlayingComponent;
-    Direction m_Direction;
-    State m_State;
+    PlayState m_State;
 
     std::string m_Name;
     QColor m_Color;
@@ -294,8 +288,6 @@ private: /* Members */
     std::size_t m_FrameSize;
 
     v_frame_t m_Startframe, m_Endframe;
-    unsigned int m_Duration;
-
     v_frame_t m_LastCached;
 
     int m_BackBuffer;
@@ -320,6 +312,12 @@ private: /* Methods */
     BufferData TrackData(const v_frame_t frame, bool nearest = false);
     BufferData SequenceData(const v_frame_t frame, bool nearest = false);
 
+    v_frame_t InternalStartframe() const;
+    v_frame_t InternalEndframe() const;
+    int InternalDuration() const;
+
+    bool Completed() const;
+
     inline std::size_t AvailableMemory() const { return m_MaxMemory - m_UsedMemory; }
 
     /**
@@ -336,7 +334,8 @@ private: /* Methods */
 
     void UpdateRange(v_frame_t start, v_frame_t end);
     inline void AddTask(QRunnable* runnable, int priority = 0) { m_ThreadPool.start(runnable, priority); }
-    
+    inline bool Cached(v_frame_t frame) const { return m_Buffered.find(frame) != m_Buffered.end(); }
+
     /**
      * A Cache process which caches all frames till the memory size allows
      */
@@ -360,16 +359,13 @@ private: /* Methods */
      */
     void Cache(v_frame_t frame);
 
+    v_frame_t GetNextFrame();
+    v_frame_t GetPreviousFrame();
     void CacheNextFrame();
     void CachePreviousFrame();
-
     void CacheNext();
     void CachePrevious();
 
-    v_frame_t GetNextFrame();
-    v_frame_t GetPreviousFrame();
-
-    inline bool Cached(v_frame_t frame) const { return m_Buffered.find(frame) != m_Buffered.end(); }
     void SettingsUpdated();
 };
 

--- a/src/VoidUi/Player/ViewerBuffer.h
+++ b/src/VoidUi/Player/ViewerBuffer.h
@@ -358,6 +358,7 @@ private: /* Methods */
      * of memory usage
      */
     void Cache(v_frame_t frame);
+    void Store(v_frame_t frame);
 
     v_frame_t GetNextFrame();
     v_frame_t GetPreviousFrame();

--- a/src/VoidUi/Player/ViewerBuffer.h
+++ b/src/VoidUi/Player/ViewerBuffer.h
@@ -43,6 +43,15 @@ enum class VOID_API PlayerViewBuffer
     /* In Future the Buffer type may also include Compare buffers like switch/swipe and others. */
 };
 
+struct BufferData
+{
+    SharedPixels image = nullptr;
+    Renderer::SharedAnnotation annotation = nullptr;
+
+    bool Valid() const { return (bool)image; }
+    explicit operator bool() const { return (bool)image; }
+};
+
 class ViewerBuffer : public QObject
 {
     Q_OBJECT
@@ -153,6 +162,24 @@ public:
      * Returns the Image Pixels from the active item in the buffer
      */
     SharedPixels Image(const v_frame_t frame);
+
+    /**
+     * @brief Returns the active media's buffer data which includes the image data
+     * and the annotations if available on the media
+     * 
+     * @param frame Frame number.
+     * @param nearest If the frame does not exist, whether a nearest available frame's data is required
+     * @return BufferData Media data from the active media.
+     */
+    BufferData MData(const v_frame_t frame, bool nearest = false);
+
+    /**
+     * @brief Returns the Media from the active component.
+     * 
+     * @param frame Frame number.
+     * @return SharedMediaClip Media clip from the active component at the given frame.
+     */
+    SharedMediaClip Media(const v_frame_t frame);
 
     /**
      * Returns the shared media clip instance
@@ -288,6 +315,10 @@ private: /* Methods */
      */
     SharedTrackItem ItemFromTrack(const v_frame_t frame);
     SharedTrackItem ItemFromSequence(const v_frame_t frame);
+
+    BufferData ClipData(const v_frame_t frame, bool nearest = false);
+    BufferData TrackData(const v_frame_t frame, bool nearest = false);
+    BufferData SequenceData(const v_frame_t frame, bool nearest = false);
 
     inline std::size_t AvailableMemory() const { return m_MaxMemory - m_UsedMemory; }
 

--- a/src/VoidUi/Timeline/Timeline.cpp
+++ b/src/VoidUi/Timeline/Timeline.cpp
@@ -175,6 +175,7 @@ void Timeline::Build()
 void Timeline::Connect()
 {
 	qRegisterMetaType<PlayState>("PlayState");
+	qRegisterMetaType<v_frame_t>("v_frame_t");
 
 	connect(m_Timeslider, &QSlider::valueChanged, this, &Timeline::TimeUpdated, Qt::DirectConnection);
 	connect(m_Timeslider, &Timeslider::seeked, this, &Timeline::seeked, Qt::DirectConnection);

--- a/src/VoidUi/Toolkit/ControlBar.cpp
+++ b/src/VoidUi/Toolkit/ControlBar.cpp
@@ -266,4 +266,14 @@ void ControlBar::SetZoomLimits(float min, float max)
     m_Zoomer->setMaximum(max);
 }
 
+void ControlBar::ToggleChannels(int channel)
+{
+    const int max = m_ChannelModeController->count() - 1;   // RGBA
+
+    if (channel > max)
+        return;
+
+    m_ChannelModeController->setCurrentIndex((channel == m_ChannelModeController->currentIndex()) ? max : channel);
+}
+
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Toolkit/ControlBar.h
+++ b/src/VoidUi/Toolkit/ControlBar.h
@@ -44,6 +44,7 @@ public:
     inline void ZoomIn() { m_Zoomer->setValue(m_Zoomer->value() + 10); }
     inline void ZoomOut() { m_Zoomer->setValue(m_Zoomer->value() - 10); }
     void SetZoomLimits(float min, float max);
+    void ToggleChannels(int channel);
 
     /**
      * Sets the current Compare mode


### PR DESCRIPTION
### Feat: Updates to Player and Viewer Buffer for BufferData based communication
* ViewerBuffer takes responsibility for all the Caching and holding items/tracks/sequences in itself.
* ViewerBuffer provides BufferData holding the frame data and annotations (if available)
* Player directly calls Render which requests the ViewerBuffer of the BufferData, if the data is valid, it's then pushed to the Renderer to render.
* Added hints to the application for windows allowing the system to consider the application for High Performance graphics processor in Optimus/PowerExpress based devices. (laptops, including mine xD)
