### PR TITLE
[VOID] Media: Fixed issues with Media removal

### DIFF
--- a/src/VoidObjects/Project/Project.cpp
+++ b/src/VoidObjects/Project/Project.cpp
@@ -63,7 +63,7 @@ void Project::InsertMedia(const SharedMediaClip& media, const int index)
 
 void Project::RemoveMedia(const QModelIndex& index)
 {
-    m_Media->Remove(index);
+    m_Media->Remove(index, false);
     /* Update the modification state for the project */
     m_Modified = true;
 }

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -249,7 +249,7 @@ void VoidMediaLister::Connect()
     connect(m_PlayAction, &QAction::triggered, this, &VoidMediaLister::AddSelectionToSequence);
     connect(m_PlayAsListAction, &QAction::triggered, this, &VoidMediaLister::PlaySelectionAsQueue);
     connect(m_AddToQueueAction, &QAction::triggered, this, &VoidMediaLister::AddSelectionToQueue);
-    connect(m_RemoveAction, &QAction::triggered, this, &VoidMediaLister::RemoveSelectedMedia);
+    connect(m_RemoveAction, &QAction::triggered, m_MediaView, &MediaView::RemoveSelectedMedia);
     connect(m_InspectMetadataAction, &QAction::triggered, this, &VoidMediaLister::InspectMetadata);
     connect(m_EditEffectsAction, &QAction::triggered, this, &VoidMediaLister::EditEffects);
     connect(m_AddTagAction, &QAction::triggered, this, &VoidMediaLister::AddTagToSelected);
@@ -281,7 +281,7 @@ void VoidMediaLister::Connect()
     connect(&_MediaBridge, &MBridge::updated, this, &VoidMediaLister::RebuildPlaylistMenu);
 
     /* Shortcut */
-    connect(m_DeleteShortcut, &QShortcut::activated, this, &VoidMediaLister::RemoveSelectedMedia);
+    connect(m_DeleteShortcut, &QShortcut::activated, m_MediaView, &MediaView::RemoveSelectedMedia);
 
     /* Preferences */
     connect(&VoidPreferences::Instance(), &VoidPreferences::updated, this, &VoidMediaLister::SetFromPreferences);
@@ -382,11 +382,11 @@ void VoidMediaLister::ShowContextMenu(const _QPoint& position)
     #endif // _QT6
 }
 
-void VoidMediaLister::RemoveSelectedMedia()
-{
-    /* Push all of the selected indexes for removal */
-    _MediaBridge.RemoveMedia(m_MediaView->SelectedIndexes());
-}
+// void VoidMediaLister::RemoveSelectedMedia()
+// {
+//     /* Push all of the selected indexes for removal */
+//     _MediaBridge.RemoveMedia(m_MediaView->SelectedIndexes());
+// }
 
 void VoidMediaLister::InspectMetadata()
 {

--- a/src/VoidUi/Media/MediaLister.h
+++ b/src/VoidUi/Media/MediaLister.h
@@ -67,7 +67,7 @@ private: /* Methods */
     void AddSelectionToSequence();
     void PlaySelectionAsQueue();
     void AddSelectionToQueue();
-    void RemoveSelectedMedia();
+    // void RemoveSelectedMedia();
     void InspectMetadata();
     void EditEffects();
 

--- a/src/VoidUi/Media/Views/MediaView.cpp
+++ b/src/VoidUi/Media/Views/MediaView.cpp
@@ -8,6 +8,7 @@
 #include <QIODevice>
 #include <QMimeData>
 #include <QPainter>
+#include <QScrollBar>
 
 /* Internal */
 #include "MediaView.h"
@@ -55,11 +56,11 @@ MediaView::~MediaView()
      * Set the source Model as nullpointer so that we don't actually delete
      * the original source model
      */
-    proxy->setSourceModel(nullptr);
+    m_Proxy->setSourceModel(nullptr);
 
-    proxy->deleteLater();
-    delete proxy;
-    proxy = nullptr;
+    m_Proxy->deleteLater();
+    delete m_Proxy;
+    m_Proxy = nullptr;
 }
 
 void MediaView::startDrag(Qt::DropActions supportedActions)
@@ -101,11 +102,11 @@ void MediaView::Setup()
 {
     /* Set Model */
     MediaModel* model = _MediaBridge.DataModel();
-    proxy = new MediaProxyModel(this);
+    m_Proxy = new MediaProxyModel(this);
 
     /* Setup the Proxy's Source Model */
     ResetModel(model);
-    setModel(proxy);
+    setModel(m_Proxy);
 
     setSelectionMode(QAbstractItemView::ExtendedSelection);
     setContextMenuPolicy(Qt::CustomContextMenu);
@@ -176,7 +177,7 @@ void MediaView::Connect()
 
 void MediaView::ResetModel(MediaModel* model)
 {
-    proxy->setSourceModel(model);
+    m_Proxy->setSourceModel(model);
     VOID_LOG_INFO("Source Model Updated");
 }
 
@@ -186,7 +187,7 @@ void MediaView::ItemDoubleClicked(const QModelIndex& index)
         return;
 
     /* The source index */
-    emit itemDoubleClicked(proxy->mapToSource(index));
+    emit itemDoubleClicked(m_Proxy->mapToSource(index));
 }
 
 const std::vector<QModelIndex> MediaView::SelectedIndexes() const
@@ -202,7 +203,7 @@ const std::vector<QModelIndex> MediaView::SelectedIndexes() const
 
     for (const QModelIndex& index: proxyindexes)
     {
-        QModelIndex source = proxy->mapToSource(index);
+        QModelIndex source = m_Proxy->mapToSource(index);
         if (source.isValid())
             sources.emplace_back(source);
     }
@@ -220,7 +221,7 @@ bool MediaView::HasSelection()
 
 void MediaView::EnableSorting(bool state, const Qt::SortOrder& order)
 {
-    proxy->sort(state ? 0 : -1, order);
+    m_Proxy->sort(state ? 0 : -1, order);
 }
 
 void MediaView::SetViewType(const ViewType& type)
@@ -228,6 +229,31 @@ void MediaView::SetViewType(const ViewType& type)
     /* Update the internal view type */
     m_ViewType = type;
     ResetView();
+}
+
+void MediaView::RemoveSelectedMedia()
+{
+    if (QItemSelectionModel* selection = selectionModel())
+    {
+        const QModelIndexList proxies = selection->selectedRows();
+        std::vector<QModelIndex> sources;
+        sources.reserve(proxies.size());
+
+        for (const QModelIndex& index : proxies)
+        {
+            const QModelIndex source = m_Proxy->mapToSource(index);
+            if (source.isValid())
+                sources.emplace_back(source);
+        }
+
+        if (!sources.empty())
+        {
+            const int scroll = verticalScrollBar()->value();
+            _MediaBridge.RemoveMedia(sources);
+
+            verticalScrollBar()->setValue(scroll);
+        }
+    }
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/Views/MediaView.h
+++ b/src/VoidUi/Media/Views/MediaView.h
@@ -33,7 +33,7 @@ public:
     ~MediaView();
 
     /* Search and filter items from the Model */
-    inline void Search(const std::string& text) { proxy->SetSearchText(text); }
+    inline void Search(const std::string& text) { m_Proxy->SetSearchText(text); }
 
     /* Returns the currently selected Media row Model Indices */
     const std::vector<QModelIndex> SelectedIndexes() const;
@@ -47,6 +47,7 @@ public:
     const ViewType GetViewType() const { return m_ViewType; }
     /* Set the View Type */
     void SetViewType(const ViewType& type);
+    void RemoveSelectedMedia();
 
 protected:
     void startDrag(Qt::DropActions supportedActions) override;
@@ -58,7 +59,7 @@ signals:
 
 private: /* Models */
     /* Proxy for filtering and sorting */
-    MediaProxyModel* proxy;
+    MediaProxyModel* m_Proxy;
 
     BasicMediaItemDelegate* m_BasicDelegate;
     MediaItemDelegate* m_MediaDelegate;

--- a/src/VoidUi/Media/Views/QueueView.cpp
+++ b/src/VoidUi/Media/Views/QueueView.cpp
@@ -39,7 +39,11 @@ void QueueView::Clear()
 
 void QueueView::dropEvent(QDropEvent* event)
 {
+    #if _QT6
+    QModelIndex index = indexAt(event->position());
+    #else
     QModelIndex index = indexAt(event->pos());
+    #endif // _QT6
     int dest = index.isValid() ? index.row() : model()->rowCount();
 
     // Currently we have single selection only

--- a/src/VoidUi/Media/Views/QueueView.h
+++ b/src/VoidUi/Media/Views/QueueView.h
@@ -8,7 +8,7 @@
 #include <QListView>
 
 /* Internal */
-#include "Definition.h"
+#include "QDefinition.h"
 #include "VoidObjects/Playlist/Playlist.h"
 
 VOID_NAMESPACE_OPEN

--- a/src/VoidUi/Player/PlayerWidget.cpp
+++ b/src/VoidUi/Player/PlayerWidget.cpp
@@ -95,17 +95,15 @@ void PlayerWidget::Connect()
     connect(m_Renderer, &VoidRenderer::zoomChanged, m_ControlBar, &ControlBar::SetZoom);
 
     /* When a MediaClip is about to be removed from the MediaBride */
-    connect(&_MediaBridge, &MBridge::mediaAboutToBeRemoved, this, &PlayerWidget::RemoveMedia);
+    connect(&_MediaBridge, &MBridge::mediaAboutToBeRemoved, this, &PlayerWidget::RemoveMedia, Qt::DirectConnection);
 }
 
 void PlayerWidget::RemoveMedia(const SharedMediaClip& media)
 {
-    /* Check if the media was playing currently */
+    // Check if the media was playing currently
     if (m_ActiveViewBuffer->Playing(media))
     {
-        /* Clear the active Viewer Buffer */
         m_ActiveViewBuffer->Clear();
-        /* Clear the player */
         Clear();
     }
 }

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -331,10 +331,8 @@ SharedTrackItem ViewerBuffer::TrackItem(const v_frame_t frame)
 
 void ViewerBuffer::Clear()
 {
-    /* Clear up --> Point to an empty clip */
-    m_Clip = std::make_shared<MediaClip>();
-    /* Clear Cache */
     ClearCache();
+    m_Clip = std::make_shared<MediaClip>();
 }
 
 bool ViewerBuffer::Playing(const SharedMediaClip& media) const


### PR DESCRIPTION
### Fixes:
* Fixed media removal from the media view to cause crash
* Fixed issue where removing actively caching media causes a crash
* Fixed Qt6 compatibility with getting the position of the QDropEvent via QDropEvent::position