### PR TITLE
[VOID] Renderer: Updated Blend Modes | Options

### DIFF
--- a/src/VoidCore/Timekeeper.cpp
+++ b/src/VoidCore/Timekeeper.cpp
@@ -211,7 +211,7 @@ v_frame_t Timekeeper::NextFrame__()
 
 v_frame_t Timekeeper::NextFrame__(int offset)
 {
-    if (m_CurrentFrame + offset >= m_End)
+    if (m_CurrentFrame + offset > m_End)
         m_CurrentFrame = m_Start;
     else
         m_CurrentFrame += offset;
@@ -230,7 +230,7 @@ v_frame_t Timekeeper::PreviousFrame__()
 
 v_frame_t Timekeeper::PreviousFrame__(int offset)
 {
-    if (m_CurrentFrame - offset <= m_Start)
+    if (m_CurrentFrame - offset < m_Start)
         m_CurrentFrame = m_End;
     else
         m_CurrentFrame -= offset;

--- a/src/VoidRenderer/Core/RenderTypes.h
+++ b/src/VoidRenderer/Core/RenderTypes.h
@@ -48,6 +48,7 @@ enum class BlendMode : int
 {
     UNDER,
     OVER,
+    ONION_SKIN,
     // MINUS,
     // DIFF,
 };
@@ -65,6 +66,7 @@ static const std::map<BlendMode, std::string> BlendModesMap =
 {
     { BlendMode::UNDER, "Under" },
     { BlendMode::OVER, "Over" },
+    { BlendMode::ONION_SKIN, "Onion Skin" },
 };
 
 /**

--- a/src/VoidRenderer/Core/RenderTypes.h
+++ b/src/VoidRenderer/Core/RenderTypes.h
@@ -70,7 +70,7 @@ static const std::map<BlendMode, std::string> BlendModesMap =
     { BlendMode::ONION_SKIN, "Onion Skin" },
     { BlendMode::MINUS, "Minus" },
     { BlendMode::DIFF, "Difference" },
-    { BlendMode::INVERT_ADD, "Invert & Add" },
+    { BlendMode::INVERT_ADD, "Invert && Add" },
 };
 
 /**

--- a/src/VoidRenderer/Core/RenderTypes.h
+++ b/src/VoidRenderer/Core/RenderTypes.h
@@ -49,8 +49,9 @@ enum class BlendMode : int
     UNDER,
     OVER,
     ONION_SKIN,
-    // MINUS,
-    // DIFF,
+    MINUS,
+    DIFF,
+    INVERT_ADD
 };
 
 static const std::map<ComparisonMode, std::string> ComparisonModesMap = 
@@ -67,6 +68,9 @@ static const std::map<BlendMode, std::string> BlendModesMap =
     { BlendMode::UNDER, "Under" },
     { BlendMode::OVER, "Over" },
     { BlendMode::ONION_SKIN, "Onion Skin" },
+    { BlendMode::MINUS, "Minus" },
+    { BlendMode::DIFF, "Difference" },
+    { BlendMode::INVERT_ADD, "Invert & Add" },
 };
 
 /**

--- a/src/VoidRenderer/Layers/GridRenderLayer.cpp
+++ b/src/VoidRenderer/Layers/GridRenderLayer.cpp
@@ -58,7 +58,13 @@ void GridRenderLayer::Initialize()
 
 void GridRenderLayer::Reset()
 {
+    glDeleteTextures(m_Textures.size(), m_Textures.data());
 
+    m_Textures.clear();
+    m_Textures.shrink_to_fit();
+
+    m_TexData.clear();
+    m_TexData.shrink_to_fit();
 }
 
 void GridRenderLayer::SetRows(int rows)
@@ -83,13 +89,7 @@ void GridRenderLayer::SetImages(const std::vector<SharedPixels>& images)
 {
     if (m_Textures.size() != images.size())
     {
-        glDeleteTextures(m_Textures.size(), m_Textures.data());
-
-        m_Textures.clear();
-        m_Textures.shrink_to_fit();
-
-        m_TexData.clear();
-        m_TexData.shrink_to_fit();
+        Reset();
 
         m_Textures.resize(images.size());
         m_TexData.resize(images.size());

--- a/src/VoidRenderer/Layers/ImageComparisonRenderLayer.cpp
+++ b/src/VoidRenderer/Layers/ImageComparisonRenderLayer.cpp
@@ -20,6 +20,7 @@ ImageComparisonRenderLayer::ImageComparisonRenderLayer()
     , m_BlendMode(0)
     , m_ComparisonMode(0)
     , m_SwipeX(0.5f)
+    , m_PeelFactor(0.5f)
     , m_VAO(0)
     , m_VBO(0)
     , m_IBO(0)
@@ -35,6 +36,7 @@ ImageComparisonRenderLayer::ImageComparisonRenderLayer()
     , m_UComparisonMode(-1)
     , m_UBlendMode(-1)
     , m_USwipeX(-1)
+    , m_UPeelFactor(-1)
     , m_UInputColorSpaceA(-1)
     , m_UInputColorSpaceB(-1)
     , m_TextureA(0)
@@ -76,6 +78,7 @@ void ImageComparisonRenderLayer::Initialize()
     m_UComparisonMode = glGetUniformLocation(m_Shader.ProgramId(), "comparisonMode");
     m_UBlendMode = glGetUniformLocation(m_Shader.ProgramId(), "blendMode");
     m_USwipeX = glGetUniformLocation(m_Shader.ProgramId(), "swipeX");
+    m_UPeelFactor = glGetUniformLocation(m_Shader.ProgramId(), "peelFactor");
     m_UInputColorSpaceA = glGetUniformLocation(m_Shader.ProgramId(), "inputColorSpaceA");
     m_UInputColorSpaceB = glGetUniformLocation(m_Shader.ProgramId(), "inputColorSpaceB");
 
@@ -320,6 +323,7 @@ void ImageComparisonRenderLayer::Draw()
      * Update the swipe factor
      */
     glUniform1f(m_USwipeX, m_SwipeX);
+    glUniform1f(m_UPeelFactor, m_PeelFactor);
 
     /**
      * Update the input colorspaces on the shader to ensure output is linear before applying the final

--- a/src/VoidRenderer/Layers/ImageComparisonRenderLayer.h
+++ b/src/VoidRenderer/Layers/ImageComparisonRenderLayer.h
@@ -44,6 +44,9 @@ public:
     inline float SwipeX() const { return m_SwipeX; }
     inline void SetSwipeX(const float x) { m_SwipeX = x; }
 
+    float PeelFactor() const { return m_PeelFactor; }
+    void SetPeelFactor(float factor) { m_PeelFactor = factor; }
+
     void ReinitShaderProgram();
 
     /* Main Render Function */
@@ -64,6 +67,7 @@ private: /* Members */
     int m_InputColorSpaceB;
 
     float m_SwipeX;
+    float m_PeelFactor;
 
     /* Render Components */
     ImageComparisonShaderProgram m_Shader;
@@ -94,6 +98,7 @@ private: /* Members */
     int m_UComparisonMode;
     int m_UBlendMode;
     int m_USwipeX;
+    int m_UPeelFactor;
     int m_UInputColorSpaceA;
     int m_UInputColorSpaceB;
 

--- a/src/VoidRenderer/Programs/ImageComparisonShaderProgram.cpp
+++ b/src/VoidRenderer/Programs/ImageComparisonShaderProgram.cpp
@@ -56,6 +56,9 @@ uniform int blendMode;
 // Swipe
 uniform float swipeX;
 
+// Onion Skin
+uniform float peelFactor;
+
 // Input Colorspace
 uniform int inputColorSpaceA;
 uniform int inputColorSpaceB;
@@ -192,8 +195,8 @@ void main() {
             case 1: // A Over B
                 color = colorA;
                 break;
-            case 2:
-                color = colorA + colorB;
+            case 2: // Onion Peel
+                color = mix(colorA, colorB, peelFactor * colorB.a);
                 break;
             case 3:
                 color = mix(colorA, colorB, 0.5);

--- a/src/VoidRenderer/Programs/ImageComparisonShaderProgram.cpp
+++ b/src/VoidRenderer/Programs/ImageComparisonShaderProgram.cpp
@@ -198,8 +198,14 @@ void main() {
             case 2: // Onion Peel
                 color = mix(colorA, colorB, peelFactor * colorB.a);
                 break;
-            case 3:
-                color = mix(colorA, colorB, 0.5);
+            case 3: // Minus
+                color = vec4(max(colorA.rgb - colorB.rgb, 0.0), 1.0);
+                break;
+            case 4: // Difference
+                color = vec4(abs(colorA.rgb - colorB.rgb), 1.0);
+                break;
+            case 5: // Invert & Add
+                color = vec4(clamp((1 - colorA.rgb) + colorB.rgb, 0.0, 1.0), 1.0);
                 break;
             default:
                 color = colorA; 

--- a/src/VoidRenderer/VoidRenderer.cpp
+++ b/src/VoidRenderer/VoidRenderer.cpp
@@ -582,6 +582,12 @@ void VoidRenderer::SetChannelMode(int mode)
     update();
 }
 
+void VoidRenderer::SetPeelFactor(float factor)
+{
+    m_ImageComparisonRenderer.SetPeelFactor(factor);
+    update();
+}
+
 void VoidRenderer::SetColorDisplay(const std::string& display)
 {
     ColorProcessor::Instance().Set(display);

--- a/src/VoidRenderer/VoidRenderer.cpp
+++ b/src/VoidRenderer/VoidRenderer.cpp
@@ -651,6 +651,7 @@ void VoidRenderer::ReloadTextures()
         /* Set The Image Buffer with the Images */
         m_ImageComparisonRenderer.SetImageA(m_ImageA);
         m_ImageComparisonRenderer.SetImageB(m_ImageB);
+        m_GridRenderer.Reset();
     }
     else
     {

--- a/src/VoidRenderer/VoidRenderer.h
+++ b/src/VoidRenderer/VoidRenderer.h
@@ -110,6 +110,7 @@ public:
      */
     void SetChannelMode(int mode);
 
+    float PeelFactor() const { return m_ImageComparisonRenderer.PeelFactor(); }
     void SetPeelFactor(float factor);
 
     /**

--- a/src/VoidRenderer/VoidRenderer.h
+++ b/src/VoidRenderer/VoidRenderer.h
@@ -110,6 +110,8 @@ public:
      */
     void SetChannelMode(int mode);
 
+    void SetPeelFactor(float factor);
+
     /**
      * The color display to be set for the OCIO Color Process
      */

--- a/src/VoidUi/BaseWindow/About.cpp
+++ b/src/VoidUi/BaseWindow/About.cpp
@@ -115,7 +115,7 @@ void AboutVoid::Build()
     m_ButtonSeparator->setMidLineWidth(3);
 
     /* Buttons */
-    m_OkButton = new QPushButton("Close");
+    m_OkButton = new QPushButton("&Close");
 
     buttonLayout->addStretch(1);
     buttonLayout->addWidget(m_OkButton);

--- a/src/VoidUi/BaseWindow/StartupWindow.cpp
+++ b/src/VoidUi/BaseWindow/StartupWindow.cpp
@@ -91,9 +91,9 @@ void StartupWindow::Build()
 
     m_ProjectsLister = new QListView;
 
-    m_DontShowCheck = new QCheckBox("Don't Show this dialog on startup");
-    m_LoadBtn = new QPushButton("Load Selected");
-    m_CloseBtn = new QPushButton("Close");
+    m_DontShowCheck = new QCheckBox("Don't &Show this dialog on startup");
+    m_LoadBtn = new QPushButton("&Load Selected");
+    m_CloseBtn = new QPushButton("&Close");
 
     m_BottomButtonsLayout->addWidget(m_DontShowCheck);
     m_BottomButtonsLayout->addStretch(1);

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SOURCES
     Toolkit/ControlBar.cpp
     Toolkit/ControlScroller.cpp
     Toolkit/GridController.cpp
+    Toolkit/ViewerController.cpp
 
     # QExtensions
     QExtensions/Delegates.cpp

--- a/src/VoidUi/Engine/IconTypes.h
+++ b/src/VoidUi/Engine/IconTypes.h
@@ -50,6 +50,7 @@ enum class IconType : char16_t
     icon_style              = 0xe41d,
     icon_sync_alt           = 0xea18,
     icon_title              = 0xe264,
+    icon_trail_length_short = 0xeb6d,
     icon_trending_flat      = 0xe8e4,
     icon_view_stream        = 0xe8f2,
     icon_visible            = 0xe8f4,

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -135,6 +135,8 @@ void VoidMediaLister::Build()
 #else
     m_DeleteShortcut = new QShortcut(QKeySequence(Qt::Key_Delete), this);
 #endif
+    m_PrimaryViewShortcut = new QShortcut(QKeySequence(Qt::Key_1), this);
+    m_SecondaryViewShortcut = new QShortcut(QKeySequence(Qt::Key_2), this);
 
     /* Base */
     m_layout = new QVBoxLayout(this);
@@ -298,6 +300,8 @@ void VoidMediaLister::Connect()
 
     /* Shortcut */
     connect(m_DeleteShortcut, &QShortcut::activated, m_MediaView, &MediaView::RemoveSelectedMedia);
+    connect(m_PrimaryViewShortcut, &QShortcut::activated, this, &VoidMediaLister::AddToPrimaryViewer);
+    connect(m_SecondaryViewShortcut, &QShortcut::activated, this, &VoidMediaLister::AddToSecondaryViewer);
 
     /* Preferences */
     connect(&VoidPreferences::Instance(), &VoidPreferences::updated, this, &VoidMediaLister::SetFromPreferences);
@@ -475,6 +479,24 @@ void VoidMediaLister::RebuildPlaylistMenu()
         connect(action, &QAction::triggered, this, [=]() { AddSelectionToPlaylist(playlist); });
         m_PlaylistMenu->addAction(action);
     }
+}
+
+void VoidMediaLister::AddToPrimaryViewer()
+{
+    std::vector<QModelIndex> selected = m_MediaView->SelectedIndexes();
+    if (selected.empty())
+        return;
+    
+    _PlayerBridge.SetMedia(_MediaBridge.MediaAt(selected[0]), PlayerViewBuffer::A);
+}
+
+void VoidMediaLister::AddToSecondaryViewer()
+{
+    std::vector<QModelIndex> selected = m_MediaView->SelectedIndexes();
+    if (selected.empty())
+        return;
+    
+    _PlayerBridge.SetMedia(_MediaBridge.MediaAt(selected[0]), PlayerViewBuffer::B);
 }
 
 void VoidMediaLister::AddSelectionToPlaylist(Playlist* playlist)

--- a/src/VoidUi/Media/MediaLister.h
+++ b/src/VoidUi/Media/MediaLister.h
@@ -112,12 +112,16 @@ private: /* Members */
 
     /* Shortcuts */
     QShortcut* m_DeleteShortcut;
+    QShortcut* m_PrimaryViewShortcut;
+    QShortcut* m_SecondaryViewShortcut;
 
 private: /* Methods */
     /* Set values from User preferences */
     void SetFromPreferences();
     // void ProjectChanged();
     void RebuildPlaylistMenu();
+    void AddToPrimaryViewer();
+    void AddToSecondaryViewer();
     void AddSelectionToPlaylist(Playlist* playlist);
     void AddTagToSelected();
     void EditSelectedTags(const QModelIndex& index, const QPoint& position);

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -186,7 +186,7 @@ void Player::SetGrid(Playlist* playlist)
     m_Renderer->Clear();
 
     // Update what is being played on the Active Viewer Buffer
-    m_ActiveViewBuffer->SetPlaylist(playlist);
+    m_ActiveViewBuffer->SetGrid(playlist);
     SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
 
     // This internally calls refresh which renders the grid

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -191,6 +191,7 @@ void Player::SetGrid(Playlist* playlist)
 
     // This internally calls refresh which renders the grid
     SetComparisonMode(5); // ComparisonMode::GRID;
+    m_ControlBar->SetViewerControl(ViewerControl::GridControl);
 }
 
 void Player::SetFrame(int frame)
@@ -491,26 +492,23 @@ void Player::RenderGrid(v_frame_t frame)
 
 void Player::SetComparisonMode(int mode)
 {
-    /* Update Comparison Mode */
     m_ComparisonMode = static_cast<Renderer::ComparisonMode>(mode);
 
     if (m_ComparisonMode != Renderer::ComparisonMode::NONE)
     {
-        /* Mark both the viewer Buffers as active */
         m_ViewBufferA.SetActive(true);
         m_ViewBufferB.SetActive(true);
     }
     else
     {
-        /* Revert to the actual active Buffer */
         bool activeA = m_ActiveViewBuffer == &m_ViewBufferA;
-        /* Set its Active state */
+
         m_ViewBufferA.SetActive(activeA);
-        /* Reset the active state for the other buffer */
         m_ViewBufferB.SetActive(!activeA);
+
+        m_ControlBar->SetViewerControl(ViewerControl::None);
     }
 
-    /* Update to show the current frame */
     Refresh();
 }
 
@@ -522,8 +520,14 @@ void Player::ToggleChannels(int channel)
 void Player::SetBlendMode(const int mode)
 {
     m_BlendMode = static_cast<Renderer::BlendMode>(mode);
-    if (m_ComparisonMode != Renderer::ComparisonMode::NONE)
-        Refresh();
+    if (m_ComparisonMode == Renderer::ComparisonMode::NONE)
+        return;
+
+    m_BlendMode == Renderer::BlendMode::ONION_SKIN && !ActiveGrid() 
+        ? m_ControlBar->SetViewerControl(ViewerControl::OnionSkinControl)
+        : m_ControlBar->SetViewerControl(ViewerControl::None);
+
+    Refresh();
 }
 
 void Player::ResetViewBuffer(const PlayerViewBuffer& buffer)

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -521,14 +521,9 @@ void Player::ToggleChannels(int channel)
 
 void Player::SetBlendMode(const int mode)
 {
-    /* Update the blend mode */
     m_BlendMode = static_cast<Renderer::BlendMode>(mode);
-
     if (m_ComparisonMode != Renderer::ComparisonMode::NONE)
-    {
-        /* Update to show the current frame */
         Refresh();
-    }
 }
 
 void Player::ResetViewBuffer(const PlayerViewBuffer& buffer)

--- a/src/VoidUi/Player/Player.h
+++ b/src/VoidUi/Player/Player.h
@@ -47,7 +47,11 @@ public:
 
     void ToggleChannels(int channel);
     void SetBlendMode(int mode);
+    void SwitchBlendMode(int delta) { m_ControlBar->SwitchBlendMode(delta); }
     void SetComparisonMode(int mode);
+
+    void SetPeelFactor(float factor) { m_Renderer->SetPeelFactor(factor); }
+
     /* Compare Media on the Player */
     void Compare(const SharedMediaClip& first, const SharedMediaClip& second);
     void InspectCurrentMetadata();

--- a/src/VoidUi/Player/Player.h
+++ b/src/VoidUi/Player/Player.h
@@ -50,6 +50,7 @@ public:
     void SwitchBlendMode(int delta) { m_ControlBar->SwitchBlendMode(delta); }
     void SetComparisonMode(int mode);
 
+    float PeelFactor() const { return m_Renderer->PeelFactor(); }
     void SetPeelFactor(float factor) { m_Renderer->SetPeelFactor(factor); }
 
     /* Compare Media on the Player */

--- a/src/VoidUi/Player/PlayerBridge.cpp
+++ b/src/VoidUi/Player/PlayerBridge.cpp
@@ -111,6 +111,11 @@ void PlayerBridge::InitMenu(MenuSystem* menuSystem)
 
     viewerMenu->addSeparator();
 
+    QAction* cycleBlendForwardsAction = menuSystem->AddAction(viewerMenu, "Cycle Next Blend Mode", QKeySequence("Shift+9"));
+    QAction* cycleBlendBackwardsAction = menuSystem->AddAction(viewerMenu, "Cycle Previous Blend Mode", QKeySequence("Shift+0"));
+
+    viewerMenu->addSeparator();
+
     QAction* editGridAction = menuSystem->AddAction(viewerMenu, "Edit Render Grid");
 
     connect(redToggleAction, &QAction::triggered, this, [&]() -> void { ToggleChannels(0); });
@@ -122,6 +127,14 @@ void PlayerBridge::InitMenu(MenuSystem* menuSystem)
     connect(zoomToFitAction, &QAction::triggered, this, &PlayerBridge::ZoomToFit);
     connect(fullscreenAction, &QAction::triggered, this, &PlayerBridge::SetFullscreen);
     connect(exitFullscreenAction, &QAction::triggered, this, &PlayerBridge::ExitFullscreen);
+    connect(cycleBlendForwardsAction, &QAction::triggered, this, [this]() -> void
+    {
+        m_Player->SwitchBlendMode(1);
+    });
+    connect(cycleBlendBackwardsAction, &QAction::triggered, this, [this]() -> void
+    {
+        m_Player->SwitchBlendMode(-1);
+    });
     connect(editGridAction, &QAction::triggered, this, [this]() -> void
     {
         GridController g;

--- a/src/VoidUi/Player/PlayerBridge.cpp
+++ b/src/VoidUi/Player/PlayerBridge.cpp
@@ -3,7 +3,6 @@
 
 /* Internal */
 #include "PlayerBridge.h"
-#include "VoidUi/Toolkit/GridController.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -111,12 +110,8 @@ void PlayerBridge::InitMenu(MenuSystem* menuSystem)
 
     viewerMenu->addSeparator();
 
-    QAction* cycleBlendForwardsAction = menuSystem->AddAction(viewerMenu, "Cycle Next Blend Mode", QKeySequence("Shift+9"));
-    QAction* cycleBlendBackwardsAction = menuSystem->AddAction(viewerMenu, "Cycle Previous Blend Mode", QKeySequence("Shift+0"));
-
-    viewerMenu->addSeparator();
-
-    QAction* editGridAction = menuSystem->AddAction(viewerMenu, "Edit Render Grid");
+    QAction* cycleBlendForwardsAction = menuSystem->AddAction(viewerMenu, "Cycle Next Blend Mode", QKeySequence("Shift+0"));
+    QAction* cycleBlendBackwardsAction = menuSystem->AddAction(viewerMenu, "Cycle Previous Blend Mode", QKeySequence("Shift+9"));
 
     connect(redToggleAction, &QAction::triggered, this, [&]() -> void { ToggleChannels(0); });
     connect(greenToggleAction, &QAction::triggered, this, [&]() -> void { ToggleChannels(1); });
@@ -134,11 +129,6 @@ void PlayerBridge::InitMenu(MenuSystem* menuSystem)
     connect(cycleBlendBackwardsAction, &QAction::triggered, this, [this]() -> void
     {
         m_Player->SwitchBlendMode(-1);
-    });
-    connect(editGridAction, &QAction::triggered, this, [this]() -> void
-    {
-        GridController g;
-        g.exec();
     });
     /* }}} */
 }

--- a/src/VoidUi/Player/PlayerBridge.h
+++ b/src/VoidUi/Player/PlayerBridge.h
@@ -56,6 +56,9 @@ public:
     int GridRows() const { return m_Player->GridRows(); }
     int GridColumns() const { return m_Player->GridColumns(); }
 
+    float PeelFactor() const { return m_Player->PeelFactor(); }
+    void SetPeelFactor(float factor) { m_Player->SetPeelFactor(factor); }
+
     inline void ResetPlaylistMedia() { m_Player->ResetPlaylistMedia(); }
 
     inline void ResumeCache() { m_Player->ResumeCache(); }

--- a/src/VoidUi/Player/PlayerWidget.cpp
+++ b/src/VoidUi/Player/PlayerWidget.cpp
@@ -45,6 +45,10 @@ PlayerWidget::PlayerWidget(QWidget* parent)
 PlayerWidget::~PlayerWidget()
 {
     m_ActiveViewBuffer = nullptr;
+
+    m_Timeline->deleteLater();
+    delete m_Timeline;
+    m_Timeline = nullptr;
 }
 
 void PlayerWidget::Connect()

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -112,6 +112,26 @@ void ViewerBuffer::Set(const std::vector<SharedMediaClip>& media)
     CacheAvailable();
 }
 
+void ViewerBuffer::SetGrid(Playlist* playlist)
+{
+    Refresh();
+    if (m_Playlist)
+        disconnect(m_Playlist, &Playlist::updated, this, &ViewerBuffer::updated);
+
+    m_Playlist = playlist;
+    m_Clip = playlist->CurrentMedia();
+
+    connect(m_Playlist, &Playlist::updated, this, &ViewerBuffer::updated);
+
+    m_PlayingComponent = PlayableComponent::Grid;
+    UpdateRange(m_Clip->FirstFrame(), m_Clip->LastFrame());
+
+    emit playlistUpdated(playlist);
+
+    EnsureCached(m_Clip->FirstFrame());
+    CacheAvailable();
+}
+
 void ViewerBuffer::SetPlaylist(Playlist* playlist)
 {
     Refresh();
@@ -169,6 +189,7 @@ SharedPlaybackTrack ViewerBuffer::ActiveTrack() const
              * if added, where does the media go to? at the last of track or clears it?
              */
             return m_Sequence->ActiveVideoTrack();
+        case PlayableComponent::Grid:
         case PlayableComponent::Playlist:
             return nullptr;
     }
@@ -233,12 +254,16 @@ std::vector<SharedPixels> ViewerBuffer::GridFrame(const v_frame_t frame)
 {
     std::vector<SharedPixels> grid;
     grid.reserve(m_Playlist->Size());
-    for (auto& media : m_Playlist->AllMedia())
+
+    if (m_PlayingComponent == PlayableComponent::Grid)
     {
-        if (media->Contains(frame))
-            grid.push_back(media->Image(frame));
-        else
-            grid.push_back(media->Image(media->NearestFrame(frame)));
+        for (auto& media : m_Playlist->AllMedia())
+        {
+            if (media->Contains(frame))
+                grid.push_back(media->Image(frame));
+            else
+                grid.push_back(media->Image(media->NearestFrame(frame)));
+        }
     }
 
     return grid;
@@ -633,6 +658,7 @@ void ViewerBuffer::EvictFront()
             ItemFromSequence(frame)->UncacheFrame(frame);
             break;
         case PlayableComponent::Clip:
+        case PlayableComponent::Grid:
         case PlayableComponent::Playlist:
         default:
             if (m_Clip->Valid() && m_Clip->Contains(frame))
@@ -659,6 +685,7 @@ void ViewerBuffer::EvictBack()
             ItemFromSequence(frame)->UncacheFrame(frame);
             break;
         case PlayableComponent::Clip:
+        case PlayableComponent::Grid:
         case PlayableComponent::Playlist:
         default:
             if (m_Clip->Valid() && m_Clip->Contains(frame))

--- a/src/VoidUi/Player/ViewerBuffer.h
+++ b/src/VoidUi/Player/ViewerBuffer.h
@@ -242,6 +242,7 @@ public:
     void Set(const SharedPlaybackSequence& sequence);
     void Set(const std::vector<SharedMediaClip>& media);
 
+    void SetGrid(Playlist* playlist);
     void SetPlaylist(Playlist* playlist);
     [[nodiscard]] bool NextMedia();
     [[nodiscard]] bool PreviousMedia();

--- a/src/VoidUi/Preferences/PreferencesUI.cpp
+++ b/src/VoidUi/Preferences/PreferencesUI.cpp
@@ -51,9 +51,9 @@ void VoidPreferencesWidget::Build()
     m_PreferencesLayout->addWidget(m_SettingsStacked);
 
     /* Buttons */
-    m_OkButton = new QPushButton("Ok");
-    m_ApplyButton = new QPushButton("Apply");
-    m_CancelButton = new QPushButton("Cancel");
+    m_OkButton = new QPushButton("&Ok");
+    m_ApplyButton = new QPushButton("&Apply");
+    m_CancelButton = new QPushButton("&Cancel");
 
     m_ButtonsLayout = new QHBoxLayout;
     

--- a/src/VoidUi/QExtensions/Dialog.h
+++ b/src/VoidUi/QExtensions/Dialog.h
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+#ifndef _Q_EXT_DIALOG_H
+#define _Q_EXT_DIALOG_H
+
 /* Qt */
 #include <QDialog>
 
@@ -17,3 +20,5 @@ public:
 };
 
 VOID_NAMESPACE_CLOSE
+
+#endif // _Q_EXT_DIALOG_H

--- a/src/VoidUi/QExtensions/Frame.cpp
+++ b/src/VoidUi/QExtensions/Frame.cpp
@@ -65,6 +65,7 @@ void SplitSectionSelector::AddRadioItems(const QStringList& texts)
         QString text = texts[i];
         QAction* action = new QAction(text, m_Menu);
         action->setCheckable(true);
+        action->setObjectName(QString::number(i));
         action->setActionGroup(m_RadioGroup);
 
         /* Any Item selection would trigger a signal to invoke that the Radio Item has been selected */
@@ -76,6 +77,22 @@ void SplitSectionSelector::AddRadioItems(const QStringList& texts)
         /* Store them in the Vector */
         m_RadioActions.push_back(action);
     }
+}
+
+void SplitSectionSelector::CycleRadioActionsForwards()
+{
+    auto action = m_RadioGroup->checkedAction();
+    int next = (action->objectName().toInt() + 1) % static_cast<int>(m_RadioActions.size());
+
+    m_RadioActions[next]->trigger();
+}
+
+void SplitSectionSelector::CycleRadioActionsBackwards()
+{
+    auto action = m_RadioGroup->checkedAction();
+    int previous = (action->objectName().toInt() + 1) % static_cast<int>(m_RadioActions.size());
+
+    m_RadioActions[previous]->trigger();
 }
 
 void SplitSectionSelector::PrimaryItemSelected(const QString& text, const int index)

--- a/src/VoidUi/QExtensions/Frame.cpp
+++ b/src/VoidUi/QExtensions/Frame.cpp
@@ -90,23 +90,19 @@ void SplitSectionSelector::CycleRadioActionsForwards()
 void SplitSectionSelector::CycleRadioActionsBackwards()
 {
     auto action = m_RadioGroup->checkedAction();
-    int previous = (action->objectName().toInt() + 1) % static_cast<int>(m_RadioActions.size());
+    int previous = std::abs((action->objectName().toInt() - 1) % static_cast<int>(m_RadioActions.size()));
 
     m_RadioActions[previous]->trigger();
 }
 
 void SplitSectionSelector::PrimaryItemSelected(const QString& text, const int index)
 {
-    /* The text would get displayed on the Frame */
     setText(text);
-
-    /* And the index gets emitted */
     emit primaryIndexChanged(index);
 }
 
 void SplitSectionSelector::RadioItemSelected(const QString& text, const int index)
 {
-    /* Emit the index */
     emit radioIndexChanged(index);
 }
 
@@ -124,7 +120,7 @@ void VLine::paintEvent(QPaintEvent* event)
     painter.setRenderHint(QPainter::Antialiasing);
 
     painter.fillRect(rect(), palette().color(QPalette::Window).darker(150));
-    painter.setPen(QPen(palette().color(QPalette::Window).lighter(180), 2));
+    painter.setPen(QPen(palette().color(QPalette::Window).lighter(180), 1));
 
     painter.drawLine(0, 0, 0, height());
     painter.drawLine(width() - 1, 0, width(), height());

--- a/src/VoidUi/QExtensions/Frame.h
+++ b/src/VoidUi/QExtensions/Frame.h
@@ -45,6 +45,9 @@ public:
      */
     void AddRadioItems(const QStringList& texts);
 
+    void CycleRadioActionsForwards();
+    void CycleRadioActionsBackwards();
+
 signals:
     /**
      * Emitted when any of the Primary Items are selected from the Menu

--- a/src/VoidUi/QExtensions/MessageBox.cpp
+++ b/src/VoidUi/QExtensions/MessageBox.cpp
@@ -3,6 +3,7 @@
 
 /* Qt */
 #include <QMouseEvent>
+#include <QPushButton>
 
 /* Internal */
 #include "MessageBox.h"
@@ -12,6 +13,9 @@ VOID_NAMESPACE_OPEN
 SaveMessageBox::SaveMessageBox(const QString& title, const QString& text, QWidget* parent)
     : QMessageBox(QMessageBox::Warning, title, text, QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel, parent)
 {
+    button(QMessageBox::Save)->setText("&Save");
+    button(QMessageBox::Discard)->setText("&Discard");
+    button(QMessageBox::Cancel)->setText("&Cancel");
 }
 
 SaveMessageBox::SaveMessageBox(QWidget* parent)

--- a/src/VoidUi/Timeline/Timeline.cpp
+++ b/src/VoidUi/Timeline/Timeline.cpp
@@ -435,18 +435,15 @@ void Timeline::PlayNextFrame()
 {
 	Timekeeper& t = Timekeeper::Instance();
 	v_frame_t next = t.NextFrame(ElapsedFrames());
-	if (next <= t.EndFrame())
-	{
-		m_Timeslider->setValue(next);
-	}
-	else
+	m_Timeslider->setValue(next);
+
+	if (next == t.EndFrame())
 	{
 		switch (m_LoopType)
 		{
-			case LoopType::PlayOnce: Stop(); break;
-			case LoopType::PingPong: PlayBackwards(); break;
+			case LoopType::PlayOnce: return Stop();
+			case LoopType::PingPong: return PlayBackwards();
 			case LoopType::LoopInfinitely: emit mediaFinished(PlayState::FORWARDS);
-			default: m_Timeslider->setValue(t.StartFrame());
 		}
 	}
 }
@@ -455,19 +452,16 @@ void Timeline::PlayPreviousFrame()
 {
 	Timekeeper& t = Timekeeper::Instance();
 	v_frame_t previous = t.PreviousFrame(ElapsedFrames());
-	if (previous < t.StartFrame())
+	m_Timeslider->setValue(previous);
+
+	if (previous == t.StartFrame())
 	{
 		switch (m_LoopType)
 		{
-			case LoopType::PlayOnce: Stop(); break;
-			case LoopType::PingPong: PlayForwards(); break;
-			case LoopType::LoopInfinitely: emit mediaFinished(PlayState::BACKWARDS);
-			default: m_Timeslider->setValue(t.EndFrame()); 
+			case LoopType::PlayOnce: return Stop();
+			case LoopType::PingPong: return PlayForwards();
+			case LoopType::LoopInfinitely: emit mediaFinished(PlayState::BACKWARDS);	
 		}
-	}
-	else
-	{
-		m_Timeslider->setValue(previous);
 	}
 }
 

--- a/src/VoidUi/Toolkit/BufferSwitch.cpp
+++ b/src/VoidUi/Toolkit/BufferSwitch.cpp
@@ -6,7 +6,6 @@
 
 /* Internal */
 #include "BufferSwitch.h"
-#include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -97,6 +96,11 @@ void ComparisonModeSelector::SetCompareMode(const Renderer::ComparisonMode& mode
 
     /* Emit the index of the Mode so that other components can receive them */
     emit primaryIndexChanged(static_cast<int>(mode));
+}
+
+void ComparisonModeSelector::SwitchBlendMode(int delta)
+{
+    delta < 0 ? CycleRadioActionsBackwards() : CycleRadioActionsForwards();
 }
 
 /* }}} */

--- a/src/VoidUi/Toolkit/BufferSwitch.h
+++ b/src/VoidUi/Toolkit/BufferSwitch.h
@@ -47,6 +47,7 @@ public:
      * Sets the Comparison Mode
      */
     void SetCompareMode(const Renderer::ComparisonMode& mode);
+    void SwitchBlendMode(int delta);
 
 private:
     /**
@@ -64,6 +65,7 @@ public:
     ~BufferSwitch();
 
     inline void SetCompareMode(const Renderer::ComparisonMode& mode) { m_ComparisonModes->SetCompareMode(mode); }
+    inline void SwitchBlendMode(int delta) { m_ComparisonModes->SwitchBlendMode(delta); }
 
 signals:
     void switched(const PlayerViewBuffer&);

--- a/src/VoidUi/Toolkit/ControlBar.cpp
+++ b/src/VoidUi/Toolkit/ControlBar.cpp
@@ -76,6 +76,9 @@ ControlBar::ControlBar(ViewerBuffer* A, ViewerBuffer* B, QWidget* parent)
 
 ControlBar::~ControlBar()
 {
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
 }
 
 QFrame* ControlBar::Separator()
@@ -137,6 +140,8 @@ void ControlBar::Build()
     m_Zoomer = new ControlSpinner();
     m_Zoomer->setToolTip(ToolTipString("Zoom Controller", "Adjust viewer image zoom.").c_str());
 
+    m_ViewerController = new ViewerController;
+
     /* The Left Side Widget */
     m_LeftControls = new QWidget();
     m_LeftLayout = new QHBoxLayout(m_LeftControls);
@@ -160,6 +165,7 @@ void ControlBar::Build()
 
     /* Add to the Right Layout */
     /* Spacer from the left side */
+    m_RightLayout->addWidget(m_ViewerController);
     m_RightLayout->addStretch(1);
     m_RightLayout->addWidget(m_ColorDisplayController);
     m_RightLayout->addWidget(m_Zoomer);

--- a/src/VoidUi/Toolkit/ControlBar.h
+++ b/src/VoidUi/Toolkit/ControlBar.h
@@ -50,6 +50,7 @@ public:
      * Sets the current Compare mode
      */
     inline void SetCompareMode(const Renderer::ComparisonMode& mode) { m_BufferSwitch->SetCompareMode(mode); }
+    inline void SwitchBlendMode(int delta) { m_BufferSwitch->SwitchBlendMode(delta); }
 
 signals:
     void zoomChanged(const float factor);

--- a/src/VoidUi/Toolkit/ControlBar.h
+++ b/src/VoidUi/Toolkit/ControlBar.h
@@ -15,6 +15,7 @@
 #include "ControlScroller.h"
 #include "ColorController.h"
 #include "Definition.h"
+#include "ViewerController.h"
 #include "VoidUi/QExtensions/PushButton.h"
 
 VOID_NAMESPACE_OPEN
@@ -51,6 +52,9 @@ public:
      */
     inline void SetCompareMode(const Renderer::ComparisonMode& mode) { m_BufferSwitch->SetCompareMode(mode); }
     inline void SwitchBlendMode(int delta) { m_BufferSwitch->SwitchBlendMode(delta); }
+
+    // Update the current viewer control that needs to be active
+    inline void SetViewerControl(const ViewerControl& control) { m_ViewerController->SetControl(control); }
 
 signals:
     void zoomChanged(const float factor);
@@ -95,9 +99,11 @@ private: /* Members */
     /* Viewer Buffers */
     ViewerBuffer* m_ViewerBufferA;
     ViewerBuffer* m_ViewerBufferB;
-    
+
     /* Viewer Buffer Switch */
     BufferSwitch* m_BufferSwitch;
+
+    ViewerController* m_ViewerController;
 
     /**
      * In order to keep the ViewerBuffer selector always in the center,

--- a/src/VoidUi/Toolkit/ViewerController.cpp
+++ b/src/VoidUi/Toolkit/ViewerController.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QLabel>
+
+/* Internal */
+#include "ViewerController.h"
+#include "GridController.h"
+#include "VoidUi/Engine/IconForge.h"
+#include "VoidUi/Player/PlayerBridge.h"
+
+VOID_NAMESPACE_OPEN
+
+ViewerController::ViewerController(QWidget* parent)
+    : QWidget(parent)
+    , m_ViewerControl(ViewerControl::None)
+{
+    Build();
+    Setup();
+    Connect();
+}
+
+ViewerController::~ViewerController()
+{
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void ViewerController::SetControl(const ViewerControl& control)
+{
+    m_ViewerControl = control;
+    m_ControlOption->setVisible(control != ViewerControl::None);
+    m_ControlOption->setIcon(Icon(control));
+}
+
+void ViewerController::Build()
+{
+    m_Layout = new QHBoxLayout(this);
+
+    m_ControlOption = new QPushButton;
+    m_Layout->addWidget(m_ControlOption);
+
+    m_Layout->setContentsMargins(0, 0, 0, 0);
+}
+
+void ViewerController::Connect()
+{
+    connect(m_ControlOption, &QPushButton::clicked, this, [this]() -> void
+    {
+        if (m_ViewerControl == ViewerControl::GridControl)
+        {
+            GridController g;
+            g.move(m_ControlOption->mapToGlobal(m_ControlOption->rect().bottomLeft()));
+            g.exec();
+        }
+        else if (m_ViewerControl == ViewerControl::OnionSkinControl)
+        {
+            OnionSkinController osc;
+            osc.move(m_ControlOption->mapToGlobal(m_ControlOption->rect().bottomLeft()));
+            osc.exec();
+        }
+    });
+}
+
+void ViewerController::Setup()
+{
+    m_ControlOption->setFixedWidth(26);
+    SetControl(ViewerControl::None);
+}
+
+QIcon ViewerController::Icon(const ViewerControl& control)
+{
+    switch (control)
+    {
+        case ViewerControl::OnionSkinControl: return IconForge::GetIcon(IconType::icon_trail_length_short, _DARK_COLOR(QPalette::Text, 100));
+        case ViewerControl::GridControl:
+        default: return IconForge::GetIcon(IconType::icon_grid_view, _DARK_COLOR(QPalette::Text, 100));
+    }
+}
+
+/// OnionSkinController
+
+OnionSkinController::OnionSkinController(QWidget* parent)
+    : TranslucentDialog(parent)
+{
+    Build();
+    Setup();
+
+    connect(m_PeelSlider, &QSlider::valueChanged, this, [this](int value) -> void
+    {
+        _PlayerBridge.SetPeelFactor((float)value / 10.f);
+    });
+}
+
+OnionSkinController::~OnionSkinController()
+{
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void OnionSkinController::Build()
+{
+    m_Layout = new QHBoxLayout(this);
+    m_PeelSlider = new QSlider(Qt::Horizontal);
+
+    m_Layout->addWidget(new QLabel("Peel Factor: ", this));
+    m_Layout->addWidget(m_PeelSlider);
+}
+
+void OnionSkinController::Setup()
+{
+    m_PeelSlider->setRange(0, 10);
+    m_PeelSlider->setValue(_PlayerBridge.PeelFactor() * 10);
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Toolkit/ViewerController.h
+++ b/src/VoidUi/Toolkit/ViewerController.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _VIEWER_CONTROLLER_H
+#define _VIEWER_CONTROLLER_H
+
+/* Qt */
+#include <QLayout>
+#include <QSlider>
+#include <QWidget>
+#include <QPushButton>
+
+/* Internal */
+#include "Definition.h"
+#include "VoidUi/QExtensions/Dialog.h"
+
+VOID_NAMESPACE_OPEN
+
+enum class ViewerControl
+{
+    None,
+    GridControl,
+    OnionSkinControl
+};
+
+class ViewerController : public QWidget
+{
+    Q_OBJECT
+public:
+    ViewerController(QWidget* parent = nullptr);
+    ~ViewerController();
+
+    void SetControl(const ViewerControl& control);
+    ViewerControl Control() const { return m_ViewerControl; }
+
+private: /* Members */
+    QLayout* m_Layout;
+    QPushButton* m_ControlOption;
+
+    ViewerControl m_ViewerControl;
+
+private: /* Methods */
+    void Build();
+    void Connect();
+    void Setup();
+    QIcon Icon(const ViewerControl& control);
+};
+
+class OnionSkinController : public TranslucentDialog
+{
+public:
+    OnionSkinController(QWidget* parent = nullptr);
+    ~OnionSkinController();
+
+private: /* Members */
+    QHBoxLayout* m_Layout;
+    QSlider* m_PeelSlider;
+
+private: /* Methods */
+    void Build();
+    void Setup();
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _VIEWER_CONTROLLER_H


### PR DESCRIPTION
## Feat: Blend Modes Update for Viewer
* Image Comparison can be done with an Onion Skin blend between the image sources
* Blend Modes can be cycled forwards and backwards using menu item (and mainly via the Shortcuts Shift+9, Shift+0).
* Added ViewerController to the Control bar which holds the Control options for blend/Comparison modes.
* Added Mnemonics on the Widget buttons to allow shortcut keys to work directly on message box/alt + shortcut key on regular dialog boxes.
* Added Shortcut keys (1 & 2) to play selected media on Buffer A and B respectively directly, as opposed to dragging the media on the buffer portion.

### Fixes
* Fixed the issue where setting fullscreen on Grid mode made the textures to not appear correctly during playback.
* Fixed issue with the playback modes which were no longer working after the change to consider elapsed frames while playback.
* Fixed the issue with using PlayableComponent::Playlist for Grid playback, introduced dedicated PlayableComponent::Grid to make sure we don't see unwanted behaviour during grid playback.