### PR TITLE
[VOID] MediaQueue

### DIFF
--- a/src/VoidObjects/Models/MediaModel.cpp
+++ b/src/VoidObjects/Models/MediaModel.cpp
@@ -4,6 +4,7 @@
 /* Internal */
 #include "MediaModel.h"
 #include "VoidCore/VoidTools.h"
+#include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -73,7 +74,22 @@ Qt::ItemFlags MediaModel::flags(const QModelIndex& index) const
     if (!index.isValid())
         return Qt::NoItemFlags;
 
-    return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled;
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+}
+
+bool MediaModel::moveRows(const QModelIndex& sourceParent, int sourceRow, int count, const QModelIndex& destinationParent, int destinationChild)
+{
+    if (sourceRow < 0 || sourceRow >= static_cast<int>(m_Media.size()) ||
+        destinationChild < 0 || destinationChild >= static_cast<int>(m_Media.size()) || count != 1)
+        return false;
+
+    beginMoveRows(sourceParent, sourceRow, sourceRow, destinationParent, destinationChild);
+    auto media = m_Media[sourceRow];
+    m_Media.erase(m_Media.begin() + sourceRow);
+
+    m_Media.insert(m_Media.begin() + destinationChild, media);
+    endMoveRows();
+    return true;
 }
 
 std::string MediaModel::ItemFramerate(const SharedMediaClip& clip) const
@@ -159,6 +175,24 @@ SharedMediaClip MediaModel::LastMedia() const
         return nullptr;
 
     return m_Media.back();
+}
+
+QModelIndex MediaModel::ShiftIndexUp(const QModelIndex& index)
+{
+    if (!index.isValid() || index.row() == 0)
+        return QModelIndex();
+
+    std::swap(m_Media[index.row()], m_Media[index.row() - 1]);
+    return createIndex(index.row() - 1, index.column());
+}
+
+QModelIndex MediaModel::ShiftIndexDown(const QModelIndex& index)
+{
+    if (!index.isValid() || index.row() == m_Media.size() - 1)
+        return QModelIndex();
+
+    std::swap(m_Media[index.row()], m_Media[index.row() + 1]);
+    return createIndex(index.row() + 1, index.column());
 }
 
 void MediaModel::Update()

--- a/src/VoidObjects/Models/MediaModel.h
+++ b/src/VoidObjects/Models/MediaModel.h
@@ -52,6 +52,9 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
     Qt::ItemFlags flags(const QModelIndex& index) const override;
+    Qt::DropActions supportedDropActions() const override { return Qt::MoveAction; }
+
+    bool moveRows(const QModelIndex& sourceParent, int sourceRow, int count, const QModelIndex& destinationParent, int destinationChild) override;
 
     /* Media */
     void Add(const SharedMediaClip& media);
@@ -67,6 +70,9 @@ public:
     SharedMediaClip LastMedia() const;
 
     void Clear() { m_Media.clear(); }
+
+    QModelIndex ShiftIndexUp(const QModelIndex& index);
+    QModelIndex ShiftIndexDown(const QModelIndex& index);
 
     /* Iterator */
     inline std::vector<SharedMediaClip>::const_iterator cbegin() const noexcept { return m_Media.cbegin(); }

--- a/src/VoidObjects/Playlist/Playlist.h
+++ b/src/VoidObjects/Playlist/Playlist.h
@@ -42,6 +42,9 @@ public:
     inline SharedMediaClip Media(const QModelIndex& index) const { return m_Media->Media(index); }
     inline SharedMediaClip Media(int row, int column) const { return m_Media->Media(m_Media->index(row, column)); }
 
+    QModelIndex ShiftIndexUp(const QModelIndex& index) { return m_Media->ShiftIndexUp(index); }
+    QModelIndex ShiftIndexDown(const QModelIndex& index) { return m_Media->ShiftIndexDown(index); }
+
     inline SharedMediaClip CurrentMedia() const { return m_Media->Media(m_Media->index(m_CurrentRow, 0)); }
     SharedMediaClip NextMedia();
     SharedMediaClip PreviousMedia();

--- a/src/VoidUi/BaseWindow/WorkspaceManager.cpp
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.cpp
@@ -19,6 +19,8 @@ WorkspaceManager::~WorkspaceManager()
     m_PlayLister->deleteLater();
     m_ScriptEditor->deleteLater();
     m_MetadataViewer->deleteLater();
+    m_PropertiesEditor->deleteLater();
+    m_MediaQueue->deleteLater();
 }
 
 QWidget* WorkspaceManager::Widget(const Component& component) const
@@ -32,17 +34,20 @@ void WorkspaceManager::Init()
     DockManager& manager = DockManager::Instance();
 
     // Media Lister Widget
-    m_MediaLister = new VoidMediaLister();
-    m_PlayLister = new VoidPlayLister();
+    m_MediaLister = new VoidMediaLister;
+    m_PlayLister = new VoidPlayLister;
 
     // Python Script Editor
-    m_ScriptEditor = new PyScriptEditor();
+    m_ScriptEditor = new PyScriptEditor;
 
     // Media Metadata Viewer
-    m_MetadataViewer = new MetadataViewer();
+    m_MetadataViewer = new MetadataViewer;
 
     // Properties Editor
-    m_PropertiesEditor = new PropertiesPanel();
+    m_PropertiesEditor = new PropertiesPanel;
+
+    // Queue viewer
+    m_MediaQueue = new MediaQueue;
 
     manager.RegisterDock(m_MediaLister, "Media View");
     manager.RegisterDock(_PlayerBridge.ActivePlayer(), "Viewer");
@@ -50,6 +55,7 @@ void WorkspaceManager::Init()
     manager.RegisterDock(m_MetadataViewer, "Metadata Viewer");
     manager.RegisterDock(m_PlayLister, "Playlist View");
     manager.RegisterDock(m_PropertiesEditor, "Properties");
+    manager.RegisterDock(m_MediaQueue, "Media Queue");
 
     // Docker
     m_Splitter = new DockSplitter(Qt::Horizontal, this);
@@ -61,6 +67,7 @@ void WorkspaceManager::Connect()
     connect(m_MediaLister, &VoidMediaLister::effectsEdited, this, &WorkspaceManager::EditEffects);
     connect(m_MediaLister, &VoidMediaLister::metadataInspected, this, &WorkspaceManager::InspectMetadata);
     connect(_PlayerBridge.ActivePlayer(), &Player::metadataInspected, this, &WorkspaceManager::InspectMetadata);
+    connect(_PlayerBridge.ActivePlayer(), &Player::playlistUpdated, this, &WorkspaceManager::UpdateMediaQueue);
 }
 
 void WorkspaceManager::InitMenu(MenuSystem* menuSystem)
@@ -147,6 +154,11 @@ void WorkspaceManager::InspectMetadata(const SharedMediaClip& media)
     const DockStruct d = DockManager::Instance().Dock(static_cast<int>(Component::MetadataViewer));
     if (!d.widget->isVisible())
         ShowComponent(Component::MetadataViewer);
+}
+
+void WorkspaceManager::UpdateMediaQueue(Playlist* playlist)
+{
+    m_MediaQueue->Set(playlist);
 }
 
 void WorkspaceManager::EditEffects(const SharedMediaClip& media)

--- a/src/VoidUi/BaseWindow/WorkspaceManager.h
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.h
@@ -18,6 +18,7 @@
 #include "VoidUi/Playlist/PlayLister.h"
 #include "VoidUi/ScriptEditor/ScriptEditor.h"
 #include "VoidUi/QExtensions/Window.h"
+#include "VoidUi/Media/MediaQueue.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -45,6 +46,7 @@ enum class Component
     MetadataViewer,
     PlayLister,
     Properties,
+    MediaQueue,
 };
 
 class WorkspaceManager : public MainWindow
@@ -71,12 +73,14 @@ private: /* Members */
     PyScriptEditor* m_ScriptEditor;
     MetadataViewer* m_MetadataViewer;
     PropertiesPanel* m_PropertiesEditor;
+    MediaQueue* m_MediaQueue;
 
     Workspace m_Current;
 
 private: /* Members */
     void Clear();
     void InspectMetadata(const SharedMediaClip& media);
+    void UpdateMediaQueue(Playlist* playlist);
     void EditEffects(const SharedMediaClip& media);
     void ShowComponent(const Component& component) const;
 };

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -37,11 +37,13 @@ set(SOURCES
     Media/MediaSearchBar.cpp
     Media/MetadataViewer.cpp
     Media/TagWidget.cpp
+    Media/MediaQueue.cpp
     Media/Models/MetadataModel.cpp
     Media/Models/MediaFilesModel.cpp
     Media/Views/FileView.cpp
     Media/Views/MediaView.cpp
     Media/Views/MetadataView.cpp
+    Media/Views/QueueView.cpp
     Media/Delegates/ListDelegate.cpp
     Media/Delegates/ThumbnailDelegate.cpp
 

--- a/src/VoidUi/Engine/IconTypes.h
+++ b/src/VoidUi/Engine/IconTypes.h
@@ -24,6 +24,8 @@ enum class IconType : char16_t
     icon_computer_cancel    = 0xf2f6,
     icon_delete             = 0xe872,
     icon_draw               = 0xe746,
+    icon_expand_circle_down = 0xe7cd,
+    icon_expand_circle_up   = 0xf5d2,
     icon_file_open          = 0xeaf3,
     icon_fast_forward       = 0xe01f,
     icon_fast_rewind        = 0xe020,

--- a/src/VoidUi/Media/MediaQueue.cpp
+++ b/src/VoidUi/Media/MediaQueue.cpp
@@ -2,10 +2,12 @@
 // Licensed under the MIT License
 
 /* Qt */
+#include <QKeyEvent>
 
 /* Internal */
 #include "MediaQueue.h"
 #include "VoidUi/Engine/IconForge.h"
+#include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -32,6 +34,20 @@ void MediaQueue::Set(Playlist* playlist)
 {
     m_Playlist = playlist;
     m_Playlist ? m_View->Set(playlist) : m_View->Clear();
+}
+
+bool MediaQueue::eventFilter(QObject* object, QEvent* event)
+{
+    if (event->type() == QEvent::ShortcutOverride)
+    {
+        QKeyEvent* k = static_cast<QKeyEvent*>(event);
+        #ifdef _VOID_PLATFORM_APPLE
+        if (k->key() == Qt::Key_Backspace) m_Playlist->RemoveMedia(m_View->currentIndex());
+        #else
+        if (k->key() == Qt::Key_Delete) m_Playlist->RemoveMedia(m_View->currentIndex());
+        #endif
+    }
+    return true;
 }
 
 void MediaQueue::Build()
@@ -62,6 +78,8 @@ void MediaQueue::Setup()
 
     m_MoveDownArrow->setIcon(IconForge::GetIcon(IconType::icon_expand_circle_down, _DARK_COLOR(QPalette::Text, 100)));
     m_MoveUpArrow->setIcon(IconForge::GetIcon(IconType::icon_expand_circle_up, _DARK_COLOR(QPalette::Text, 100)));
+
+    installEventFilter(this);
 }
 
 void MediaQueue::Connect()
@@ -76,7 +94,7 @@ void MediaQueue::Connect()
     {
         QModelIndex index = m_Playlist->ShiftIndexUp(m_View->currentIndex());
         if (index.isValid())
-            m_View->setCurrentIndex(index);    
+            m_View->setCurrentIndex(index);
     });
 }
 

--- a/src/VoidUi/Media/MediaQueue.cpp
+++ b/src/VoidUi/Media/MediaQueue.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+
+/* Internal */
+#include "MediaQueue.h"
+#include "VoidUi/Engine/IconForge.h"
+
+VOID_NAMESPACE_OPEN
+
+MediaQueue::MediaQueue(QWidget* parent)
+    : QWidget(parent)
+{
+    Build();
+    Setup();
+    Connect();
+}
+
+MediaQueue::~MediaQueue()
+{
+    m_View->deleteLater();
+    delete m_View;
+    m_View = nullptr;
+
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void MediaQueue::Set(Playlist* playlist)
+{
+    m_Playlist = playlist;
+    m_Playlist ? m_View->Set(playlist) : m_View->Clear();
+}
+
+void MediaQueue::Build()
+{
+    m_Layout = new QVBoxLayout(this);
+
+    QHBoxLayout* buttonLayout = new QHBoxLayout;
+
+    m_MoveUpArrow = new QPushButton;
+    m_MoveDownArrow = new QPushButton;
+
+    buttonLayout->addWidget(m_MoveDownArrow);
+    buttonLayout->addWidget(m_MoveUpArrow);
+    buttonLayout->addStretch(1);
+
+    m_View = new QueueView(this);
+    m_Layout->addLayout(buttonLayout);
+    m_Layout->addWidget(m_View);
+
+    auto margins = m_Layout->contentsMargins();
+    m_Layout->setContentsMargins(2, margins.top(), 2, 2);
+}
+
+void MediaQueue::Setup()
+{
+    m_MoveDownArrow->setFixedWidth(25);
+    m_MoveUpArrow->setFixedWidth(25);
+
+    m_MoveDownArrow->setIcon(IconForge::GetIcon(IconType::icon_expand_circle_down, _DARK_COLOR(QPalette::Text, 100)));
+    m_MoveUpArrow->setIcon(IconForge::GetIcon(IconType::icon_expand_circle_up, _DARK_COLOR(QPalette::Text, 100)));
+}
+
+void MediaQueue::Connect()
+{
+    connect(m_MoveDownArrow, &QPushButton::clicked, this, [&]() -> void
+    {
+        QModelIndex index = m_Playlist->ShiftIndexDown(m_View->currentIndex());
+        if (index.isValid())
+            m_View->setCurrentIndex(index);
+    });
+    connect(m_MoveUpArrow, &QPushButton::clicked, this, [&]() -> void
+    {
+        QModelIndex index = m_Playlist->ShiftIndexUp(m_View->currentIndex());
+        if (index.isValid())
+            m_View->setCurrentIndex(index);    
+    });
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/MediaQueue.h
+++ b/src/VoidUi/Media/MediaQueue.h
@@ -21,6 +21,10 @@ public:
     void Set(Playlist* playlist);
     void Clear() { m_View->Clear(); }
 
+protected:
+    // TODO: Check why the shortcut doesn't work and replace this with the Shortcut Override
+    bool eventFilter(QObject* object, QEvent* event) override;
+
 private: /* Members */
     QVBoxLayout* m_Layout;
     QPushButton* m_MoveUpArrow;

--- a/src/VoidUi/Media/MediaQueue.h
+++ b/src/VoidUi/Media/MediaQueue.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QWidget>
+#include <QLayout>
+#include <QPushButton>
+
+/* Internal */
+#include "Definition.h"
+#include "VoidUi/Media/Views/QueueView.h"
+
+VOID_NAMESPACE_OPEN
+
+class MediaQueue : public QWidget
+{
+public:
+    explicit MediaQueue(QWidget* parent = nullptr);
+    ~MediaQueue();
+
+    void Set(Playlist* playlist);
+    void Clear() { m_View->Clear(); }
+
+private: /* Members */
+    QVBoxLayout* m_Layout;
+    QPushButton* m_MoveUpArrow;
+    QPushButton* m_MoveDownArrow;
+    QueueView* m_View;
+
+    Playlist* m_Playlist;
+
+private: /* Methods */
+    void Build();
+    void Setup();
+    void Connect();
+};
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/Views/QueueView.cpp
+++ b/src/VoidUi/Media/Views/QueueView.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QDropEvent>
+
+/* Internal */
+#include "QueueView.h"
+#include "VoidUi/Media/Delegates/ListDelegate.h"
+#include "VoidCore/Logging.h"
+
+VOID_NAMESPACE_OPEN
+
+QueueView::QueueView(QWidget* parent)
+    : QListView(parent)
+{
+    setItemDelegate(new MediaItemDelegate(this));
+    setSpacing(1);
+
+    setDragEnabled(true);
+    setAcceptDrops(true);
+    setDropIndicatorShown(true);
+    setDragDropMode(QAbstractItemView::InternalMove);
+    setDefaultDropAction(Qt::MoveAction);
+}
+
+QueueView::~QueueView()
+{
+}
+
+void QueueView::Set(Playlist* playlist)
+{
+    setModel(playlist->DataModel());
+}
+
+void QueueView::Clear()
+{
+    setModel(nullptr);
+}
+
+void QueueView::dropEvent(QDropEvent* event)
+{
+    QModelIndex index = indexAt(event->pos());
+    int dest = index.isValid() ? index.row() : model()->rowCount();
+
+    // Currently we have single selection only
+    int source = currentIndex().row();
+    model()->moveRows(QModelIndex(), source, 1, QModelIndex(), dest);
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/Views/QueueView.cpp
+++ b/src/VoidUi/Media/Views/QueueView.cpp
@@ -7,7 +7,6 @@
 /* Internal */
 #include "QueueView.h"
 #include "VoidUi/Media/Delegates/ListDelegate.h"
-#include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
 

--- a/src/VoidUi/Media/Views/QueueView.h
+++ b/src/VoidUi/Media/Views/QueueView.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QListView>
+
+/* Internal */
+#include "Definition.h"
+#include "VoidObjects/Playlist/Playlist.h"
+
+VOID_NAMESPACE_OPEN
+
+class QueueView : public QListView
+{
+public:
+    explicit QueueView(QWidget* parent = nullptr);
+    ~QueueView();
+
+    void Set(Playlist* playlist);
+    void Clear();
+
+protected:
+    void dropEvent(QDropEvent* event) override;
+};
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/Views/QueueView.h
+++ b/src/VoidUi/Media/Views/QueueView.h
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+#ifndef _QUEUE_VIEW_H
+#define _QUEUE_VIEW_H
+
 /* Qt */
 #include <QListView>
 
@@ -24,3 +27,5 @@ protected:
 };
 
 VOID_NAMESPACE_CLOSE
+
+#endif // _QUEUE_VIEW_H

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -243,6 +243,9 @@ void Player::Connect()
     connect(m_ControlBar, &ControlBar::viewerBufferSwitched, this, &Player::ResetViewBuffer);
     connect(m_ControlBar, &ControlBar::comparisonModeChanged, this, &Player::SetComparisonMode);
     connect(m_ControlBar, &ControlBar::blendModeChanged, this, &Player::SetBlendMode);
+
+    // ViewerBuffer
+    connect(&m_ViewBufferA, &ViewerBuffer::playlistUpdated, this, &Player::playlistUpdated);
 }
 
 void Player::PauseCache()

--- a/src/VoidUi/Player/Player.h
+++ b/src/VoidUi/Player/Player.h
@@ -59,6 +59,7 @@ signals:
      * @param clip: The Shared pointer to the Media clip for which the metadata is to be inspected.
      */
     void metadataInspected(const SharedMediaClip&);
+    void playlistUpdated(Playlist*);
 
 protected:
     void dragEnterEvent(QDragEnterEvent* event) override;

--- a/src/VoidUi/Player/PlayerWidget.h
+++ b/src/VoidUi/Player/PlayerWidget.h
@@ -133,7 +133,6 @@ public:
     inline void ResetOutFrame() { m_Timeline->ResetOutFrame(); }
     inline void ResetRange() { m_Timeline->ResetRange(); }
 
-public:
     void Clear();
 
 protected:  /* Methods */

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -60,6 +60,8 @@ void ViewerBuffer::Set(const SharedMediaClip& media)
     m_PlayingComponent = PlayableComponent::Clip;
     UpdateRange(m_Clip->FirstFrame(), m_Clip->LastFrame());
     EnsureCached(media->FirstFrame());
+
+    emit playlistUpdated(nullptr);
     CacheAvailable();
 }
 
@@ -119,6 +121,8 @@ void ViewerBuffer::SetPlaylist(Playlist* playlist)
 
     m_PlayingComponent = PlayableComponent::Playlist;
     UpdateRange(m_Clip->FirstFrame(), m_Clip->LastFrame());
+
+    emit playlistUpdated(playlist);
 
     EnsureCached(m_Clip->FirstFrame());
     CacheAvailable();

--- a/src/VoidUi/Player/ViewerBuffer.h
+++ b/src/VoidUi/Player/ViewerBuffer.h
@@ -248,6 +248,7 @@ public:
 
 signals:
     void updated();
+    void playlistUpdated(Playlist*);
 
 private: /* Members */
     /**


### PR DESCRIPTION
## Feat: Added UI for Showing the Media Queue
### Details
Media Queue is used when items from the Media view are selected to be played in a queue.
Media Queue UI represents visually what's being played at the moment and then also provides users a way to edit the queue by dragging-arranging media or with the help of shift buttons (Shift Up/Shift Down)

This will also be used to allow users to set media as a layout view/contact sheet in the Viewport when that is implemented and control which media comes where in the layout view.