### PR TITLE
[VOID] Show Channels in the Media Delegates

### DIFF
--- a/src/VoidCore/Media/Frame.cpp
+++ b/src/VoidCore/Media/Frame.cpp
@@ -108,6 +108,7 @@ void Frame::Cache()
     if (m_ImageData->Empty() || m_Dirty)
     {
         m_ImageData->Read();
+        m_Channels = m_ImageData->Channels();
     }
 }
 

--- a/src/VoidCore/Media/Frame.h
+++ b/src/VoidCore/Media/Frame.h
@@ -69,7 +69,7 @@ protected: /* Members */
     MEntry m_MediaEntry;
     SharedPixels m_ImageData;
     v_frame_t m_Framenumber;
-    int m_Channels = {3};
+    int m_Channels = {0};
     bool m_Dirty = {false};
 
 private: /* Members*/

--- a/src/VoidCore/Media/Frame.h
+++ b/src/VoidCore/Media/Frame.h
@@ -47,6 +47,7 @@ public:
     [[nodiscard]] inline bool Valid() const { return bool(m_ImageData); }
     [[nodiscard]] inline bool Invalid() const { return !m_ImageData; }
     [[nodiscard]] inline bool Dirty() const { return m_Dirty; }
+    [[nodiscard]] inline int Channels() const { return m_Channels; }
 
     /**
      * Returns Shared Pointer to the ImageData
@@ -68,6 +69,7 @@ protected: /* Members */
     MEntry m_MediaEntry;
     SharedPixels m_ImageData;
     v_frame_t m_Framenumber;
+    int m_Channels = {3};
     bool m_Dirty = {false};
 
 private: /* Members*/

--- a/src/VoidCore/Media/Media.cpp
+++ b/src/VoidCore/Media/Media.cpp
@@ -172,9 +172,9 @@ void Media::ProcessMovie()
     m_FirstFrame = frange.startframe;
     m_LastFrame = frange.endframe;
 
-    for (v_frame_t i = frange.startframe; i < frange.duration; ++i)
+    for (v_frame_t i = frange.startframe, counter = 0; counter < frange.duration; ++i, ++counter)
     {
-        m_Mediaframes[i] = std::move(MovieFrame(entry, i));
+        m_Mediaframes[counter] = std::move(MovieFrame(entry, i));
         m_Framenumbers.emplace_back(i);
     }
 

--- a/src/VoidCore/Media/Media.h
+++ b/src/VoidCore/Media/Media.h
@@ -115,6 +115,7 @@ public:
     inline SharedPixels FirstImage() { return Image(m_FirstFrame); }
     inline SharedPixels LastImage() { return Image(m_LastFrame); }
 
+    inline int Channels() const { return m_Mediaframes.front().Channels(); }
     inline const std::map<std::string, std::string> Metadata() const { return m_Mediaframes.front().Metadata(); }
 
     inline double Framerate() const { return m_Framerate; }

--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -254,6 +254,7 @@ void FFmpegPixReader::ProcessInformation()
             {
                 /* This always has been 2 less than the total number of frames, need a bit more information here... */
                 m_Duration = stream->nb_frames - 2;
+                m_Startframe = av_rescale_q(stream->start_time, stream->time_base, av_inv_q(stream->r_frame_rate));
                 m_Framerate = av_q2d(stream->r_frame_rate);
                 m_Endframe = m_Duration - 1;
             }

--- a/src/VoidObjects/Models/MediaModel.cpp
+++ b/src/VoidObjects/Models/MediaModel.cpp
@@ -65,6 +65,7 @@ QVariant MediaModel::data(const QModelIndex& index, int role) const
         case MRoles::Color: return item->Color();
         case MRoles::Audio: return item->HasAudio();
         case MRoles::Tags: return item->HasTags();
+        case MRoles::Channels: return item->Channels();
         default: return QVariant();
     }
 }

--- a/src/VoidObjects/Models/MediaModel.h
+++ b/src/VoidObjects/Models/MediaModel.h
@@ -37,7 +37,8 @@ public:
         Thumbnail,
         Color,
         Audio,
-        Tags
+        Tags,
+        Channels
     };
 
 public:

--- a/src/VoidUi/Media/Delegates/ListDelegate.cpp
+++ b/src/VoidUi/Media/Delegates/ListDelegate.cpp
@@ -10,7 +10,6 @@
 #include "ListDelegate.h"
 #include "VoidUi/Media/MediaBridge.h"
 #include "VoidUi/Engine/IconForge.h"
-#include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -126,6 +125,23 @@ void BasicMediaItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem
         )
     );
 
+    const int channels = index.data(static_cast<int>(MediaModel::MRoles::Channels)).toInt();
+    if (channels == 3)
+    {
+        const int w = (ICON_SIZE + 6) * 0.333334;
+        painter->fillRect(option.rect.left(), option.rect.bottom() - 1, w, 1, QColor(255, 0, 0));
+        painter->fillRect(option.rect.left() + w, option.rect.bottom() - 1, w, 1, QColor(0, 255, 0));
+        painter->fillRect(option.rect.left() + 2 * w, option.rect.bottom() - 1, w, 1, QColor(0, 0, 255));
+    }
+    else if (channels == 4)
+    {
+        const int w = (ICON_SIZE + 6) * 0.25;
+        painter->fillRect(option.rect.left(), option.rect.bottom() - 1, w, 1, QColor(255, 0, 0));
+        painter->fillRect(option.rect.left() + w, option.rect.bottom() - 1, w, 1, QColor(0, 255, 0));
+        painter->fillRect(option.rect.left() + 2 * w, option.rect.bottom() - 1, w, 1, QColor(0, 0, 255));
+        painter->fillRect(option.rect.left() + 3 * w, option.rect.bottom() - 1, w, 1, QColor(255, 255, 255));
+    }
+
     /* Name */
     const QRect namerect(option.rect.left() + 30, option.rect.top(), option.rect.right(), option.rect.height());
     painter->drawText(
@@ -236,6 +252,23 @@ void MediaItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opt
 
     const bool audio = index.data(static_cast<int>(MediaModel::MRoles::Audio)).toBool();
     const bool tags = index.data(static_cast<int>(MediaModel::MRoles::Tags)).toBool();
+
+    const int channels = index.data(static_cast<int>(MediaModel::MRoles::Channels)).toInt();
+    if (channels == 3)
+    {
+        const int w = (ICON_SIZE + 6) * 0.333334;
+        painter->fillRect(rect.left(), rect.bottom() - 1, w, 1, QColor(255, 0, 0));
+        painter->fillRect(rect.left() + w, rect.bottom() - 1, w, 1, QColor(0, 255, 0));
+        painter->fillRect(rect.left() + 2 * w, rect.bottom() - 1, w, 1, QColor(0, 0, 255));
+    }
+    else if (channels == 4)
+    {
+        const int w = (ICON_SIZE + 6) * 0.25;
+        painter->fillRect(rect.left(), rect.bottom() - 1, w, 1, QColor(255, 0, 0));
+        painter->fillRect(rect.left() + w, rect.bottom() - 1, w, 1, QColor(0, 255, 0));
+        painter->fillRect(rect.left() + 2 * w, rect.bottom() - 1, w, 1, QColor(0, 0, 255));
+        painter->fillRect(rect.left() + 3 * w, rect.bottom() - 1, w, 1, QColor(255, 255, 255));
+    }
 
     painter->drawPixmap(rect.left() + 2, rect.top() + 2, IconForge::GetPixmap(
         IconType::icon_volume_up,

--- a/src/VoidUi/Media/Delegates/ThumbnailDelegate.cpp
+++ b/src/VoidUi/Media/Delegates/ThumbnailDelegate.cpp
@@ -131,6 +131,23 @@ void MediaThumbnailDelegate::paint(QPainter* painter, const QStyleOptionViewItem
         ICON_SIZE
     ));
 
+    const int channels = index.data(static_cast<int>(MediaModel::MRoles::Channels)).toInt();
+    if (channels == 3)
+    {
+        const int w = (ICON_SIZE + 6) * 0.333334;
+        painter->fillRect(rect.left(), rect.bottom() - 1, w, 1, QColor(255, 0, 0));
+        painter->fillRect(rect.left() + w, rect.bottom() - 1, w, 1, QColor(0, 255, 0));
+        painter->fillRect(rect.left() + 2 * w, rect.bottom() - 1, w, 1, QColor(0, 0, 255));
+    }
+    else if (channels == 4)
+    {
+        const int w = (ICON_SIZE + 6) * 0.25;
+        painter->fillRect(rect.left(), rect.bottom() - 1, w, 1, QColor(255, 0, 0));
+        painter->fillRect(rect.left() + w, rect.bottom() - 1, w, 1, QColor(0, 255, 0));
+        painter->fillRect(rect.left() + 2 * w, rect.bottom() - 1, w, 1, QColor(0, 0, 255));
+        painter->fillRect(rect.left() + 3 * w, rect.bottom() - 1, w, 1, QColor(255, 255, 255));
+    }
+
     /* Name */
     const QRect namerect(left, thumbrect.bottom(), 90 * m_Scale, 20);
     painter->drawText(


### PR DESCRIPTION
### Feat: Represent Channels for the Media in the UI.
* Exposed Channels for the Media and through the Media Model.
* Draw channel colours according to the channel count for the Media.

### Fixes
* Consider the first frame from the movie metadata for movie types.

#### Details:
Incorrect start frame for the movie media was causing issues when loading thumbnails or other information for the media