### PR TITLE
[VOID] Media Playback rate

### DIFF
--- a/src/VoidCore/Timekeeper.cpp
+++ b/src/VoidCore/Timekeeper.cpp
@@ -95,6 +95,41 @@ v_frame_t Timekeeper::NextFrame()
     return m_CurrentFrame;
 }
 
+v_frame_t Timekeeper::NextFrame(int offset)
+{
+    /**
+     * We can't really ever sync to audio when the playback rate of video is different
+     * than the actual rate of the media and the audio, don't even bother to continue here
+     */
+    if (m_CurrentTime < 0 || HasDifferentRate())
+        return NextFrame__(offset);
+
+    int distance = m_CurrentFrame - ConvertedTime();
+    /**
+     * The time is lagging behind --
+     * For now return the Next Frame as supposed to
+     * with the understanding that the time will catch up
+     */
+    if (std::abs(distance) < 3)
+        return NextFrame__();
+
+    // -ve Distance: time (from the audio) is ahead than the threshold
+    if (distance < 0)
+    {
+        // Catch up to it slowly
+        m_CurrentFrame += std::abs(distance) / 2;
+
+        if (m_CurrentFrame > m_End)
+            m_CurrentFrame = m_Start;
+
+        return m_CurrentFrame;
+    }
+
+    // Time (from the audio) is trailing behind at the moment, return the frame without increment
+    // This basically mimics slowing down the video fps to catch-up to the audio
+    return m_CurrentFrame;
+}
+
 v_frame_t Timekeeper::PreviousFrame()
 {
     /**
@@ -103,6 +138,41 @@ v_frame_t Timekeeper::PreviousFrame()
      */
     if (m_CurrentTime < 0 || HasDifferentRate())
         return PreviousFrame__();
+
+    int distance = m_CurrentFrame - ConvertedTime();
+    /**
+     * The time is lagging behind --
+     * For now return the Next Frame as supposed to
+     * with the understanding that the time will catch up
+     */
+    if (std::abs(distance) < 3)
+        return PreviousFrame__();
+
+    // Time (from the audio) is trailing behind at the moment, return the frame without increment
+    if (distance > 0)
+    {
+        // Catch up to it slowly
+        m_CurrentFrame += std::abs(distance) / 2;
+
+        if (m_CurrentFrame < m_Start)
+            m_CurrentFrame = m_End;
+
+        return m_CurrentFrame;
+    }
+
+    // +ve Distance: time (from the audio) is ahead than the threshold
+    // This basically mimics slowing down the video fps to catch-up to the audio
+    return m_CurrentFrame;
+}
+
+v_frame_t Timekeeper::PreviousFrame(int offset)
+{
+    /**
+     * We can't really ever sync to audio when the playback rate of video is different
+     * than the actual rate of the media and the audio, don't even bother to continue here
+     */
+    if (m_CurrentTime < 0 || HasDifferentRate())
+        return PreviousFrame__(offset);
 
     int distance = m_CurrentFrame - ConvertedTime();
     /**
@@ -139,12 +209,31 @@ v_frame_t Timekeeper::NextFrame__()
     return m_CurrentFrame;
 }
 
+v_frame_t Timekeeper::NextFrame__(int offset)
+{
+    if (m_CurrentFrame + offset >= m_End)
+        m_CurrentFrame = m_Start;
+    else
+        m_CurrentFrame += offset;
+
+    return m_CurrentFrame;
+}
+
 v_frame_t Timekeeper::PreviousFrame__()
 {
     if (m_CurrentFrame <= m_Start)
         m_CurrentFrame = m_End;
     else
         m_CurrentFrame--;
+    return m_CurrentFrame;
+}
+
+v_frame_t Timekeeper::PreviousFrame__(int offset)
+{
+    if (m_CurrentFrame - offset <= m_Start)
+        m_CurrentFrame = m_End;
+    else
+        m_CurrentFrame -= offset;
     return m_CurrentFrame;
 }
 

--- a/src/VoidCore/Timekeeper.h
+++ b/src/VoidCore/Timekeeper.h
@@ -87,6 +87,7 @@ public:
      * @return v_frame_t The next frame.
      */
     v_frame_t NextFrame();
+    v_frame_t NextFrame(int offset);
 
     /**
      * @brief Returns the Previous Frame based on the current frame and also on the current time
@@ -98,6 +99,7 @@ public:
      * @return v_frame_t The previous frame.
      */
     v_frame_t PreviousFrame();
+    v_frame_t PreviousFrame(int offset);
 
 private: /* Members */
     v_frame_t m_Start, m_End, m_CurrentFrame;
@@ -108,7 +110,9 @@ private: /* Methods */
     inline v_frame_t ConvertedTime() const { return m_CurrentTime * m_Framerate; }
     inline bool HasDifferentRate() const { return m_Mediarate != m_Framerate; }
     v_frame_t NextFrame__();
+    v_frame_t NextFrame__(int offset);
     v_frame_t PreviousFrame__();
+    v_frame_t PreviousFrame__(int offset);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Player/PlayerBridge.cpp
+++ b/src/VoidUi/Player/PlayerBridge.cpp
@@ -63,6 +63,7 @@ void PlayerBridge::InitMenu(MenuSystem* menuSystem)
     QAction* setInFrameAction = menuSystem->AddAction(playbackMenu, "Set In Frame", QKeySequence(Qt::Key_BracketLeft));
     QAction* setOutFrameAction = menuSystem->AddAction(playbackMenu, "Set Out Frame", QKeySequence(Qt::Key_BracketRight));
     QAction* resetRangeAction = menuSystem->AddAction(playbackMenu, "Reset In/Out Frames", QKeySequence(Qt::Key_Backslash));
+    QAction* editRateAction = menuSystem->AddAction(playbackMenu, "Edit Framerate", QKeySequence("Shift + F"));
 
     /* -------------------------------- */
     playbackMenu->addSeparator();
@@ -86,6 +87,7 @@ void PlayerBridge::InitMenu(MenuSystem* menuSystem)
     connect(setInFrameAction, &QAction::triggered, this, &PlayerBridge::ResetInFrame);
     connect(setOutFrameAction, &QAction::triggered, this, &PlayerBridge::ResetOutFrame);
     connect(resetRangeAction, &QAction::triggered, this, &PlayerBridge::ResetRange);
+    connect(editRateAction, &QAction::triggered, this, &PlayerBridge::EditFramerate);
 
     connect(inspectMetdataAction, &QAction::triggered, this, &PlayerBridge::InspectCurrentMetadata);
     /* }}} */

--- a/src/VoidUi/Player/PlayerBridge.h
+++ b/src/VoidUi/Player/PlayerBridge.h
@@ -66,6 +66,7 @@ public:
     inline void ResetInFrame() { m_Player->ResetInFrame(); }
     inline void ResetOutFrame() { m_Player->ResetOutFrame(); }
     inline void ResetRange() { m_Player->ResetRange(); }
+    inline void EditFramerate() { m_Player->EditFramerate(); }
 
     inline void InspectCurrentMetadata() { m_Player->InspectCurrentMetadata(); }
     inline void ToggleChannels(int channel) { m_Player->ToggleChannels(channel); }

--- a/src/VoidUi/Player/PlayerWidget.h
+++ b/src/VoidUi/Player/PlayerWidget.h
@@ -124,6 +124,8 @@ public:
     inline void SetUserFirstframe(int frame) { m_Timeline->SetUserFirstframe(frame); }
     inline void SetUserEndframe(int frame) { m_Timeline->SetUserEndframe(frame); }
 
+    inline void EditFramerate() { m_Timeline->EditFramerate(); }
+
     /**
      * (Re)sets the In and out framing of the Timeslider
      * Calling it once sets the frame as in/out frame (User-In/User-Out)

--- a/src/VoidUi/Timeline/Timeline.cpp
+++ b/src/VoidUi/Timeline/Timeline.cpp
@@ -6,7 +6,6 @@
 
 /* Qt */
 #include <QCoreApplication>
-#include <QElapsedTimer>
 #include <QIcon>
 #include <QLayout>
 #include <QStyle>
@@ -30,13 +29,8 @@ Timeline::Timeline(QWidget* parent)
 	, m_Playing(false)
 	, m_Playstate(PlayState::STOPPED)
 {
-	/* Build the layout of the widget */
 	Build();
-
-	/* Setup any values */
 	Setup();
-
-	/* Connect Signals */
 	Connect();
 }
 
@@ -203,14 +197,12 @@ void Timeline::Connect()
 
 void Timeline::Setup()
 {
-	/* Set the default rate */
 	SetFramerate(UIGlobals::FramerateString());
 	SetFrame(m_Timeslider->minimum());
+	m_PlayTimer.setTimerType(Qt::PreciseTimer);
 
-	/* Fixed Height for the timeslider panel */
 	setFixedHeight(50);
 
-	/* Update the internal range */
 	Timekeeper::Instance().SetRange(m_Timeslider->minimum(), m_Timeslider->maximum());
 }
 
@@ -226,6 +218,7 @@ void Timeline::StartPlayback()
 	// /* Start Playback worker async */
 	// m_Worker = std::async(std::launch::async, &Timeline::PlaybackLoop, this);
 
+	m_ElapsedTimer.start();
 	m_PlayTimer.start(m_FrameInterval);
 }
 
@@ -410,6 +403,16 @@ void Timeline::Stop()
 	// 	m_Worker.get();
 }
 
+int Timeline::ElapsedFrames()
+{
+	if (m_FrameInterval > 20)
+		return 1;
+
+	int elapsed = m_ElapsedTimer.elapsed() / m_FrameInterval;
+	m_ElapsedTimer.restart();
+	return std::max(elapsed, 1);
+}
+
 void Timeline::Replay()
 {
 	if (m_Playstate == PlayState::FORWARDS)
@@ -431,9 +434,10 @@ void Timeline::PreviousFrame()
 void Timeline::PlayNextFrame()
 {
 	Timekeeper& t = Timekeeper::Instance();
-	if (m_Timeslider->value() < t.EndFrame())
+	v_frame_t next = t.NextFrame(ElapsedFrames());
+	if (next <= t.EndFrame())
 	{
-		m_Timeslider->setValue(t.NextFrame());
+		m_Timeslider->setValue(next);
 	}
 	else
 	{
@@ -450,7 +454,8 @@ void Timeline::PlayNextFrame()
 void Timeline::PlayPreviousFrame()
 {
 	Timekeeper& t = Timekeeper::Instance();
-	if (m_Timeslider->value() == t.StartFrame())
+	v_frame_t previous = t.PreviousFrame(ElapsedFrames());
+	if (previous < t.StartFrame())
 	{
 		switch (m_LoopType)
 		{
@@ -462,7 +467,7 @@ void Timeline::PlayPreviousFrame()
 	}
 	else
 	{
-		m_Timeslider->setValue(t.PreviousFrame());
+		m_Timeslider->setValue(previous);
 	}
 }
 

--- a/src/VoidUi/Timeline/Timeline.h
+++ b/src/VoidUi/Timeline/Timeline.h
@@ -14,6 +14,7 @@
 #include <QLayout>
 #include <QPushButton>
 #include <QTimer>
+#include <QElapsedTimer>
 #include <QWidget>
 
 /* Internal */
@@ -43,6 +44,8 @@ public:
 	Timeline(QWidget* parent = nullptr);
 	virtual ~Timeline();
 
+	void EditFramerate() { m_FramerateBox->setFocus(Qt::FocusReason::TabFocusReason); }
+
 	/* Getters */
 	inline double Framerate() const { return m_FramerateBox->Framerate(); }
 	inline int Frame() const { return m_Timeslider->value(); }
@@ -67,7 +70,6 @@ public:
 	void SetUserEndframe(int frame);
 
 	void SetRange(const int min, const int max);
-
 	void ResetRange();
 
 	/**
@@ -137,6 +139,7 @@ private: /* Members */
 
 	QDoubleValidator* m_DoubleValidator;
 	QTimer m_PlayTimer;
+	QElapsedTimer m_ElapsedTimer;
 
 	/* Loop mode for playback */
 	LoopType m_LoopType;
@@ -169,6 +172,8 @@ protected: /* Methods */
 
 	void PlayNextFrame();
 	void PlayPreviousFrame();
+
+	int ElapsedFrames();
 
 	inline void MoveToStart() { m_Timeslider->setValue(m_Timeslider->Minimum()); }
 	inline void MoveToEnd() { m_Timeslider->setValue(m_Timeslider->Maximum()); }


### PR DESCRIPTION
## Feat: Remove playback rate capping.

### Details:
Utilising Qt's Timer for playback depends on many factors including system scheduling around queueing of the events.
Till the time we have our event system in place. Using frame skip to ensure that media is played at the user specified rate or at least is closer to the requested rate.

### Updates
* Ensure the framerate is maintained more-or-less
* Frames are skipped in this approach depending on the playback rate
* Maybe a configuration needs to be provided to allow the capping to be broken but need to first check if this approach works all across.
* Support for editing framerate with a shortcut.