### PR TITLE
[VOID] ImageProcessing: Effect Editor UI

### DIFF
--- a/src/VoidApplication/Engine/Engine.cpp
+++ b/src/VoidApplication/Engine/Engine.cpp
@@ -98,8 +98,10 @@ void VoidEngine::Initialize()
     m_Imager = new VoidMainWindow;
     UIGlobals::g_VoidMainWindow = m_Imager;
 
-    /* Workspace */
-    m_Imager->SwitchWorkspace(m_Args.basic ? Workspace::BASIC : Workspace::PLAYBACK);
+    // Workspace
+    m_Imager->SwitchWorkspace(m_Args.basic
+                ? Workspace::BASIC
+                : static_cast<Workspace>(VoidPreferences::Instance().GetDefaultWorkspace()));
 
     /* Init Menu */
     m_MenuSystem = new MenuSystem(m_Imager);

--- a/src/VoidCore/Media/Frame.cpp
+++ b/src/VoidCore/Media/Frame.cpp
@@ -105,8 +105,6 @@ void Frame::Cache()
      * crashes
      */
     std::lock_guard<std::mutex> guard(m_Mutex);
-
-    /* Read and load the image data onto the memory */
     if (m_ImageData->Empty() || m_Dirty)
     {
         m_ImageData->Read();
@@ -117,12 +115,11 @@ void Frame::ClearCache()
 {
     if (!m_ImageData->Empty())
     {
-        /**
-         * Don't allow concurrent access when clearing the underlying data vector
-         */
+        // Don't allow concurrent access when clearing the underlying data vector
         std::lock_guard<std::mutex> guard(m_Mutex);
         m_ImageData->Clear();
     }
+    m_Dirty = true;
 }
 
 MovieFrame::MovieFrame(const MEntry& e, const v_frame_t frame)

--- a/src/VoidCore/Operators/Grader.cpp
+++ b/src/VoidCore/Operators/Grader.cpp
@@ -13,9 +13,9 @@ VOID_NAMESPACE_OPEN
 GradeOp::GradeOp()
 {
     // std::string gain = "r_gain";
-    m_RedGain = AddParam(Param("r_gain", 1.f, Param::TypeDesc::Float));
-    m_GreenGain = AddParam(Param("g_gain", 1.f, Param::TypeDesc::Float));
-    m_BlueGain = AddParam(Param("b_gain", 1.f, Param::TypeDesc::Float));
+    m_RedGain = AddParam(Param("r_gain", "Red", 1.f, Param::TypeDesc::Float));
+    m_GreenGain = AddParam(Param("g_gain", "Green", 1.f, Param::TypeDesc::Float));
+    m_BlueGain = AddParam(Param("b_gain", "Blue", 1.f, Param::TypeDesc::Float));
     // m_GreenGain = Add
 }
 

--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -76,7 +76,13 @@ void FFmpegDecoder::Close()
     if (m_Packet) av_packet_free(&m_Packet);
     if (m_CodecContext) avcodec_free_context(&m_CodecContext);
     if (m_FormatContext) avformat_close_input(&m_FormatContext);
+
+    #if LIBSWSCALE_VERSION_MAJOR < 9
+    if (m_SwsContext) sws_freeContext(m_SwsContext);
+    m_SwsContext = nullptr;
+    #else
     if (m_SwsContext) sws_free_context(&m_SwsContext);
+    #endif
 
     /* The read stream ID */
     m_StreamID = -1;

--- a/src/VoidObjects/Effects/Effects.cpp
+++ b/src/VoidObjects/Effects/Effects.cpp
@@ -30,10 +30,22 @@ bool Effect::SetValue(const std::string& param, ValueType value)
         p->SetValue(value);
 
         emit updated();
+        emit valueChanged(p);
         return true;
     }
 
     return false;
+}
+
+void Effect::ResetValue(const std::string& param)
+{
+    if (Param* p = m_Operator->GetParam(param))
+    {
+        p->ResetValue();
+
+        emit updated();
+        emit valueChanged(p);
+    }
 }
 
 const ValueType& Effect::Value(const std::string& param) const
@@ -41,7 +53,8 @@ const ValueType& Effect::Value(const std::string& param) const
     if (Param* p = m_Operator->GetParam(param))
         return p->Value();
 
-    return -1;
+    static ValueType invalid = std::monostate{};
+    return invalid;
 }
 
 void Effect::SetEnabled(bool enable)

--- a/src/VoidObjects/Effects/Effects.h
+++ b/src/VoidObjects/Effects/Effects.h
@@ -32,6 +32,13 @@ public:
     bool SetValue(const std::string& param, ValueType value);
 
     /**
+     * @brief Resets the value on the param to the default value.
+     * 
+     * @param param Parameter name.
+     */
+    void ResetValue(const std::string& param);
+
+    /**
      * @brief Returns the Value from the parameter, if found with the provided name.
      * Else a Value bearing -1 is returned.
      * 
@@ -46,8 +53,11 @@ public:
     Param* GetParam(const std::string& name) const { return m_Operator->GetParam(name); }
     ImageOp* ImageOperator() { return m_Operator; }
 
+    const std::map<std::string, Param>& Params() const { return m_Operator->Params(); }
+
 signals:
     void updated();
+    void valueChanged(const Param*);
 
 private:
     ImageOp* m_Operator;

--- a/src/VoidObjects/Media/MediaClip.h
+++ b/src/VoidObjects/Media/MediaClip.h
@@ -95,6 +95,7 @@ public:
      */
     Renderer::SharedAnnotation Annotation(const v_frame_t frame) const;
     std::vector<int> AnnotatedFrames() const;
+    const std::vector<Effect*>& Effects() const { return m_Effects; }
 
     QPixmap Thumbnail();
 

--- a/src/VoidUi/BaseWindow/WorkspaceManager.cpp
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.cpp
@@ -26,32 +26,37 @@ QWidget* WorkspaceManager::Widget(const Component& component) const
 
 void WorkspaceManager::Init()
 {
-    /* Register Dock Widgets in the Dock Manager */
+    // Register Dock Widgets in the Dock Manager
     DockManager& manager = DockManager::Instance();
 
-    /* Media Lister Widget */
+    // Media Lister Widget
     m_MediaLister = new VoidMediaLister();
     m_PlayLister = new VoidPlayLister();
 
-    /* Python Script Editor */
+    // Python Script Editor
     m_ScriptEditor = new PyScriptEditor();
 
-    /* Media Metadata Viewer */
+    // Media Metadata Viewer
     m_MetadataViewer = new MetadataViewer();
+
+    // Properties Editor
+    m_PropertiesEditor = new PropertiesPanel();
 
     manager.RegisterDock(m_MediaLister, "Media View");
     manager.RegisterDock(_PlayerBridge.ActivePlayer(), "Viewer");
     manager.RegisterDock(m_ScriptEditor, "Script Editor");
     manager.RegisterDock(m_MetadataViewer, "Metadata Viewer");
     manager.RegisterDock(m_PlayLister, "Playlist View");
+    manager.RegisterDock(m_PropertiesEditor, "Properties");
 
-    /* Docker */
+    // Docker
     m_Splitter = new DockSplitter(Qt::Horizontal, this);
     setCentralWidget(m_Splitter);
 }
 
 void WorkspaceManager::Connect()
 {
+    connect(m_MediaLister, &VoidMediaLister::effectsEdited, this, &WorkspaceManager::EditEffects);
     connect(m_MediaLister, &VoidMediaLister::metadataInspected, this, &WorkspaceManager::InspectMetadata);
     connect(_PlayerBridge.ActivePlayer(), &Player::metadataInspected, this, &WorkspaceManager::InspectMetadata);
 }
@@ -112,10 +117,20 @@ void WorkspaceManager::InspectMetadata(const SharedMediaClip& media)
 {
     m_MetadataViewer->SetFromMedia(media);
 
-    /* Show if it's not already being shown */
+    // Show if it's not already being shown
     const DockStruct d = DockManager::Instance().Dock(static_cast<int>(Component::MetadataViewer));
     if (!d.widget->isVisible())
         ShowComponent(Component::MetadataViewer);
+}
+
+void WorkspaceManager::EditEffects(const SharedMediaClip& media)
+{
+    for (auto effect : media->Effects())
+        m_PropertiesEditor->EditEffect(effect);
+
+    const DockStruct d = DockManager::Instance().Dock(static_cast<int>(Component::Properties));
+    if (!d.widget->isVisible())
+        ShowComponent(Component::Properties);
 }
 
 void WorkspaceManager::ShowComponent(const Component& component) const

--- a/src/VoidUi/BaseWindow/WorkspaceManager.cpp
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.cpp
@@ -3,11 +3,13 @@
 
 /* Internal */
 #include "WorkspaceManager.h"
+#include "VoidUi/Preferences/Preferences.h"
 
 VOID_NAMESPACE_OPEN
 
 WorkspaceManager::WorkspaceManager(QWidget* parent)
     : MainWindow(parent)
+    , m_Current(Workspace::BASIC)
 {
 }
 
@@ -65,20 +67,39 @@ void WorkspaceManager::InitMenu(MenuSystem* menuSystem)
 {
     QMenu* workspaceMenu = menuSystem->AddMenu("Workspace");
 
-    QAction* basicWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Switch to Basic Workspace", QKeySequence("Shift+F1"));
-    QAction* playbackWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Switch to Playback Workspace", QKeySequence("Shift+F2"));
+    QAction* playbackWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Switch to Playback Workspace", QKeySequence("Shift+F1"));
+    QAction* basicWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Switch to Basic Workspace", QKeySequence("Shift+F2"));
     QAction* reviewWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Switch to Review Workspace", QKeySequence("Shift+F3"));
     QAction* scriptingWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Switch to Scripting Workspace", QKeySequence("Shift+F4"));
+    QAction* editingWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Switch to Editing Workspace", QKeySequence("Shift+F5"));
 
-    connect(basicWorkspaceAction, &QAction::triggered, this, [this]() { Switch(Workspace::BASIC); });
-    connect(playbackWorkspaceAction, &QAction::triggered, this, [this]() { Switch(Workspace::PLAYBACK); });
-    connect(reviewWorkspaceAction, &QAction::triggered, this, [this]() { Switch(Workspace::REVIEW); });
-    connect(scriptingWorkspaceAction, &QAction::triggered, this, [this]() { Switch(Workspace::SCRIPTING); });
+    workspaceMenu->addSeparator();
+
+    QAction* setCurrentWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Set current workspace as default");
+    QAction* resetDefaultWorkspaceAction = menuSystem->AddAction(workspaceMenu, "Reset the default workspace");
+
+    connect(playbackWorkspaceAction, &QAction::triggered, this, [&]() -> void { Switch(Workspace::PLAYBACK); });
+    connect(basicWorkspaceAction, &QAction::triggered, this, [&]() -> void { Switch(Workspace::BASIC); });
+    connect(reviewWorkspaceAction, &QAction::triggered, this, [&]() -> void { Switch(Workspace::REVIEW); });
+    connect(scriptingWorkspaceAction, &QAction::triggered, this, [&]() -> void { Switch(Workspace::SCRIPTING); });
+    connect(editingWorkspaceAction, &QAction::triggered, this, [&]() -> void { Switch(Workspace::EDITING); });
+
+    connect(setCurrentWorkspaceAction, &QAction::triggered, this, [&]() -> void
+    {
+        VoidPreferences::Instance().Set(Settings::DefaultWorkspace, static_cast<int>(m_Current));
+    });
+
+    connect(resetDefaultWorkspaceAction, &QAction::triggered, this, [&]() -> void
+    {
+        VoidPreferences::Instance().Set(Settings::DefaultWorkspace, 0);
+        Switch(Workspace::PLAYBACK);
+    });
 }
 
 void WorkspaceManager::Switch(const Workspace& workspace)
 {
     m_Splitter->ClearPanes();
+    m_Current = workspace;
 
     switch (workspace)
     {
@@ -100,6 +121,11 @@ void WorkspaceManager::Switch(const Workspace& workspace)
                 Qt::Vertical
             );
             m_Splitter->AddPane(static_cast<int>(Component::Viewer));
+            break;
+        case Workspace::EDITING:
+            m_Splitter->AddPane(static_cast<int>(Component::MediaLister));
+            m_Splitter->AddPane(static_cast<int>(Component::Viewer));
+            m_Splitter->AddPane(static_cast<int>(Component::Properties));
             break;
         case Workspace::PLAYBACK:
         default:

--- a/src/VoidUi/BaseWindow/WorkspaceManager.h
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.h
@@ -11,6 +11,7 @@
 #include "VoidUi/Dock/Docker.h"
 
 /* Internal Widget Components */
+#include "VoidUi/Editor/Properties.h"
 #include "VoidUi/Media/MediaLister.h"
 #include "VoidUi/Media/MetadataViewer.h"
 #include "VoidUi/Player/PlayerBridge.h"
@@ -42,6 +43,7 @@ enum class Component
     ScriptEditor,
     MetadataViewer,
     PlayLister,
+    Properties,
 };
 
 class WorkspaceManager : public MainWindow
@@ -67,10 +69,12 @@ private: /* Members */
     VoidPlayLister* m_PlayLister;
     PyScriptEditor* m_ScriptEditor;
     MetadataViewer* m_MetadataViewer;
+    PropertiesPanel* m_PropertiesEditor;
 
 private: /* Members */
     void Clear();
     void InspectMetadata(const SharedMediaClip& media);
+    void EditEffects(const SharedMediaClip& media);
     void ShowComponent(const Component& component) const;
 };
 

--- a/src/VoidUi/BaseWindow/WorkspaceManager.h
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.h
@@ -23,10 +23,11 @@ VOID_NAMESPACE_OPEN
 
 enum class Workspace
 {
-    BASIC,
     PLAYBACK,
+    BASIC,
     REVIEW,
-    SCRIPTING
+    SCRIPTING,
+    EDITING
 };
 
 /**
@@ -70,6 +71,8 @@ private: /* Members */
     PyScriptEditor* m_ScriptEditor;
     MetadataViewer* m_MetadataViewer;
     PropertiesPanel* m_PropertiesEditor;
+
+    Workspace m_Current;
 
 private: /* Members */
     void Clear();

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SOURCES
     QExtensions/Dialog.cpp
     QExtensions/Frame.cpp
     QExtensions/Label.cpp
+    QExtensions/LineEdit.cpp
     QExtensions/MessageBox.cpp
     QExtensions/ProgressTask.cpp
     QExtensions/PushButton.cpp

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -19,6 +19,10 @@ set(SOURCES
     Dock/DockManager.cpp
     Dock/DockPanel.cpp
     Dock/DockSplitter.cpp
+
+    # Editors
+    Editor/Properties.cpp
+    Editor/Effects.cpp
     
     # Core Engine Globals
     Engine/Bridge.cpp
@@ -111,6 +115,8 @@ if (WIN32)
 
         # # Objects   --- This is needed on windows for the moc compilation to succeed on PlayerWidget which expects
         # # the staticMetaObject for MediaClip, Track, TrackItem, Sequence and MediaBridge to be present at compile time rather link time
+        ../VoidObjects/Effects/Effects.h
+
         ../VoidObjects/Media/MediaClip.h
 
         ../VoidObjects/Playlist/Playlist.h

--- a/src/VoidUi/Editor/Effects.cpp
+++ b/src/VoidUi/Editor/Effects.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QCheckBox>
+#include <QDoubleSpinBox>
+#include <QFormLayout>
+#include <QPainter>
+#include <QSpinBox>
+
+/* Internal */
+#include "Effects.h"
+#include "VoidUi/Player/PlayerBridge.h"
+#include "VoidUi/Engine/IconForge.h"
+
+VOID_NAMESPACE_OPEN
+
+EffectEditor::EffectEditor(Effect* effect, QWidget* parent)
+    : QWidget(parent)
+    , m_Effect(effect)
+{
+    Build();
+    Setup();
+    Connect();
+}
+
+EffectEditor::~EffectEditor()
+{
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void EffectEditor::Close()
+{
+    hide();
+    setParent(nullptr);
+    deleteLater();
+}
+
+void EffectEditor::paintEvent(QPaintEvent* event)
+{
+    QPainter painter(this);
+
+    const QRect r = rect();
+    painter.save();
+
+    painter.setPen(QPen(QBrush(Qt::black), 1));
+    painter.setBrush(QBrush(palette().color(QPalette::Window)));
+    painter.drawRect(r.adjusted(0, 0, -1, -1));
+
+    painter.setBrush(QBrush(palette().color(QPalette::Dark)));
+    painter.drawRect(0, 0, r.width() - 1, 30);
+    painter.restore();
+
+    QWidget::paintEvent(event);
+}
+
+void EffectEditor::Build()
+{
+    m_Layout = new QVBoxLayout(this);
+
+    // int margins[4];
+    // m_Layout->getContentsMargins(&margins[0], &margins[1], &margins[2], &margins[3]);
+    // m_Layout->setContentsMargins(margins[0], 1, 1, margins[3]);
+
+    QHBoxLayout* title = new QHBoxLayout;
+    title->setContentsMargins(2, 0, 6, 8);
+
+    m_NameEdit = new QLineEdit;
+    m_NameEdit->setText(m_Effect->Name().c_str());
+
+    m_EnableButton = new QToolButton;
+    m_CloseButton = new CloseButton;
+
+    title->addWidget(m_NameEdit);
+    title->addWidget(m_EnableButton);
+    title->addWidget(m_CloseButton);
+
+    QFormLayout* form = new QFormLayout;
+
+    for (const auto& [name, param] : m_Effect->Params())
+    {
+        switch (param.type)
+        {
+            case Param::TypeDesc::Boolean:
+            {
+                QCheckBox* editor = new QCheckBox;
+                editor->setChecked(param.GetBool());
+                form->addRow(param.label.c_str(), editor);
+
+                connect(editor, &QCheckBox::toggled, this, [&](bool b) -> void
+                {
+                    m_Effect->SetValue(name, b);
+                    _PlayerBridge.Refresh();
+                }, Qt::DirectConnection);
+                break;
+            }
+            case Param::TypeDesc::Float:
+            {
+                QDoubleSpinBox* editor = new QDoubleSpinBox;
+                editor->setValue(param.GetFloat());
+                form->addRow(param.label.c_str(), editor);
+                editor->setSingleStep(0.1);
+
+                connect(editor, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, [&](double d) -> void
+                {
+                    m_Effect->SetValue(name, static_cast<float>(d));
+                    _PlayerBridge.Refresh();
+                }, Qt::DirectConnection);
+                break;
+            }
+            case Param::TypeDesc::Int:
+            {
+                QSpinBox* editor = new QSpinBox;
+                editor->setValue(param.GetInt());
+                form->addRow(param.label.c_str(), editor);
+
+                connect(editor, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, [&](int i) -> void
+                {
+                    m_Effect->SetValue(name, i);
+                    _PlayerBridge.Refresh();
+                }, Qt::DirectConnection);
+                break;
+            }
+            case Param::TypeDesc::String:
+            default:
+            {
+                QLineEdit* editor = new QLineEdit;
+                editor->setText(param.GetString().c_str());
+                form->addRow(param.label.c_str(), editor);
+
+                connect(editor, &QLineEdit::editingFinished, this, [&]() -> void
+                {
+                    m_Effect->SetValue(name, editor->text().toStdString());
+                    _PlayerBridge.Refresh();
+                }, Qt::DirectConnection);
+                break;
+            }
+        }
+    }
+
+    form->setContentsMargins(8, 0, 8, 8);
+
+    m_Layout->addLayout(title);
+    m_Layout->addLayout(form);
+}
+
+void EffectEditor::Setup()
+{
+    int margins[4];
+    m_Layout->getContentsMargins(&margins[0], &margins[1], &margins[2], &margins[3]);
+    m_Layout->setContentsMargins(1, 4, 1, margins[3]);
+
+    QIcon icon;
+    icon.addPixmap(IconForge::GetPixmap(IconType::icon_visible, _DARK_COLOR(QPalette::Text, 100)), QIcon::Normal, QIcon::On);
+    icon.addPixmap(IconForge::GetPixmap(IconType::icon_visible_off, _DARK_COLOR(QPalette::Text, 100)), QIcon::Normal, QIcon::Off);
+
+    m_EnableButton->setIcon(icon);
+    m_EnableButton->setCheckable(true);
+    m_EnableButton->setAutoRaise(true);
+
+    m_EnableButton->setChecked(m_Effect->Enabled());
+
+    m_EnableButton->setFixedSize(16, 16);
+    m_CloseButton->setFixedSize(16, 16);
+
+    // Match the Effect Name, for finding the widget corresponding to the effect
+    setObjectName(m_Effect->Name().c_str());
+}
+
+void EffectEditor::Connect()
+{
+    connect(m_NameEdit, &QLineEdit::editingFinished, this, [&]() -> void
+    {
+        const QString text = m_NameEdit->text();
+        m_Effect->SetName(text.toStdString());
+        setObjectName(text);
+    });
+
+    connect(m_CloseButton, &QToolButton::clicked, this, &EffectEditor::Close);
+    connect(m_EnableButton, &QToolButton::toggled, this, [&](bool checked) -> void
+    {
+        m_Effect->SetEnabled(checked);
+        _PlayerBridge.Refresh();
+    });
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/Effects.cpp
+++ b/src/VoidUi/Editor/Effects.cpp
@@ -60,10 +60,6 @@ void EffectEditor::Build()
 {
     m_Layout = new QVBoxLayout(this);
 
-    // int margins[4];
-    // m_Layout->getContentsMargins(&margins[0], &margins[1], &margins[2], &margins[3]);
-    // m_Layout->setContentsMargins(margins[0], 1, 1, margins[3]);
-
     QHBoxLayout* title = new QHBoxLayout;
     title->setContentsMargins(2, 0, 6, 8);
 
@@ -183,7 +179,7 @@ void EffectEditor::Connect()
     {
         m_Effect->SetEnabled(checked);
         _PlayerBridge.Refresh();
-    });
+    }, Qt::DirectConnection);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/Effects.h
+++ b/src/VoidUi/Editor/Effects.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _EFFECTS_EDITOR_H
+#define _EFFECTS_EDITOR_H
+
+/* Qt */
+#include <QWidget>
+#include <QLayout>
+#include <QLineEdit>
+#include <QToolButton>
+
+/* Internal */
+#include "Definition.h"
+#include "VoidObjects/Effects/Effects.h"
+#include "VoidUi/QExtensions/PushButton.h"
+
+VOID_NAMESPACE_OPEN
+
+class EffectEditor : public QWidget
+{
+    Q_OBJECT
+
+public:
+    EffectEditor(Effect* effect, QWidget* parent = nullptr);
+    ~EffectEditor();
+
+    void Close();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private: /* Members */
+    QVBoxLayout* m_Layout;
+    QLineEdit* m_NameEdit;
+    QToolButton* m_EnableButton;
+    CloseButton* m_CloseButton;
+
+    Effect* m_Effect;
+
+private: /* Methods */
+    void Build();
+    void Setup();
+    void Connect();
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _EFFECTS_EDITOR_H

--- a/src/VoidUi/Editor/Properties.cpp
+++ b/src/VoidUi/Editor/Properties.cpp
@@ -4,6 +4,7 @@
 /* Qt */
 #include <QPainter>
 #include <QScrollArea>
+#include <QValidator>
 
 /* Internal */
 #include "Properties.h"
@@ -55,13 +56,26 @@ void PropertiesPanel::EditEffect(Effect* effect)
     for (auto w : findChildren<EffectEditor*>(effect->Name().c_str()))
         w->Close();
 
-    m_ScrollLayout->addWidget(new EffectEditor(effect, this));
+    // Ensure we have only panels till the limit
+    // Going one lesser here as we are also adding another widget
+    ClearAdditionalPanels(m_PanelCounter->CurrentValue() - 1);
+    m_ScrollLayout->insertWidget(0, new EffectEditor(effect, this));
 }
 
 void PropertiesPanel::Clear()
 {
     for (auto w : findChildren<EffectEditor*>())
         w->Close();
+}
+
+void PropertiesPanel::ClearAdditionalPanels(int limit)
+{
+    QList<EffectEditor*> panels = findChildren<EffectEditor*>();
+    if (panels.size() >= limit)
+    {
+        for (int i = 0; i < panels.size() - limit; ++i)
+            panels.at(i)->Close();
+    }
 }
 
 void PropertiesPanel::Build()
@@ -71,9 +85,11 @@ void PropertiesPanel::Build()
     QHBoxLayout* optionsLayout = new QHBoxLayout;
     optionsLayout->setContentsMargins(8, 0, 8, 0);
     m_ClearButton = new QPushButton;
+    m_PanelCounter = new IntBoundLineEdit(1, 20, 10, this);
 
-    optionsLayout->addWidget(m_ClearButton);
+    optionsLayout->addWidget(m_PanelCounter);
     optionsLayout->addStretch(1);
+    optionsLayout->addWidget(m_ClearButton);
 
     BaseWidget* scrollWidget = new BaseWidget;
     scrollWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
@@ -92,6 +108,8 @@ void PropertiesPanel::Build()
 
 void PropertiesPanel::Setup()
 {
+    m_PanelCounter->setFixedWidth(25);
+
     m_ClearButton->setFixedSize(25, 25);
     m_ClearButton->setIcon(IconForge::GetIcon(IconType::icon_clear_all, _DARK_COLOR(QPalette::Text, 100)));
 }
@@ -99,6 +117,7 @@ void PropertiesPanel::Setup()
 void PropertiesPanel::Connect()
 {
     connect(m_ClearButton, &QPushButton::clicked, this, &PropertiesPanel::Clear);
+    connect(m_PanelCounter, &IntBoundLineEdit::currentValueChanged, this, &PropertiesPanel::ClearAdditionalPanels);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/Properties.cpp
+++ b/src/VoidUi/Editor/Properties.cpp
@@ -7,6 +7,7 @@
 
 /* Internal */
 #include "Properties.h"
+#include "VoidUi/Engine/IconForge.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -28,6 +29,8 @@ PropertiesPanel::PropertiesPanel(QWidget* parent)
     : QWidget(parent)
 {
     Build();
+    Setup();
+    Connect();
 }
 
 PropertiesPanel::~PropertiesPanel()
@@ -55,9 +58,22 @@ void PropertiesPanel::EditEffect(Effect* effect)
     m_ScrollLayout->addWidget(new EffectEditor(effect, this));
 }
 
+void PropertiesPanel::Clear()
+{
+    for (auto w : findChildren<EffectEditor*>())
+        w->Close();
+}
+
 void PropertiesPanel::Build()
 {
     m_Layout = new QVBoxLayout(this);
+
+    QHBoxLayout* optionsLayout = new QHBoxLayout;
+    optionsLayout->setContentsMargins(8, 0, 8, 0);
+    m_ClearButton = new QPushButton;
+
+    optionsLayout->addWidget(m_ClearButton);
+    optionsLayout->addStretch(1);
 
     BaseWidget* scrollWidget = new BaseWidget;
     scrollWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
@@ -69,8 +85,20 @@ void PropertiesPanel::Build()
     scrollArea->setWidgetResizable(true);
     scrollArea->setWidget(scrollWidget);
 
+    m_Layout->addLayout(optionsLayout);
     m_Layout->addWidget(scrollArea);
-    m_Layout->setContentsMargins(1, 1, 1, 1);
+    m_Layout->setContentsMargins(1, 8, 1, 1);
+}
+
+void PropertiesPanel::Setup()
+{
+    m_ClearButton->setFixedSize(25, 25);
+    m_ClearButton->setIcon(IconForge::GetIcon(IconType::icon_clear_all, _DARK_COLOR(QPalette::Text, 100)));
+}
+
+void PropertiesPanel::Connect()
+{
+    connect(m_ClearButton, &QPushButton::clicked, this, &PropertiesPanel::Clear);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/Properties.cpp
+++ b/src/VoidUi/Editor/Properties.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QPainter>
+#include <QScrollArea>
+
+/* Internal */
+#include "Properties.h"
+
+VOID_NAMESPACE_OPEN
+
+/* Scroll Area {{{ */
+
+class BaseWidget : public QWidget
+{
+protected:
+    void paintEvent(QPaintEvent* event) override
+    {
+        QPainter painter(this);
+        painter.fillRect(rect(), palette().color(QPalette::Base));
+    }
+};
+
+/* }}} */
+
+PropertiesPanel::PropertiesPanel(QWidget* parent)
+    : QWidget(parent)
+{
+    Build();
+}
+
+PropertiesPanel::~PropertiesPanel()
+{
+    m_ScrollLayout->deleteLater();
+    delete m_ScrollLayout;
+    m_ScrollLayout = nullptr;
+
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void PropertiesPanel::Show(QWidget* panel)
+{
+    m_ScrollLayout->addWidget(panel);
+}
+
+void PropertiesPanel::EditEffect(Effect* effect)
+{
+    // Remove any existing Editors for the same Effect before adding this again
+    for (auto w : findChildren<EffectEditor*>(effect->Name().c_str()))
+        w->Close();
+
+    m_ScrollLayout->addWidget(new EffectEditor(effect, this));
+}
+
+void PropertiesPanel::Build()
+{
+    m_Layout = new QVBoxLayout(this);
+
+    BaseWidget* scrollWidget = new BaseWidget;
+    scrollWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
+
+    m_ScrollLayout = new QVBoxLayout(scrollWidget);
+    m_ScrollLayout->setContentsMargins(4, 4, 4, 0);
+
+    QScrollArea* scrollArea = new QScrollArea;
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setWidget(scrollWidget);
+
+    m_Layout->addWidget(scrollArea);
+    m_Layout->setContentsMargins(1, 1, 1, 1);
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/Properties.h
+++ b/src/VoidUi/Editor/Properties.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _PROPERTIES_EDITOR_H
+#define _PROPERTIES_EDITOR_H
+
+/* Qt */
+#include <QWidget>
+#include <QLayout>
+
+/* Internal */
+#include "Definition.h"
+#include "Effects.h"
+
+VOID_NAMESPACE_OPEN
+
+class PropertiesPanel : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PropertiesPanel(QWidget* parent = nullptr);
+    ~PropertiesPanel();
+
+    void Show(QWidget* panel);
+    void EditEffect(Effect* effect);
+
+private: /* Members */
+    QVBoxLayout* m_Layout;
+    QVBoxLayout* m_ScrollLayout;
+
+private: /* Methods */
+    void Build();
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _PROPERTIES_EDITOR_H

--- a/src/VoidUi/Editor/Properties.h
+++ b/src/VoidUi/Editor/Properties.h
@@ -12,6 +12,7 @@
 /* Internal */
 #include "Definition.h"
 #include "Effects.h"
+#include "VoidUi/QExtensions/LineEdit.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -27,11 +28,13 @@ public:
     void EditEffect(Effect* effect);
 
     void Clear();
+    void ClearAdditionalPanels(int limit);
 
 private: /* Members */
     QVBoxLayout* m_Layout;
     QVBoxLayout* m_ScrollLayout;
     QPushButton* m_ClearButton;
+    IntBoundLineEdit* m_PanelCounter;
 
 private: /* Methods */
     void Build();

--- a/src/VoidUi/Editor/Properties.h
+++ b/src/VoidUi/Editor/Properties.h
@@ -7,6 +7,7 @@
 /* Qt */
 #include <QWidget>
 #include <QLayout>
+#include <QPushButton>
 
 /* Internal */
 #include "Definition.h"
@@ -25,12 +26,17 @@ public:
     void Show(QWidget* panel);
     void EditEffect(Effect* effect);
 
+    void Clear();
+
 private: /* Members */
     QVBoxLayout* m_Layout;
     QVBoxLayout* m_ScrollLayout;
+    QPushButton* m_ClearButton;
 
 private: /* Methods */
     void Build();
+    void Setup();
+    void Connect();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/Properties.h
+++ b/src/VoidUi/Editor/Properties.h
@@ -24,6 +24,8 @@ public:
     explicit PropertiesPanel(QWidget* parent = nullptr);
     ~PropertiesPanel();
 
+    QSize sizeHint() const override { return QSize(300, 720); }
+
     void Show(QWidget* panel);
     void EditEffect(Effect* effect);
 

--- a/src/VoidUi/Engine/IconTypes.h
+++ b/src/VoidUi/Engine/IconTypes.h
@@ -19,6 +19,7 @@ enum class IconType : char16_t
     icon_build              = 0xe869,
     icon_browse             = 0xeb13,
     icon_brush              = 0xe3ae,
+    icon_clear_all          = 0xe0b8,
     icon_close              = 0xe5cd,
     icon_computer_cancel    = 0xf2f6,
     icon_delete             = 0xe872,

--- a/src/VoidUi/Engine/IconTypes.h
+++ b/src/VoidUi/Engine/IconTypes.h
@@ -49,6 +49,8 @@ enum class IconType : char16_t
     icon_title              = 0xe264,
     icon_trending_flat      = 0xe8e4,
     icon_view_stream        = 0xe8f2,
+    icon_visible            = 0xe8f4,
+    icon_visible_off        = 0xe8f5,
     icon_volume_up          = 0xe050,
 };
 

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -26,16 +26,10 @@ VOID_NAMESPACE_OPEN
 VoidMediaLister::VoidMediaLister(QWidget* parent)
     : QWidget(parent)
 {
-    /* Build Layout */
     Build();
-
-    /* Connect Signals */
     Connect();
-
-    /* Setup UI */
     Setup();
 
-    /* Accept drops */
     setAcceptDrops(true);
 }
 
@@ -86,18 +80,11 @@ VoidMediaLister::~VoidMediaLister()
     m_ClearTagsAction = nullptr;
 }
 
-QSize VoidMediaLister::sizeHint() const
-{
-    return QSize(300, 720);
-}
-
 void VoidMediaLister::dragEnterEvent(QDragEnterEvent* event)
 {
     /* Check if we have urls in the mime data */
     if (event->mimeData()->hasUrls())
-    {
         event->acceptProposedAction();
-    }
 }
 
 void VoidMediaLister::dropEvent(QDropEvent* event)

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -73,6 +73,10 @@ VoidMediaLister::~VoidMediaLister()
     delete m_InspectMetadataAction;
     m_InspectMetadataAction = nullptr;
 
+    m_EditEffectsAction->deleteLater();
+    delete m_EditEffectsAction;
+    m_EditEffectsAction = nullptr;
+
     m_AddTagAction->deleteLater();
     delete m_AddTagAction;
     m_AddTagAction = nullptr;
@@ -124,6 +128,7 @@ void VoidMediaLister::Build()
     m_AddToQueueAction = new QAction("Add Selected to Queue");
     m_RemoveAction = new QAction("Remove Selected");
     m_InspectMetadataAction = new QAction("Show in Metadata Viewer");
+    m_EditEffectsAction = new QAction("Edit Effects");
 
     m_AddTagAction = new QAction("Add tag...");
     m_ClearTagsAction = new QAction("Clear all tags");
@@ -259,6 +264,7 @@ void VoidMediaLister::Connect()
     connect(m_AddToQueueAction, &QAction::triggered, this, &VoidMediaLister::AddSelectionToQueue);
     connect(m_RemoveAction, &QAction::triggered, this, &VoidMediaLister::RemoveSelectedMedia);
     connect(m_InspectMetadataAction, &QAction::triggered, this, &VoidMediaLister::InspectMetadata);
+    connect(m_EditEffectsAction, &QAction::triggered, this, &VoidMediaLister::EditEffects);
     connect(m_AddTagAction, &QAction::triggered, this, &VoidMediaLister::AddTagToSelected);
     connect(m_ClearTagsAction, &QAction::triggered, this, &VoidMediaLister::ClearTagsFromSelected);
 
@@ -373,6 +379,7 @@ void VoidMediaLister::ShowContextMenu(const _QPoint& position)
 
     contextMenu.addSeparator();
     contextMenu.addAction(m_InspectMetadataAction);
+    contextMenu.addAction(m_EditEffectsAction);
 
     contextMenu.addSeparator();
     contextMenu.addMenu(m_PlaylistMenu);
@@ -402,6 +409,15 @@ void VoidMediaLister::InspectMetadata()
 
     /* We can only inspect one item at a time */
     emit metadataInspected(*(static_cast<SharedMediaClip*>(selected[0].internalPointer())));
+}
+
+void VoidMediaLister::EditEffects()
+{
+    QModelIndex current = m_MediaView->currentIndex();
+    if (current.isValid())
+    {
+        emit effectsEdited(_MediaBridge.MediaAt(current));
+    }
 }
 
 void VoidMediaLister::SetFromPreferences()

--- a/src/VoidUi/Media/MediaLister.h
+++ b/src/VoidUi/Media/MediaLister.h
@@ -37,7 +37,7 @@ public:
     virtual ~VoidMediaLister();
 
     /* Override the default size of the widget */
-    QSize sizeHint() const override;
+    QSize sizeHint() const override { return QSize(300, 720); }
 
 signals:
     void mediaChanged(const SharedMediaClip&);

--- a/src/VoidUi/Media/MediaLister.h
+++ b/src/VoidUi/Media/MediaLister.h
@@ -46,6 +46,7 @@ signals:
     void mediaDropped(const std::string&);
     /* When a Media is inspected of its Metdata */
     void metadataInspected(const SharedMediaClip&);
+    void effectsEdited(const SharedMediaClip&);
 
 protected: /* Methods */
     void dragEnterEvent(QDragEnterEvent* event) override;
@@ -68,6 +69,7 @@ private: /* Methods */
     void AddSelectionToQueue();
     void RemoveSelectedMedia();
     void InspectMetadata();
+    void EditEffects();
 
     void IndexSelected(const QModelIndex& index);
 
@@ -97,6 +99,7 @@ private: /* Members */
     QAction* m_AddToQueueAction;
     QAction* m_RemoveAction;
     QAction* m_InspectMetadataAction;
+    QAction* m_EditEffectsAction;
     QAction* m_AddTagAction;
     QAction* m_ClearTagsAction;
     QMenu* m_PlaylistMenu;

--- a/src/VoidUi/Media/Views/MediaView.cpp
+++ b/src/VoidUi/Media/Views/MediaView.cpp
@@ -30,17 +30,26 @@ MediaView::MediaView(QWidget* parent)
 
 MediaView::~MediaView()
 {
-    m_BasicDelegate->deleteLater();
-    delete m_BasicDelegate;
-    m_BasicDelegate = nullptr;
+    if (m_BasicDelegate)
+    {
+        m_BasicDelegate->deleteLater();
+        delete m_BasicDelegate;
+        m_BasicDelegate = nullptr;
+    }
 
-    m_MediaDelegate->deleteLater();
-    delete m_MediaDelegate;
-    m_MediaDelegate = nullptr;
+    if (m_MediaDelegate)
+    {
+        m_MediaDelegate->deleteLater();
+        delete m_MediaDelegate;
+        m_MediaDelegate = nullptr;
+    }
 
-    m_ThumbnailDelegate->deleteLater();
-    delete m_ThumbnailDelegate;
-    m_ThumbnailDelegate = nullptr;
+    if (m_ThumbnailDelegate)
+    {
+        m_ThumbnailDelegate->deleteLater();
+        delete m_ThumbnailDelegate;
+        m_ThumbnailDelegate = nullptr;
+    }
 
     /**
      * Set the source Model as nullpointer so that we don't actually delete

--- a/src/VoidUi/Player/ViewerBuffer.h
+++ b/src/VoidUi/Player/ViewerBuffer.h
@@ -52,7 +52,7 @@ struct BufferData
     explicit operator bool() const { return (bool)image; }
 };
 
-class ViewerBuffer : public QObject
+class VOID_API ViewerBuffer : public QObject
 {
     Q_OBJECT
 

--- a/src/VoidUi/Preferences/Preferences.h
+++ b/src/VoidUi/Preferences/Preferences.h
@@ -23,6 +23,7 @@ namespace Settings
     constexpr auto RecentProjects = "recents/projects";
     constexpr auto DontShowStartup = "startup/dontShowPopup";
     constexpr auto LastBrowsedLocation = "recents/browsed";
+    constexpr auto DefaultWorkspace = "ui/workspace";
 }
 
 class VOID_API VoidPreferences : public QObject
@@ -57,6 +58,7 @@ public:
     inline int GetColorStyle() const { return GetSetting(Settings::ColorStyle).toInt(); }
     inline bool ShowStartup() const { return !GetSetting(Settings::DontShowStartup).toBool(); }
     inline QString LastBrowsed() const { return GetSetting(Settings::LastBrowsedLocation).toString(); }
+    inline int GetDefaultWorkspace() const { return GetSetting(Settings::DefaultWorkspace).toInt(); }
 
     void AddRecentProject(const std::string& path);
     std::vector<std::string> RecentProjects();

--- a/src/VoidUi/QExtensions/LineEdit.cpp
+++ b/src/VoidUi/QExtensions/LineEdit.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QIntValidator>
+#include <QKeyEvent>
+
+/* Internal */
+#include "LineEdit.h"
+
+VOID_NAMESPACE_OPEN
+
+IntBoundLineEdit::IntBoundLineEdit(int lower, int upper, QWidget* parent)
+    : QLineEdit(parent)
+    , m_Last(QString::number(upper))
+{
+    setValidator(new QIntValidator(lower, upper, this));
+}
+
+IntBoundLineEdit::IntBoundLineEdit(int lower, int upper, int value, QWidget* parent)
+    : QLineEdit(parent)
+    , m_Last(QString::number(value))
+{
+    setText(m_Last);
+    setValidator(new QIntValidator(lower, upper, this));   
+}
+
+void IntBoundLineEdit::focusOutEvent(QFocusEvent* event)
+{
+    QLineEdit::focusOutEvent(event);
+    Validate();
+}
+
+void IntBoundLineEdit::keyPressEvent(QKeyEvent* event)
+{
+    QLineEdit::keyPressEvent(event);
+
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
+        Validate();
+}
+
+void IntBoundLineEdit::Validate()
+{
+    QString t = text();
+
+    if (t == m_Last)
+        return;
+
+    int pos = 0;
+    if (validator()->validate(t, pos) == QIntValidator::Acceptable)
+    {
+        m_Last = t;
+        emit currentValueChanged(t.toInt());
+    }
+    else
+    {
+        setText(m_Last);
+    }
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/LineEdit.h
+++ b/src/VoidUi/QExtensions/LineEdit.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _Q_EXT_LINE_EDIT_H
+#define _Q_EXT_LINE_EDIT_H
+
+/* Qt */
+#include <QLineEdit>
+
+/* Internal */
+#include "Definition.h"
+
+VOID_NAMESPACE_OPEN
+
+class IntBoundLineEdit : public QLineEdit
+{
+    Q_OBJECT
+
+public:
+    IntBoundLineEdit(int lower, int upper, QWidget* parent = nullptr);
+    IntBoundLineEdit(int lower, int upper, int value, QWidget* parent = nullptr);
+
+    int CurrentValue() const { return text().toInt(); }
+
+signals:
+    void currentValueChanged(int value);
+
+protected:
+    void focusOutEvent(QFocusEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+
+private: /* Members */
+    QString m_Last;
+
+private:
+    void Validate();
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _Q_EXT_LINE_EDIT_H

--- a/src/include/Operator.h
+++ b/src/include/Operator.h
@@ -6,7 +6,7 @@
 
 /* STD */
 #include <memory>
-#include <unordered_map>
+#include <map>
 
 /* Internal */
 #include "Definition.h"
@@ -23,12 +23,14 @@ public:
     Param* GetParam(const std::string& name);    
     virtual bool Evaluate(ImageRow& row) = 0;
 
+    const std::map<std::string, Param>& Params() const { return m_Params; }
+
 protected:
     Param* AddParam(const Param& param);
     Param* AddParam(Param&& param);
 
 private:
-    std::unordered_map<std::string, Param> m_Params;
+    std::map<std::string, Param> m_Params;
 };
 
 typedef std::shared_ptr<ImageOp> SharedImageOp;

--- a/src/include/Param.h
+++ b/src/include/Param.h
@@ -14,7 +14,7 @@
 
 VOID_NAMESPACE_OPEN
 
-typedef std::variant<bool, int, float, std::string> ValueType;
+typedef std::variant<bool, int, float, std::string, std::monostate> ValueType;
 
 class VOID_API ParamValue
 {
@@ -57,18 +57,27 @@ struct VOID_API Param
     enum class TypeDesc { Int, Float, Boolean, String };
 
     std::string name;
+    std::string label;
+    std::string description;
     TypeDesc type;
     ParamValue value;
+    ParamValue preset;
 
     Param()
-        : name(""), type(TypeDesc::Int), value(0) {}
+        : name(""), label(""), description(""), type(TypeDesc::Int), value(0), preset(0) {}
 
-    Param(std::string name, ParamValue value, const TypeDesc& type)
-        : name(std::move(name)), type(type), value(std::move(value)) {}
+    Param(std::string name, std::string label, ParamValue value, const TypeDesc& type)
+        : name(std::move(name)), label(std::move(label)), description("")
+        , type(type), value(value), preset(std::move(value)) {}
+
+    Param(std::string name, std::string label, std::string description, ParamValue value, const TypeDesc& type)
+        : name(std::move(name)), label(std::move(label)), description(std::move(description))
+        , type(type), value(value), preset(std::move(value)) {}
 
     template <typename _Ty>
     void SetValue(_Ty v) { value.Set(v); }
     void SetValue(ValueType v) { value.SetValue(v); }
+    void ResetValue() { value = preset; }
     const ValueType& Value() const { return value.Value(); }
 
     // Helpers


### PR DESCRIPTION
## Feat: Add Editor for Effect allowing users to Modify the params for image processing.
- Added Effect Editor widget showing the dynamic params for a Node/Effect/Operator.
- Added Properties Panel as a base widget which can be docked and is a part of the workspace manager.
- Updated Param to reset its value to default.
- Added Support for Editing Workspace through workspace manager
- Workspace manager also saves the default workspace in the preferences and allow users to set a default workspace.

## Additional Fixes:
- Ensure the ffmpeg code can be compiled with ffmpeg version < 8.0 (i.e. libswscale version < 9)
- Fixed the issue where MediaView would cause seg faults on destruction as the delegates weren't initiatlized.