### PR TITLE
[VOID] FFmpegReader: Multiple Movie streams support for simultaneous playback

### DIFF
--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -47,14 +47,16 @@ FFmpegDecoder& FFmpegDecoder::Instance(const std::string& path)
     auto it = s_decoders.find(path);
     if (it == s_decoders.end())
     {
+        std::unique_ptr<FFmpegDecoder> decoder = nullptr;
         if (s_decoders.size() == MAX_DECODERS)
         {
             auto iter = s_decoders.begin();
             std::advance(iter, s_head);
+            decoder = std::move(iter->second);
             s_decoders.erase(iter);
         }
 
-        s_decoders[path] = std::make_unique<FFmpegDecoder>();
+        s_decoders[path] = decoder == nullptr ? std::make_unique<FFmpegDecoder>() : std::move(decoder);
         s_head = (s_head + 1) % MAX_DECODERS;
     }
 

--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -2,7 +2,6 @@
 // Licensed under the MIT License
 
 /* STD */
-#include <array>
 #include <memory>
 
 /* Internal */

--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -1,12 +1,20 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* STD */
+#include <array>
+#include <memory>
+
 /* Internal */
 #include "FFmpegReader.h"
-#include "VoidCore/Logging.h"
-#include "VoidCore/Profiler.h"
 
 VOID_NAMESPACE_OPEN
+
+// This governs how many parallel instances of the Decoder can exist at ones
+// allowing multiple streams of videos to be decoded for playback
+// we may want to allow configuring this later on depending on system specs
+// For now we allow 16 as something to test as well
+static constexpr std::size_t MAX_DECODERS = 16;
 
 /* FFmpegDecoder {{{ */
 FFmpegDecoder::FFmpegDecoder()
@@ -29,6 +37,28 @@ FFmpegDecoder::FFmpegDecoder()
 FFmpegDecoder::~FFmpegDecoder()
 {
     Close();
+}
+
+FFmpegDecoder& FFmpegDecoder::Instance(const std::string& path)
+{
+    static std::unordered_map<std::string, std::unique_ptr<FFmpegDecoder>> s_decoders;
+    static std::size_t s_head = 0;
+
+    auto it = s_decoders.find(path);
+    if (it == s_decoders.end())
+    {
+        if (s_decoders.size() == MAX_DECODERS)
+        {
+            auto iter = s_decoders.begin();
+            std::advance(iter, s_head);
+            s_decoders.erase(iter);
+        }
+
+        s_decoders[path] = std::make_unique<FFmpegDecoder>();
+        s_head = (s_head + 1) % MAX_DECODERS;
+    }
+
+    return *(s_decoders[path].get());
 }
 
 void FFmpegDecoder::Open()
@@ -289,7 +319,7 @@ double FFmpegPixReader::Framerate()
 void FFmpegPixReader::Read()
 {
     /* Decoder */
-    FFmpegDecoder& decoder = FFmpegDecoder::Instance();
+    FFmpegDecoder& decoder = FFmpegDecoder::Instance(m_Path);
     if (decoder.Decode(m_Path, m_Framenumber, m_Pixels))
     {
         /* Read the Frame Dimensions */

--- a/src/VoidCore/Readers/FFmpegReader.h
+++ b/src/VoidCore/Readers/FFmpegReader.h
@@ -27,15 +27,10 @@ VOID_NAMESPACE_OPEN
 
 class FFmpegDecoder
 {
-    FFmpegDecoder();
-
 public:
-    static FFmpegDecoder& Instance()
-    {
-        static FFmpegDecoder instance;
-        return instance;
-    }
-
+    static FFmpegDecoder& Instance(const std::string& path);
+        
+    FFmpegDecoder();
     ~FFmpegDecoder();    
 
     FFmpegDecoder(const FFmpegDecoder&) = delete;
@@ -86,7 +81,6 @@ private: /* Methods */
      */
     v_frame_t DecodeNextFrame(bool save = true);
 };
-
 
 class VOID_API FFmpegPixReader : public VoidMPixReader
 {


### PR DESCRIPTION
## Feat: Support Multiple video streams to play movies in compare/grid buffers simultaneously
* Use Circular buffer for holding Decoder instances supporting many movie streams for playback at once.

### Details
With initial design, a single movie stream was sufficient, but as the player grows it needs multiple streams of video playback (at least 2 when comparing) but with the introduction of Grid playback, multiple movies could be played back together and to support that behaviour in a performant way, supporting multiple streams is required