### PR TITLE
[VOID] Image Export System

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,9 +112,9 @@ find_package(spdlog REQUIRED)
 
 # Definitions
 # Enable Logging if we have spdlog present and we're on the debug build
-if (CMAKE_BUILD_TYPE STREQUAL "debug")
-    add_definitions(-DVOID_ENABLE_LOGGING)
-endif()
+# if (CMAKE_BUILD_TYPE STREQUAL "debug")
+add_definitions(-DVOID_ENABLE_LOGGING)
+# endif()
 
 # Add the VOID Source
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,9 +112,9 @@ find_package(spdlog REQUIRED)
 
 # Definitions
 # Enable Logging if we have spdlog present and we're on the debug build
-# if (CMAKE_BUILD_TYPE STREQUAL "debug")
-add_definitions(-DVOID_ENABLE_LOGGING)
-# endif()
+if (CMAKE_BUILD_TYPE STREQUAL "debug")
+    add_definitions(-DVOID_ENABLE_LOGGING)
+endif()
 
 # Add the VOID Source
 add_subdirectory(src)

--- a/src/VoidApplication/Engine/Engine.cpp
+++ b/src/VoidApplication/Engine/Engine.cpp
@@ -7,10 +7,12 @@
 #include "VoidCore/Logging.h"
 /* Theme */
 #include "VoidStyle.h"
-/* Reader Registration */
+/* Plugin Registration */
 #include "VoidCore/Plugins/Loader.h"
 #include "VoidCore/Readers/Registration.h"
 #include "VoidCore/Operators/Registration.h"
+#include "VoidCore/Writers/Registration.h"
+
 #include "VoidCore/Profiler.h"
 #include "VoidObjects/Core/Threads.h"
 #include "VoidUi/Engine/Bridge.h"
@@ -117,10 +119,12 @@ void VoidEngine::Initialize()
 
 void VoidEngine::PostInit()
 {
-    /* Register Media Readers */
+    // Register Media Readers
     RegisterReaders();
-    /* Register Operators */
+    // Register Operators
     RegisterOperators();
+    // Register Media Writers
+    RegisterWriters();
 
     /* Register Any other Media plugins that are found in the way */
     // ReaderPluginLoader::Instance().LoadExternals();
@@ -140,7 +144,7 @@ void VoidEngine::PostStartup()
 void VoidEngine::Callback()
 {
     if (m_Args.project.empty() && m_Args.media.empty() && !m_Args.basic)
-    {    
+    {
         /* Startup window pop-up */
         StartupWindow::Exec(m_Imager);
     }

--- a/src/VoidCore/CMakeLists.txt
+++ b/src/VoidCore/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     Media/Filesystem.cpp
     Media/Frame.cpp
     Media/Media.cpp
+    Media/Renderer.cpp
 
     # Media Readers
     Readers/OIIOReader.cpp
@@ -37,6 +38,10 @@ set(SOURCES
 
     # Processors
     Processors/ImageProcessor.cpp
+
+    # Media Writers
+    Writers/OIIOWriter.cpp
+    Writers/FFmpegWriter.cpp
 )
 
 add_library(

--- a/src/VoidCore/FormatForge.cpp
+++ b/src/VoidCore/FormatForge.cpp
@@ -31,6 +31,7 @@ bool Forge::Register(const FormatRegistry<MPixForge>& registry)
         RegisterMovieReader(extension, registry.reader);
     }
 
+    // Need to have a better way to deal with the return status or not have this at all
     return true;
 }
 
@@ -39,6 +40,22 @@ bool Forge::Register(const IOpRegistry& registry)
     VOID_LOG_INFO("Registering Image Operator: {0}", registry.name);
     auto it = m_IOpForger.emplace(registry.name, std::move(registry.iop));
     return it.second;
+}
+
+bool Forge::Register(const WriterRegistry& registry)
+{
+    if (registry.type == WriterType::Image)
+    {
+        for (const auto& extension : registry.extensions)
+            RegisterImageWriter(extension, registry.writer);
+    }
+    else
+    {
+        for (const auto& extension : registry.extensions)
+            RegisterMovieWriter(extension, registry.writer);
+    }
+
+    return true;
 }
 
 void Forge::UnregisterPlugins()
@@ -81,6 +98,30 @@ void Forge::RegisterMovieReader(const std::string& extension, MPixForge forger)
     m_MovieForger[extension] = std::move(forger);
 }
 
+void Forge::RegisterImageWriter(const std::string& extension, PixWriterForge forger)
+{
+    if (m_ImageWriters.find(extension) != m_ImageWriters.end())
+    {
+        VOID_LOG_WARN("Image writer for {0} extension is already registered. Ignoring registration");
+        return;
+    }
+
+    VOID_LOG_INFO("Registering Image Writer for extension: {0}", extension);
+    m_ImageWriters[extension] = std::move(forger);
+}
+
+void Forge::RegisterMovieWriter(const std::string& extension, PixWriterForge forger)
+{
+    if (m_MovieWriters.find(extension) != m_MovieWriters.end())
+    {
+        VOID_LOG_WARN("Movie writer for {0} extension is already registered. Ignoring registration");
+        return;
+    }
+
+    VOID_LOG_INFO("Registering Movie Writer for extension: {0}", extension);
+    m_MovieWriters[extension] = std::move(forger);
+}
+
 std::unique_ptr<VoidPixReader> Forge::GetImageReader(const std::string& extension, const std::string& path, v_frame_t framenumber) const
 {
     std::unordered_map<std::string, PixForge>::const_iterator it = m_ImageForger.find(extension);
@@ -97,6 +138,18 @@ std::unique_ptr<ImageOp> Forge::GetImageOp(const std::string& name) const
 {
     std::unordered_map<std::string, IOpForge>::const_iterator it = m_IOpForger.find(name);
     return it == m_IOpForger.end() ? nullptr : it->second();
+}
+
+std::unique_ptr<PixWriter> Forge::GetImageWriter(const std::string& extension, int width, int height, int channels, const WriterType& type) const
+{
+    auto it = m_ImageWriters.find(extension);
+    return it == m_ImageWriters.end() ? nullptr : it->second(width, height, channels, type);
+}
+
+std::unique_ptr<PixWriter> Forge::GetMovieWriter(const std::string& extension, int width, int height, int channels, const WriterType& type) const
+{
+    auto it = m_MovieWriters.find(extension);
+    return it == m_MovieWriters.end() ? nullptr : it->second(width, height, channels, type);
 }
 
 bool Forge::IsRegistered(const std::string& extension) const

--- a/src/VoidCore/Media/Filesystem.cpp
+++ b/src/VoidCore/Media/Filesystem.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License
 
 /* STD */
+#include <cmath>
 #include <iomanip>
 #include <regex>
 #include <sstream>
@@ -251,6 +252,28 @@ std::string MEntry::TemplatedName() const
     return name;
 }
 
+std::string MEntry::ResolvedPath(v_frame_t frame) const
+{
+    if (m_Templated)
+    {
+        std::string path;
+        int padding = frame == 0 ? 1 : static_cast<int>(std::log10(frame)) + 1;
+        path.reserve(m_Basepath.size() + 1 + m_Name.size() + 1 + padding + 1 + m_Extension.size());
+
+        path += m_Basepath;
+        path += "/";
+        path += m_Name;
+        path += ".";
+        path += std::to_string(frame);
+        path += ".";
+        path += m_Extension;
+
+        return path;
+    }
+
+    // The internals are not templated and we don't want to resolve to another frame directly
+    return m_Path;
+}
 
 /* }}} */
 

--- a/src/VoidCore/Media/Filesystem.h
+++ b/src/VoidCore/Media/Filesystem.h
@@ -75,6 +75,7 @@ public:
     inline unsigned int Framepadding() const { return m_FramePadding; }
     std::string TemplatedPath() const;
     std::string TemplatedName() const;
+    std::string ResolvedPath(v_frame_t frame) const;
 
     /**
      * Returns True if the Media does not have a frame number on it to denote that this

--- a/src/VoidCore/Media/Renderer.cpp
+++ b/src/VoidCore/Media/Renderer.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* STD */
+#include <filesystem>
+
+/* Internal */
+#include "Renderer.h"
+#include "FormatForge.h"
+#include "VoidCore/Logging.h"
+#include "VoidCore/Profiler.h"
+
+VOID_NAMESPACE_OPEN
+
+namespace Renderer {
+
+ImageRenderer::ImageRenderer(const MEntry& entry, int width, int height, int channels)
+    : m_Writer(std::move(Forge::Instance().GetImageWriter(entry.Extension(), width, height, channels, WriterType::Image)))
+    , m_MediaEntry(entry)
+{
+}
+
+ImageRenderer::~ImageRenderer()
+{
+    // if (m_Writer)
+    //     m_Writer->Cleanup();
+}
+
+bool ImageRenderer::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+{
+    // if (m_Writer)
+    //     m_Writer->AddBuffer(buffer, size, type);
+    if (m_Writer)
+    {
+        if (m_Writer->Setup(m_MediaEntry.Fullpath()))
+        {
+            m_Writer->AddBuffer(buffer, size, type);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ImageRenderer::AddBuffer(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type)
+{
+    // if (m_Writer)
+    //     m_Writer->AddBuffer(buffer, size, type);
+    if (m_Writer)
+    {
+        if (m_Writer->Setup(m_MediaEntry.ResolvedPath(frame)))
+        {
+            m_Writer->AddBuffer(buffer, size, type);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ImageRenderer::Render()
+{
+    if (m_Writer)
+    {
+        if (m_Writer->Write())
+        {
+            m_Writer->Cleanup();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ImageRenderer::Render(const void* buffer, std::size_t size, const BufferType& type)
+{
+    Tools::VoidProfiler<std::chrono::duration<double>> p("ImageRenderer::Render");
+    if (m_Writer)
+    {
+        if (m_Writer->Setup(m_MediaEntry.Fullpath()))
+        {
+            m_Writer->AddBuffer(buffer, size, type);
+            m_Writer->Write();
+            m_Writer->Cleanup();
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ImageRenderer::Render(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type)
+{
+    Tools::VoidProfiler<std::chrono::duration<double>> p("ImageRenderer::Render");
+    if (m_Writer)
+    {
+        if (m_Writer->Setup(m_MediaEntry.ResolvedPath(frame)))
+        {
+            m_Writer->AddBuffer(buffer, size, type);
+            m_Writer->Write();
+            m_Writer->Cleanup();
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+/// MovieRenderer
+
+MovieRenderer::MovieRenderer(const MEntry& entry, int width, int height, int channels)
+    : m_Writer(std::move(Forge::Instance().GetMovieWriter(entry.Extension(), width, height, channels, WriterType::Movie)))
+    , m_MediaEntry(entry)
+{
+    if (m_Writer)
+        m_Writer->Setup(m_MediaEntry.Fullpath());
+}
+
+MovieRenderer::~MovieRenderer()
+{
+    if (m_Writer)
+        m_Writer->Cleanup();
+}
+
+bool MovieRenderer::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+{
+    if (m_Writer)
+    {
+        m_Writer->AddBuffer(buffer, size, type);
+        return true;
+    }
+
+    return false;
+}
+
+bool MovieRenderer::Render()
+{
+    if (m_Writer)
+        return m_Writer->Write();
+
+    return false;
+}
+
+
+bool RenderImage(const MEntry& e, int w, int h, int ch, const void* buf, std::size_t size, const BufferType& type)
+{
+    // VOID_LOG_INFO("RenderImage::Path: {0}, extension: {1}", e.Fullpath(), e.Extension());
+    // VOID_LOG_INFO("Image Specs: {0}x{1}, channels: {2}, size: {3}", w, h, ch, size);
+    
+    Tools::VoidProfiler<std::chrono::duration<double>> p("Renderer::RenderImage");
+    // auto writer = std::move(Forge::Instance().GetImageWriter(e.Extension(), w, h, ch, WriterType::Image));
+    if (auto writer = std::move(Forge::Instance().GetImageWriter(e.Extension(), w, h, ch, WriterType::Image)))
+    {
+        // VOID_LOG_INFO("Writer found for extension: {}", e.Extension());
+        // writer->AddBuffer(buf, size, type);
+        // return writer->Write(e.Fullpath());
+
+        if (writer->Setup(e.Fullpath()))
+        {
+            writer->AddBuffer(buf, size, type);
+            writer->Write();
+            writer->Cleanup();
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool RenderImage(
+    const MEntry& e, v_frame_t f, int w, int h, int ch, const void* buf, std::size_t size, const BufferType& type
+)
+{
+    // This method does not concern whether the entry is templated correctly or not
+    // That's something which gets handled at the calling function level
+    // Assuming the entry is correct and that the resolved path with the frame returns correct path to the numbered frame
+    
+    Tools::VoidProfiler<std::chrono::duration<double>> p("Renderer::RenderImage");
+    // auto writer = std::move(Forge::Instance().GetImageWriter(entry.Extension(), width, height, channels, WriterType::Image));
+    if (auto writer = std::move(Forge::Instance().GetImageWriter(e.Extension(), w, h, ch, WriterType::Image)))
+    {
+        // VOID_LOG_INFO("Writer found for extension: {}", e.Extension());
+        // writer->AddBuffer(buf, size, type);
+        // return writer->Write(e.ResolvedPath(f));
+        if (writer->Setup(e.ResolvedPath(f)))
+        {
+            writer->AddBuffer(buf, size, type);
+
+            writer->Write();
+            writer->Cleanup();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // namespace Renderer
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Media/Renderer.cpp
+++ b/src/VoidCore/Media/Renderer.cpp
@@ -28,15 +28,10 @@ ImageRenderer::~ImageRenderer()
 
 bool ImageRenderer::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
 {
-    // if (m_Writer)
-    //     m_Writer->AddBuffer(buffer, size, type);
     if (m_Writer)
     {
         if (m_Writer->Setup(m_MediaEntry.Fullpath()))
-        {
-            m_Writer->AddBuffer(buffer, size, type);
-            return true;
-        }
+            return m_Writer->AddBuffer(buffer, size, type);
     }
 
     return false;
@@ -44,15 +39,10 @@ bool ImageRenderer::AddBuffer(const void* buffer, std::size_t size, const Buffer
 
 bool ImageRenderer::AddBuffer(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type)
 {
-    // if (m_Writer)
-    //     m_Writer->AddBuffer(buffer, size, type);
     if (m_Writer)
     {
         if (m_Writer->Setup(m_MediaEntry.ResolvedPath(frame)))
-        {
-            m_Writer->AddBuffer(buffer, size, type);
-            return true;
-        }
+            return m_Writer->AddBuffer(buffer, size, type);
     }
 
     return false;
@@ -79,11 +69,11 @@ bool ImageRenderer::Render(const void* buffer, std::size_t size, const BufferTyp
     {
         if (m_Writer->Setup(m_MediaEntry.Fullpath()))
         {
-            m_Writer->AddBuffer(buffer, size, type);
-            m_Writer->Write();
+            bool ret = m_Writer->AddBuffer(buffer, size, type);
+            ret = m_Writer->Write();
             m_Writer->Cleanup();
 
-            return true;
+            return ret;
         }
     }
 
@@ -97,11 +87,11 @@ bool ImageRenderer::Render(v_frame_t frame, const void* buffer, std::size_t size
     {
         if (m_Writer->Setup(m_MediaEntry.ResolvedPath(frame)))
         {
-            m_Writer->AddBuffer(buffer, size, type);
-            m_Writer->Write();
+            bool ret = m_Writer->AddBuffer(buffer, size, type);
+            ret = m_Writer->Write();
             m_Writer->Cleanup();
 
-            return true;
+            return ret;
         }
     }
 
@@ -128,10 +118,7 @@ MovieRenderer::~MovieRenderer()
 bool MovieRenderer::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
 {
     if (m_Writer)
-    {
-        m_Writer->AddBuffer(buffer, size, type);
-        return true;
-    }
+        return m_Writer->AddBuffer(buffer, size, type);
 
     return false;
 }
@@ -140,61 +127,6 @@ bool MovieRenderer::Render()
 {
     if (m_Writer)
         return m_Writer->Write();
-
-    return false;
-}
-
-
-bool RenderImage(const MEntry& e, int w, int h, int ch, const void* buf, std::size_t size, const BufferType& type)
-{
-    // VOID_LOG_INFO("RenderImage::Path: {0}, extension: {1}", e.Fullpath(), e.Extension());
-    // VOID_LOG_INFO("Image Specs: {0}x{1}, channels: {2}, size: {3}", w, h, ch, size);
-    
-    Tools::VoidProfiler<std::chrono::duration<double>> p("Renderer::RenderImage");
-    // auto writer = std::move(Forge::Instance().GetImageWriter(e.Extension(), w, h, ch, WriterType::Image));
-    if (auto writer = std::move(Forge::Instance().GetImageWriter(e.Extension(), w, h, ch, WriterType::Image)))
-    {
-        // VOID_LOG_INFO("Writer found for extension: {}", e.Extension());
-        // writer->AddBuffer(buf, size, type);
-        // return writer->Write(e.Fullpath());
-
-        if (writer->Setup(e.Fullpath()))
-        {
-            writer->AddBuffer(buf, size, type);
-            writer->Write();
-            writer->Cleanup();
-
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool RenderImage(
-    const MEntry& e, v_frame_t f, int w, int h, int ch, const void* buf, std::size_t size, const BufferType& type
-)
-{
-    // This method does not concern whether the entry is templated correctly or not
-    // That's something which gets handled at the calling function level
-    // Assuming the entry is correct and that the resolved path with the frame returns correct path to the numbered frame
-    
-    Tools::VoidProfiler<std::chrono::duration<double>> p("Renderer::RenderImage");
-    // auto writer = std::move(Forge::Instance().GetImageWriter(entry.Extension(), width, height, channels, WriterType::Image));
-    if (auto writer = std::move(Forge::Instance().GetImageWriter(e.Extension(), w, h, ch, WriterType::Image)))
-    {
-        // VOID_LOG_INFO("Writer found for extension: {}", e.Extension());
-        // writer->AddBuffer(buf, size, type);
-        // return writer->Write(e.ResolvedPath(f));
-        if (writer->Setup(e.ResolvedPath(f)))
-        {
-            writer->AddBuffer(buf, size, type);
-
-            writer->Write();
-            writer->Cleanup();
-            return true;
-        }
-    }
 
     return false;
 }

--- a/src/VoidCore/Media/Renderer.h
+++ b/src/VoidCore/Media/Renderer.h
@@ -19,13 +19,14 @@ public:
     ImageRenderer(const MEntry& entry, int width, int height, int channels);
     ~ImageRenderer();
 
+    bool Valid() const { return (bool)m_Writer; }
+
     bool AddBuffer(const void* buf, std::size_t size, const BufferType& type);
     bool AddBuffer(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type);
 
     bool Render();
     bool Render(const void* buffer, std::size_t size, const BufferType& type);
     bool Render(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type);
-    // bool Render(v_frame_t frame);
 
 private:
     std::unique_ptr<PixWriter> m_Writer;
@@ -38,6 +39,8 @@ public:
     MovieRenderer(const MEntry& entry, int width, int height, int channels);
     ~MovieRenderer();
 
+    bool Valid() const { return (bool)m_Writer; }
+
     bool AddBuffer(const void* buf, std::size_t size, const BufferType& type);
     bool Render();
 
@@ -45,12 +48,6 @@ private:
     std::unique_ptr<PixWriter> m_Writer;
     MEntry m_MediaEntry;
 };
-
-VOID_API bool RenderImage(const MEntry& e, int w, int h, int ch, const void* buf, std::size_t size, const BufferType& type);
-
-VOID_API bool RenderImage(
-    const MEntry& e, v_frame_t f, int w, int h, int ch, const void* buf, std::size_t size, const BufferType& type
-);
 
 } // namespace Renderer
 

--- a/src/VoidCore/Media/Renderer.h
+++ b/src/VoidCore/Media/Renderer.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _MEDIA_RENDERER_H
+#define _MEDIA_RENDERER_H
+
+/* Internal */
+#include "Definition.h"
+#include "Filesystem.h"
+#include "PixWriter.h"
+
+VOID_NAMESPACE_OPEN
+
+namespace Renderer {
+
+class VOID_API ImageRenderer
+{
+public:
+    ImageRenderer(const MEntry& entry, int width, int height, int channels);
+    ~ImageRenderer();
+
+    bool AddBuffer(const void* buf, std::size_t size, const BufferType& type);
+    bool AddBuffer(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type);
+
+    bool Render();
+    bool Render(const void* buffer, std::size_t size, const BufferType& type);
+    bool Render(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type);
+    // bool Render(v_frame_t frame);
+
+private:
+    std::unique_ptr<PixWriter> m_Writer;
+    MEntry m_MediaEntry;
+};
+
+class VOID_API MovieRenderer
+{
+public:
+    MovieRenderer(const MEntry& entry, int width, int height, int channels);
+    ~MovieRenderer();
+
+    bool AddBuffer(const void* buf, std::size_t size, const BufferType& type);
+    bool Render();
+
+private:
+    std::unique_ptr<PixWriter> m_Writer;
+    MEntry m_MediaEntry;
+};
+
+VOID_API bool RenderImage(const MEntry& e, int w, int h, int ch, const void* buf, std::size_t size, const BufferType& type);
+
+VOID_API bool RenderImage(
+    const MEntry& e, v_frame_t f, int w, int h, int ch, const void* buf, std::size_t size, const BufferType& type
+);
+
+} // namespace Renderer
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _MEDIA_RENDERER_H

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -12,7 +12,8 @@ FFmpegWriter::FFmpegWriter(int width, int height, int channels, const WriterType
     , m_FormatCtx(nullptr)
     , m_CodecCtx(nullptr)
     , m_SwsCtx(nullptr)
-    , m_Frame(0)
+    , m_Stream(nullptr)
+    , m_Pts(0)
 {
 }
 
@@ -22,7 +23,6 @@ bool FFmpegWriter::Setup(const std::string& path)
     {
         Cleanup();
         m_Path = path;
-        VOID_LOG_INFO("FFmpegWriter::Setup path: {0}", m_Path);
 
         avformat_alloc_output_context2(&m_FormatCtx, nullptr, nullptr, path.c_str());
 
@@ -30,30 +30,37 @@ bool FFmpegWriter::Setup(const std::string& path)
         // TODO: Enable multi format selection for Movies
         // How to best implement that?
         const AVCodec* codec = avcodec_find_encoder(AV_CODEC_ID_H264);
-        AVStream* stream = avformat_new_stream(m_FormatCtx, codec);
-
         m_CodecCtx = avcodec_alloc_context3(codec);
 
         m_CodecCtx->codec_id = AV_CODEC_ID_H264;
         m_CodecCtx->codec_type = AVMEDIA_TYPE_VIDEO;
         m_CodecCtx->width = m_Width;
         m_CodecCtx->height = m_Height;
-        m_CodecCtx->time_base = {1, 30};
-        m_CodecCtx->framerate = {30, 1};
+        m_CodecCtx->time_base = av_make_q(1, 30);
+        m_CodecCtx->framerate = av_make_q(30, 1);
         m_CodecCtx->pix_fmt = AV_PIX_FMT_YUV420P;
 
-        avcodec_open2(m_CodecCtx, codec, nullptr);
-        avcodec_parameters_from_context(stream->codecpar, m_CodecCtx);
+        int ret = avcodec_open2(m_CodecCtx, codec, nullptr);
+        if (ret < 0)
+        {
+            VOID_LOG_INFO("Unable to open Codec");
+            return false;
+        }
+
+        m_Stream = avformat_new_stream(m_FormatCtx, codec);
+        avcodec_parameters_from_context(m_Stream->codecpar, m_CodecCtx);
+        // This will change when we call avformat_write_header to something which ffmpeg finds appropriate
+        // to ensure this the framerate of the final written container, ensure the the AVFrame* pts is
+        // always incremented by av_rescale_q(1, codec_context->time_base, stream->time_base)
+        m_Stream->time_base = av_make_q(1, 30);
 
         // open
         avio_open(&m_FormatCtx->pb, path.c_str(), AVIO_FLAG_WRITE);
-        if (avformat_write_header(m_FormatCtx, nullptr) > 0)
-        {
-            VOID_LOG_WARN("Unable to write header.");
-
-            Cleanup();
-            return false;
-        }
+        avformat_write_header(m_FormatCtx, nullptr);
+        // {
+        //     Cleanup();
+        //     return false;
+        // }
 
         m_SwsCtx = sws_getContext(m_Width, m_Height, AV_PIX_FMT_RGBA, m_Width, m_Height, AV_PIX_FMT_YUV420P, SWS_BILINEAR, nullptr, nullptr, nullptr);
 
@@ -72,28 +79,45 @@ void FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferT
     frame->format = m_CodecCtx->pix_fmt;
     frame->width = m_CodecCtx->width;
     frame->height = m_CodecCtx->height;
-    
+
     // 32 byte align
-    av_frame_get_buffer(frame, 32);
+    if (av_frame_get_buffer(frame, 32) < 0)
+        return;
+
+    if (av_frame_make_writable(frame) < 0)
+        return;
 
     const uint8_t* srcSlice[1] = { static_cast<const uint8_t*>(buffer) };
     int srcStride[1] = { 4 * m_Width };
 
     sws_scale(m_SwsCtx, srcSlice, srcStride, 0, m_Height, frame->data, frame->linesize);
-    frame->pts = m_Frame;
+    frame->pts = m_Pts;
 
     // Encode
-    avcodec_send_frame(m_CodecCtx, frame);
+    int ret = avcodec_send_frame(m_CodecCtx, frame);
+    if ( ret < 0)
+    {
+        char errbuf[256];
+        av_strerror(ret, errbuf, sizeof(errbuf));
+
+        VOID_LOG_INFO("Unable to send frame: {0}, {1}, {2}", errbuf, ret, ret == AVERROR(EINVAL));
+        return;
+    }
+
     AVPacket* packet = av_packet_alloc();
-    // av_init_packet(packet);
     if (avcodec_receive_packet(m_CodecCtx, packet) == 0)
     {
+        packet->stream_index = m_Stream->index;
+
         av_interleaved_write_frame(m_FormatCtx, packet);
         av_packet_unref(packet);
     }
 
+    av_packet_free(&packet);
     av_frame_free(&frame);
-    m_Frame++;
+
+    // This ensures that the framerate of the encoded container is the expected
+    m_Pts += av_rescale_q(1, m_CodecCtx->time_base, m_Stream->time_base);
 }
 
 bool FFmpegWriter::Write()
@@ -123,7 +147,7 @@ void FFmpegWriter::Cleanup()
         m_FormatCtx = nullptr;
     }
 
-    m_Frame = 0;
+    m_Pts = 0;
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -43,7 +43,8 @@ bool FFmpegWriter::Setup(const std::string& path)
         int ret = avcodec_open2(m_CodecCtx, codec, nullptr);
         if (ret < 0)
         {
-            VOID_LOG_INFO("Unable to open Codec");
+            VOID_LOG_WARN("Unable to open specified codec");
+            Cleanup();
             return false;
         }
 
@@ -56,11 +57,12 @@ bool FFmpegWriter::Setup(const std::string& path)
 
         // open
         avio_open(&m_FormatCtx->pb, path.c_str(), AVIO_FLAG_WRITE);
-        avformat_write_header(m_FormatCtx, nullptr);
-        // {
-        //     Cleanup();
-        //     return false;
-        // }
+        if (avformat_write_header(m_FormatCtx, nullptr))
+        {
+            VOID_LOG_WARN("Unable to write header");
+            Cleanup();
+            return false;
+        }
 
         m_SwsCtx = sws_getContext(m_Width, m_Height, AV_PIX_FMT_RGBA, m_Width, m_Height, AV_PIX_FMT_YUV420P, SWS_BILINEAR, nullptr, nullptr, nullptr);
 
@@ -70,10 +72,10 @@ bool FFmpegWriter::Setup(const std::string& path)
     return false;
 }
 
-void FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
 {
     if (!m_FormatCtx)
-        return;
+        return false;
 
     AVFrame* frame = av_frame_alloc();
     frame->format = m_CodecCtx->pix_fmt;
@@ -82,10 +84,10 @@ void FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferT
 
     // 32 byte align
     if (av_frame_get_buffer(frame, 32) < 0)
-        return;
+        return false;
 
     if (av_frame_make_writable(frame) < 0)
-        return;
+        return false;
 
     const uint8_t* srcSlice[1] = { static_cast<const uint8_t*>(buffer) };
     int srcStride[1] = { 4 * m_Width };
@@ -101,7 +103,7 @@ void FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferT
         av_strerror(ret, errbuf, sizeof(errbuf));
 
         VOID_LOG_INFO("Unable to send frame: {0}, {1}, {2}", errbuf, ret, ret == AVERROR(EINVAL));
-        return;
+        return false;
     }
 
     AVPacket* packet = av_packet_alloc();
@@ -118,6 +120,8 @@ void FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferT
 
     // This ensures that the framerate of the encoded container is the expected
     m_Pts += av_rescale_q(1, m_CodecCtx->time_base, m_Stream->time_base);
+
+    return true;
 }
 
 bool FFmpegWriter::Write()

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Internal */
+#include "FFmpegWriter.h"
+#include "VoidCore/Logging.h"
+
+VOID_NAMESPACE_OPEN
+
+FFmpegWriter::FFmpegWriter(int width, int height, int channels, const WriterType& type)
+    : PixWriter(width, height, channels, type)
+    , m_FormatCtx(nullptr)
+    , m_CodecCtx(nullptr)
+    , m_SwsCtx(nullptr)
+    , m_Frame(0)
+{
+}
+
+bool FFmpegWriter::Setup(const std::string& path)
+{
+    if (path != m_Path)
+    {
+        Cleanup();
+        m_Path = path;
+        VOID_LOG_INFO("FFmpegWriter::Setup path: {0}", m_Path);
+
+        avformat_alloc_output_context2(&m_FormatCtx, nullptr, nullptr, path.c_str());
+
+        // H.264 encode
+        // TODO: Enable multi format selection for Movies
+        // How to best implement that?
+        const AVCodec* codec = avcodec_find_encoder(AV_CODEC_ID_H264);
+        AVStream* stream = avformat_new_stream(m_FormatCtx, codec);
+
+        m_CodecCtx = avcodec_alloc_context3(codec);
+
+        m_CodecCtx->codec_id = AV_CODEC_ID_H264;
+        m_CodecCtx->codec_type = AVMEDIA_TYPE_VIDEO;
+        m_CodecCtx->width = m_Width;
+        m_CodecCtx->height = m_Height;
+        m_CodecCtx->time_base = {1, 30};
+        m_CodecCtx->framerate = {30, 1};
+        m_CodecCtx->pix_fmt = AV_PIX_FMT_YUV420P;
+
+        avcodec_open2(m_CodecCtx, codec, nullptr);
+        avcodec_parameters_from_context(stream->codecpar, m_CodecCtx);
+
+        // open
+        avio_open(&m_FormatCtx->pb, path.c_str(), AVIO_FLAG_WRITE);
+        if (avformat_write_header(m_FormatCtx, nullptr) > 0)
+        {
+            VOID_LOG_WARN("Unable to write header.");
+
+            Cleanup();
+            return false;
+        }
+
+        m_SwsCtx = sws_getContext(m_Width, m_Height, AV_PIX_FMT_RGBA, m_Width, m_Height, AV_PIX_FMT_YUV420P, SWS_BILINEAR, nullptr, nullptr, nullptr);
+
+        return true;
+    }
+
+    return false;
+}
+
+void FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+{
+    if (!m_FormatCtx)
+        return;
+
+    AVFrame* frame = av_frame_alloc();
+    frame->format = m_CodecCtx->pix_fmt;
+    frame->width = m_CodecCtx->width;
+    frame->height = m_CodecCtx->height;
+    
+    // 32 byte align
+    av_frame_get_buffer(frame, 32);
+
+    const uint8_t* srcSlice[1] = { static_cast<const uint8_t*>(buffer) };
+    int srcStride[1] = { 4 * m_Width };
+
+    sws_scale(m_SwsCtx, srcSlice, srcStride, 0, m_Height, frame->data, frame->linesize);
+    frame->pts = m_Frame;
+
+    // Encode
+    avcodec_send_frame(m_CodecCtx, frame);
+    AVPacket* packet = av_packet_alloc();
+    // av_init_packet(packet);
+    if (avcodec_receive_packet(m_CodecCtx, packet) == 0)
+    {
+        av_interleaved_write_frame(m_FormatCtx, packet);
+        av_packet_unref(packet);
+    }
+
+    av_frame_free(&frame);
+    m_Frame++;
+}
+
+bool FFmpegWriter::Write()
+{
+    if (!m_FormatCtx)
+        return false;
+
+    av_write_trailer(m_FormatCtx);
+    avio_close(m_FormatCtx->pb);
+
+    return true;
+}
+
+void FFmpegWriter::Cleanup()
+{
+    #if LIBSWSCALE_VERSION_MAJOR < 9
+    if (m_SwsCtx) sws_freeContext(m_SwsCtx);
+    m_SwsCtx = nullptr;
+    #else
+    if (m_SwsCtx) sws_free_context(&m_SwsCtx);
+    #endif
+    
+    if (m_CodecCtx) avcodec_free_context(&m_CodecCtx);
+    if (m_FormatCtx)
+    {
+        avformat_free_context(m_FormatCtx);
+        m_FormatCtx = nullptr;
+    }
+
+    m_Frame = 0;
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/FFmpegWriter.h
+++ b/src/VoidCore/Writers/FFmpegWriter.h
@@ -22,10 +22,10 @@ class VOID_API FFmpegWriter : public PixWriter
 public:
     FFmpegWriter(int width, int height, int channels, const WriterType& type);
 
-    bool Setup(const std::string& path);
-    void AddBuffer(const void* buffer, std::size_t size, const BufferType& type);
-    bool Write();
-    void Cleanup();
+    bool Setup(const std::string& path) override;
+    bool AddBuffer(const void* buffer, std::size_t size, const BufferType& type) override;
+    bool Write() override;
+    void Cleanup() override;
 
 private:
     AVFormatContext* m_FormatCtx;

--- a/src/VoidCore/Writers/FFmpegWriter.h
+++ b/src/VoidCore/Writers/FFmpegWriter.h
@@ -31,7 +31,8 @@ private:
     AVFormatContext* m_FormatCtx;
     AVCodecContext* m_CodecCtx;
     SwsContext* m_SwsCtx;
-    unsigned int m_Frame;
+    AVStream* m_Stream;
+    int64_t m_Pts;
 
     std::string m_Path;
 };

--- a/src/VoidCore/Writers/FFmpegWriter.h
+++ b/src/VoidCore/Writers/FFmpegWriter.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _FFMPEG_PIX_WRITER_H
+#define _FFMPEG_PIX_WRITER_H
+
+/* FFmpeg */
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libswscale/swscale.h>
+}
+
+/* Internal */
+#include "Definition.h"
+#include "PixWriter.h"
+
+VOID_NAMESPACE_OPEN
+
+class VOID_API FFmpegWriter : public PixWriter
+{
+public:
+    FFmpegWriter(int width, int height, int channels, const WriterType& type);
+
+    bool Setup(const std::string& path);
+    void AddBuffer(const void* buffer, std::size_t size, const BufferType& type);
+    bool Write();
+    void Cleanup();
+
+private:
+    AVFormatContext* m_FormatCtx;
+    AVCodecContext* m_CodecCtx;
+    SwsContext* m_SwsCtx;
+    unsigned int m_Frame;
+
+    std::string m_Path;
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _FFMPEG_PIX_WRITER_H

--- a/src/VoidCore/Writers/OIIOWriter.cpp
+++ b/src/VoidCore/Writers/OIIOWriter.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* STD */
+#include <cstring>
+
+/* OpenImageIO */
+#include <OpenImageIO/imageio.h>
+
+/* Internal */
+#include "OIIOWriter.h"
+#include "VoidCore/Logging.h"
+
+VOID_NAMESPACE_OPEN
+
+OIIOWriter::OIIOWriter(int width, int height, int channels, const WriterType& type)
+    : PixWriter(width, height, channels, type)
+    , m_OutPtr(nullptr)
+{
+}
+
+bool OIIOWriter::Setup(const std::string& path)
+{
+    m_OutPtr = OIIO::ImageOutput::create(path);
+    if (!m_OutPtr)
+    {
+        VOID_LOG_WARN("OIIOWriter::Unable to create out file at: {0}", path);
+        return false;
+    }
+
+    OIIO::ImageSpec spec(m_Width, m_Height, m_Channels, OIIO::TypeDesc::UINT8);
+    m_OutPtr->open(path, spec);
+
+    return true;
+}
+
+void OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+{
+    if (m_OutPtr)
+    {
+        switch (type)
+        {
+            case BufferType::Uint16:
+                m_OutPtr->write_image(OIIO::TypeDesc::UINT16, buffer);
+                break;
+            case BufferType::Float:
+                m_OutPtr->write_image(OIIO::TypeDesc::FLOAT, buffer);
+                break;
+            case BufferType::Uint8:
+            default:
+                m_OutPtr->write_image(OIIO::TypeDesc::UINT8, buffer);
+        }
+
+        VOID_LOG_INFO("Image written to file");
+    }
+}
+
+bool OIIOWriter::Write()
+{
+    return (bool)m_OutPtr;
+}
+
+void OIIOWriter::Cleanup()
+{
+    if (m_OutPtr)
+        m_OutPtr->close();
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/OIIOWriter.cpp
+++ b/src/VoidCore/Writers/OIIOWriter.cpp
@@ -34,7 +34,7 @@ bool OIIOWriter::Setup(const std::string& path)
     return true;
 }
 
-void OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
 {
     if (m_OutPtr)
     {
@@ -52,7 +52,10 @@ void OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const BufferTyp
         }
 
         VOID_LOG_INFO("Image written to file");
+        return true;
     }
+
+    return false;
 }
 
 bool OIIOWriter::Write()

--- a/src/VoidCore/Writers/OIIOWriter.h
+++ b/src/VoidCore/Writers/OIIOWriter.h
@@ -18,10 +18,10 @@ class VOID_API OIIOWriter : public PixWriter
 public:
     OIIOWriter(int width, int height, int channels, const WriterType& type);
 
-    bool Setup(const std::string& path);
-    void AddBuffer(const void* buffer, std::size_t size, const BufferType& type);
-    bool Write();
-    void Cleanup();
+    bool Setup(const std::string& path) override;
+    bool AddBuffer(const void* buffer, std::size_t size, const BufferType& type) override;
+    bool Write() override;
+    void Cleanup() override;
 
 private:
     OIIO::ImageOutput::unique_ptr m_OutPtr;

--- a/src/VoidCore/Writers/OIIOWriter.h
+++ b/src/VoidCore/Writers/OIIOWriter.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _OIIO_PIX_WRITER_H
+#define _OIIO_PIX_WRITER_H
+
+/* OpenImageIO */
+#include <OpenImageIO/imageio.h>
+
+/* Internal */
+#include "Definition.h"
+#include "PixWriter.h"
+
+VOID_NAMESPACE_OPEN
+
+class VOID_API OIIOWriter : public PixWriter
+{
+public:
+    OIIOWriter(int width, int height, int channels, const WriterType& type);
+
+    bool Setup(const std::string& path);
+    void AddBuffer(const void* buffer, std::size_t size, const BufferType& type);
+    bool Write();
+    void Cleanup();
+
+private:
+    OIIO::ImageOutput::unique_ptr m_OutPtr;
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _OIIO_PIX_WRITER_H

--- a/src/VoidCore/Writers/Registration.h
+++ b/src/VoidCore/Writers/Registration.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Internal */
+#include "Definition.h"
+#include "FormatForge.h"
+#include "OIIOWriter.h"
+#include "FFmpegWriter.h"
+
+VOID_NAMESPACE_OPEN
+
+namespace Internal {
+
+    bool RegisterOpenImageIOWriter()
+    {
+        WriterRegistry f;
+        f.name = "OIIO Writer";
+        f.extensions = { "png", "jpg" };
+        f.type = WriterType::Image;
+        f.writer = [](int width, int height, int channels, const WriterType& type) -> std::unique_ptr<OIIOWriter>
+                        {
+                            return std::make_unique<OIIOWriter>(width, height, channels, type);
+                        };
+
+        return Forge::Instance().Register(f);
+    }
+
+    bool RegisterFFmpegWriter()
+    {
+        WriterRegistry f;
+        f.name = "FFmpeg Writer";
+        f.extensions = { "mov", "mp4" };
+        f.type = WriterType::Movie;
+        f.writer = [](int width, int height, int channels, const WriterType& type) -> std::unique_ptr<FFmpegWriter>
+                        {
+                            return std::make_unique<FFmpegWriter>(width, height, channels, type);
+                        };
+
+        return Forge::Instance().Register(f);
+    }
+
+} // namespace Internal
+
+void RegisterWriters()
+{
+    Internal::RegisterOpenImageIOWriter();
+    Internal::RegisterFFmpegWriter();
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Media/MediaClip.h
+++ b/src/VoidObjects/Media/MediaClip.h
@@ -105,6 +105,7 @@ public:
     Renderer::SharedAnnotation Annotation(const v_frame_t frame) const;
     std::vector<int> AnnotatedFrames() const;
     const std::vector<Effect*>& Effects() const { return m_Effects; }
+    const std::unordered_map<v_frame_t, Renderer::SharedAnnotation>& Annotations() const { return m_Annotations; }
 
     QPixmap Thumbnail();
 

--- a/src/VoidRenderer/Core/RenderTypes.h
+++ b/src/VoidRenderer/Core/RenderTypes.h
@@ -17,6 +17,7 @@
 
 /* Internal */
 #include "Definition.h"
+#include "PixWriter.h"
 #include "VoidCore/Serialization.h"
 
 VOID_NAMESPACE_OPEN
@@ -232,6 +233,38 @@ enum class DrawType
     TEXT,
     /* Erase Strokes/Text */
     ERASER
+};
+
+template <typename Ty>
+struct BufferTypeTrait;
+
+template <>
+struct BufferTypeTrait<unsigned char>
+{
+    static constexpr BufferType value = BufferType::Uint8;
+};
+
+template <>
+struct BufferTypeTrait<unsigned int>
+{
+    static constexpr BufferType value = BufferType::Uint16;
+};
+
+template <>
+struct BufferTypeTrait<float>
+{
+    static constexpr BufferType value = BufferType::Float;
+};
+
+template <typename Ty>
+struct RenderData
+{
+    int width, height;
+    int channels;
+    std::vector<Ty> pixels;
+    static constexpr BufferType type = BufferTypeTrait<Ty>::value;
+
+    std::size_t Size() const { return static_cast<std::size_t>(width) * height * channels; }
 };
 
 } // namespace Renderer

--- a/src/VoidRenderer/VoidRenderer.cpp
+++ b/src/VoidRenderer/VoidRenderer.cpp
@@ -495,6 +495,24 @@ void VoidRenderer::Clear()
     update();
 }
 
+Renderer::RenderData<unsigned char> VoidRenderer::FrameBuffer()
+{
+    Renderer::RenderData<unsigned char> r;
+
+    // This is temporary, till we get to do this ourselves
+    // The main prob is that the glReadPixels are giving wrong values at the moment
+    // Need to see how qt does that correctly
+    QImage image = grabFramebuffer();
+    QImage rgbimage(image.convertToFormat(QImage::Format::Format_RGBA8888));
+
+    r.width = rgbimage.width();
+    r.height = rgbimage.height();
+    r.channels = 4;
+
+    r.pixels.assign(rgbimage.constBits(), rgbimage.constBits() + rgbimage.sizeInBytes());
+    return r;
+}
+
 void VoidRenderer::SetZoom(float zoom)
 {
     m_ZoomFactor = float(m_ImageA->Width()) * zoom / (width() * 100);

--- a/src/VoidRenderer/VoidRenderer.h
+++ b/src/VoidRenderer/VoidRenderer.h
@@ -52,6 +52,8 @@ public:
     /* Clears current Frame and rids of any textures that were loaded */
     void Clear();
 
+    Renderer::RenderData<unsigned char> FrameBuffer();
+
     /* Set zoom values */
     /**
      * @brief Sets the Zoom of the image based on the zoom percentage

--- a/src/VoidUi/Media/Browser.cpp
+++ b/src/VoidUi/Media/Browser.cpp
@@ -7,7 +7,7 @@
 VOID_NAMESPACE_OPEN
 
 const QString images = "Image Media (*.png *.jpg)";
-const QString movies = "Movie Media (*.mov)";
+const QString movies = "Movie Media (*.mov *.mp4)";
 
 MediaBrowser::MediaBrowser(QWidget* parent)
     : MediaFileDialog(parent)

--- a/src/VoidUi/Media/Browser.cpp
+++ b/src/VoidUi/Media/Browser.cpp
@@ -6,6 +6,9 @@
 
 VOID_NAMESPACE_OPEN
 
+const QString images = "Image Media (*.png *.jpg)";
+const QString movies = "Movie Media (*.mov)";
+
 MediaBrowser::MediaBrowser(QWidget* parent)
     : MediaFileDialog(parent)
 {
@@ -26,6 +29,32 @@ bool MediaBrowser::BrowseDirectory()
 {
     SetFileMode(MediaFileDialog::FileMode::Directory);
     return exec();
+}
+
+/// MediaExport Browser
+
+MediaExportBrowser::MediaExportBrowser(QWidget* parent)
+    : QFileDialog(parent)
+{
+    setOption(QFileDialog::DontUseNativeDialog);
+    setNameFilters({ images, movies });
+}
+
+bool MediaExportBrowser::Save()
+{
+    setAcceptMode(QFileDialog::AcceptSave);
+    setFileMode(QFileDialog::AnyFile);
+
+    return exec();
+}
+
+MediaExportDescriptor MediaExportBrowser::File() const
+{
+    QString filepath = selectedFiles().first();
+    QString filter = selectedNameFilter();
+
+    WriterType type = filter == images ? WriterType::Image : WriterType::Movie;
+    return { type, MEntry(filepath.toStdString()) };
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Media/Browser.h
+++ b/src/VoidUi/Media/Browser.h
@@ -11,8 +11,15 @@
 #include "Definition.h"
 #include "FileDialog.h"
 #include "VoidCore/Media/Filesystem.h"
+#include "VoidCore/Media/Renderer.h"
 
 VOID_NAMESPACE_OPEN
+
+struct MediaExportDescriptor
+{
+    WriterType type;
+    MEntry entry;
+};
 
 class MediaBrowser : public MediaFileDialog
 {
@@ -31,6 +38,21 @@ public:
 
     inline std::string SelectedDirectory() const { return SelectedPath().toStdString(); }
     std::string GetSelectedFile() const { return SelectedPath().toStdString(); }
+};
+
+class MediaExportBrowser : public QFileDialog
+{
+public:
+    MediaExportBrowser(QWidget* parent = nullptr);
+
+    /*
+     * Begin saving
+     * Calls exec() which allows user to select on an entry from filesystem
+     * will wait executing other instructions below and returns back a bool value telling if the browse
+     * was successful or not.
+     */
+    [[nodiscard]] bool Save();
+    MediaExportDescriptor File() const;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -556,7 +556,12 @@ void Player::RenderAnnotatedFrames()
                 {
                     m_Renderer->Render(data.image, data.annotation);
                     const Renderer::RenderData r = m_Renderer->FrameBuffer();
-                    ir.Render(frame, r.pixels.data(), r.Size(), r.type);
+                    if (!ir.Render(frame, r.pixels.data(), r.Size(), r.type))
+                    {
+                        ErrorMessageBox box("There was an error in exporting media.", "Error", this);
+                        box.exec();
+                        return;
+                    }
                 }
             }
 
@@ -579,7 +584,12 @@ void Player::RenderAnnotatedFrames()
                 {
                     m_Renderer->Render(data.image, data.annotation);
                     const Renderer::RenderData r = m_Renderer->FrameBuffer();
-                    mr.AddBuffer(r.pixels.data(), r.Size(), r.type);
+                    if (!mr.AddBuffer(r.pixels.data(), r.Size(), r.type))
+                    {
+                        ErrorMessageBox box("There was an error in exporting media.", "Error", this);
+                        box.exec();
+                        return;
+                    }
                 }
             }
 
@@ -607,7 +617,7 @@ void Player::SetBlendMode(const int mode)
     if (m_ComparisonMode == Renderer::ComparisonMode::NONE)
         return;
 
-    m_BlendMode == Renderer::BlendMode::ONION_SKIN && !ActiveGrid() 
+    m_BlendMode == Renderer::BlendMode::ONION_SKIN && !ActiveGrid()
         ? m_ControlBar->SetViewerControl(ViewerControl::OnionSkinControl)
         : m_ControlBar->SetViewerControl(ViewerControl::None);
 

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -8,9 +8,12 @@
 /* Internal */
 #include "Player.h"
 #include "VoidCore/Timekeeper.h"
+#include "VoidCore/Media/Renderer.h"
 #include "VoidUi/Descriptors.h"
+#include "VoidUi/Media/Browser.h"
 #include "VoidUi/Media/MediaBridge.h"
 #include "VoidUi/Engine/Globals.h"
+#include "VoidUi/QExtensions/MessageBox.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -510,6 +513,87 @@ void Player::SetComparisonMode(int mode)
     }
 
     Refresh();
+}
+
+void Player::RenderCurrentFrame()
+{
+    MediaExportBrowser browser;
+    if (browser.Save())
+    {
+        const MediaExportDescriptor descriptor = browser.File();
+        const Renderer::RenderData r = m_Renderer->FrameBuffer();
+
+        Renderer::ImageRenderer ir(descriptor.entry, r.width, r.height, r.channels);
+        ir.Render(r.pixels.data(), r.Size(), r.type);
+
+        InfoMessageBox box("Frame exported.", "Success", this);
+        box.exec();
+    }
+}
+
+void Player::RenderAnnotatedFrames()
+{
+    const auto& annotations = m_ActiveViewBuffer->Annotations();
+    if (annotations.empty())
+    {
+        ErrorMessageBox box("No annotated frames found for current media.", "Error", this);
+        box.exec();
+        return;
+    }
+
+    MediaExportBrowser browser;
+    if (browser.Save())
+    {
+        const MediaExportDescriptor descriptor = browser.File();
+        if (descriptor.type == WriterType::Image && descriptor.entry.Templated())
+        {
+            const Renderer::RenderData r = m_Renderer->FrameBuffer();
+            Renderer::ImageRenderer ir(descriptor.entry, r.width, r.height, r.channels);
+
+            for (auto& [frame, _] : annotations)
+            {
+                if (auto data = m_ActiveViewBuffer->MData(frame))
+                {
+                    m_Renderer->Render(data.image, data.annotation);
+                    const Renderer::RenderData r = m_Renderer->FrameBuffer();
+                    ir.Render(frame, r.pixels.data(), r.Size(), r.type);
+                }
+            }
+
+            // Render back the current frame
+            // This is obviously temporary till we have an offscreen renderer available for using offscreen framebuffer
+            Refresh();
+
+            InfoMessageBox box("Annotated frames have been exported.", "Success", this);
+            box.exec();
+            return;
+        }
+        else if (descriptor.type == WriterType::Movie)
+        {
+            const Renderer::RenderData r = m_Renderer->FrameBuffer();
+            Renderer::MovieRenderer mr(descriptor.entry, r.width, r.height, r.channels);
+
+            for (auto& [frame, _] : annotations)
+            {
+                if (auto data = m_ActiveViewBuffer->MData(frame))
+                {
+                    m_Renderer->Render(data.image, data.annotation);
+                    const Renderer::RenderData r = m_Renderer->FrameBuffer();
+                    mr.AddBuffer(r.pixels.data(), r.Size(), r.type);
+                }
+            }
+
+            mr.Render();
+
+            // Render back the current frame
+            // This is obviously temporary till we have an offscreen renderer available for using offscreen framebuffer
+            Refresh();
+
+            InfoMessageBox box("Annotated frames have been exported.", "Success", this);
+            box.exec();
+            return;
+        }
+    }
 }
 
 void Player::ToggleChannels(int channel)

--- a/src/VoidUi/Player/Player.h
+++ b/src/VoidUi/Player/Player.h
@@ -45,6 +45,9 @@ public:
     int GridRows() const { return m_ComparisonMode == Renderer::ComparisonMode::GRID ? m_Renderer->Rows() : 1; }
     int GridColumns() const { return m_ComparisonMode == Renderer::ComparisonMode::GRID ? m_Renderer->Columns() : 1; }
 
+    void RenderCurrentFrame();
+    void RenderAnnotatedFrames();
+
     void ToggleChannels(int channel);
     void SetBlendMode(int mode);
     void SwitchBlendMode(int delta) { m_ControlBar->SwitchBlendMode(delta); }

--- a/src/VoidUi/Player/PlayerBridge.cpp
+++ b/src/VoidUi/Player/PlayerBridge.cpp
@@ -131,6 +131,15 @@ void PlayerBridge::InitMenu(MenuSystem* menuSystem)
         m_Player->SwitchBlendMode(-1);
     });
     /* }}} */
+
+    /// Render Menu
+    QMenu* renderMenu = menuSystem->AddMenu("Render");
+
+    QAction* renderCurrentFrameAction = menuSystem->AddAction(renderMenu, "Export Current Frame...");
+    QAction* renderAnnotatedFramesAction = menuSystem->AddAction(renderMenu, "Export Annotated Frames...");
+
+    connect(renderCurrentFrameAction, &QAction::triggered, this, &PlayerBridge::RenderCurrentFrame);
+    connect(renderAnnotatedFramesAction, &QAction::triggered, this, &PlayerBridge::RenderAnnotatedFrames);
 }
 
 void PlayerBridge::AddToQueue(const SharedMediaClip& media, bool refresh)

--- a/src/VoidUi/Player/PlayerBridge.h
+++ b/src/VoidUi/Player/PlayerBridge.h
@@ -89,6 +89,9 @@ public:
     inline void SetFullscreen() { m_Player->SetRendererFullscreen(); }
     inline void ExitFullscreen() { m_Player->ExitFullscreenRenderer(); }
 
+    inline void RenderCurrentFrame() { m_Player->RenderCurrentFrame(); }
+    inline void RenderAnnotatedFrames() { m_Player->RenderAnnotatedFrames(); }
+
 private: /* Members */
     Player* m_Player;
     Playlist* m_Playlist;

--- a/src/VoidUi/Player/ViewerBuffer.h
+++ b/src/VoidUi/Player/ViewerBuffer.h
@@ -256,6 +256,7 @@ public:
      * Removes Annotation from the Active Media item
      */
     void RemoveAnnotation(const v_frame_t);
+    const std::unordered_map<v_frame_t, Renderer::SharedAnnotation>& Annotations() const { return m_Clip->Annotations(); }
 
 signals:
     void updated();

--- a/src/VoidUi/Project/Browser.h
+++ b/src/VoidUi/Project/Browser.h
@@ -24,7 +24,7 @@ class VoidProjectBrowser : public QFileDialog
 {
 public:
     VoidProjectBrowser(QWidget* parent = nullptr);
-    virtual ~VoidProjectBrowser();
+    ~VoidProjectBrowser();
 
     /*
      * Begin browsing

--- a/src/VoidUi/QExtensions/MessageBox.cpp
+++ b/src/VoidUi/QExtensions/MessageBox.cpp
@@ -28,4 +28,20 @@ QMessageBox::StandardButton SaveMessageBox::Prompt()
     return static_cast<QMessageBox::StandardButton>(exec());
 }
 
+/// InfoMessageBox
+
+InfoMessageBox::InfoMessageBox(const QString& text, const QString& title, QWidget* parent)
+    : QMessageBox(QMessageBox::Information, title, text, QMessageBox::Ok)
+{
+    button(QMessageBox::Ok)->setText("&Ok");
+}
+
+/// ErrorMessageBox
+
+ErrorMessageBox::ErrorMessageBox(const QString& text, const QString& title, QWidget* parent)
+    : QMessageBox(QMessageBox::Critical, title, text, QMessageBox::Ok)
+{
+    button(QMessageBox::Ok)->setText("&Ok");
+}
+
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/MessageBox.h
+++ b/src/VoidUi/QExtensions/MessageBox.h
@@ -26,6 +26,18 @@ public:
     QMessageBox::StandardButton Prompt();
 };
 
+class InfoMessageBox : public QMessageBox
+{
+public:
+    InfoMessageBox(const QString& text, const QString& title = "Info", QWidget* parent = nullptr);
+};
+
+class ErrorMessageBox : public QMessageBox
+{
+public:
+    ErrorMessageBox(const QString& text, const QString& title = "Error", QWidget* parent = nullptr);
+};
+
 VOID_NAMESPACE_CLOSE
 
 #endif // _VOID_Q_EXT_MESSAGE_BOX_H

--- a/src/include/FormatForge.h
+++ b/src/include/FormatForge.h
@@ -13,6 +13,7 @@
 /* Internal */
 #include "Definition.h"
 #include "PixReader.h"
+#include "PixWriter.h"
 #include "Operator.h"
 
 VOID_NAMESPACE_OPEN
@@ -21,6 +22,7 @@ VOID_NAMESPACE_OPEN
 using PixForge = std::function<std::unique_ptr<VoidPixReader>(const std::string&, v_frame_t)>;
 using MPixForge = std::function<std::unique_ptr<VoidMPixReader>(const std::string&, v_frame_t)>;
 using IOpForge = std::function<std::unique_ptr<ImageOp>()>;
+using PixWriterForge = std::function<std::unique_ptr<PixWriter>(int, int, int, const WriterType&)>;
 
 /**
  * Registry describing the Plugin
@@ -39,6 +41,14 @@ struct FormatRegistry
 
     /* The Image or Movie Reader to be registered */
     Ty reader;
+};
+
+struct WriterRegistry
+{
+    WriterType type;
+    PixWriterForge writer;
+    std::string name;
+    std::vector<std::string> extensions;
 };
 
 struct IOpRegistry
@@ -74,6 +84,7 @@ public:
     bool Register(const FormatRegistry<PixForge>& registry);
     bool Register(const FormatRegistry<MPixForge>& registry);
     bool Register(const IOpRegistry& registry);
+    bool Register(const WriterRegistry& registry);
 
     /* Unregister all of the loaded plugins */
     void UnregisterPlugins();
@@ -85,6 +96,8 @@ public:
     std::unique_ptr<VoidPixReader> GetImageReader(const std::string& extension, const std::string& path, v_frame_t framenumber = 0) const;
     std::unique_ptr<VoidMPixReader> GetMovieReader(const std::string& extension, const std::string& path, v_frame_t framenumber = 0) const;
     std::unique_ptr<ImageOp> GetImageOp(const std::string& name) const;
+    std::unique_ptr<PixWriter> GetImageWriter(const std::string& extension, int width, int height, int channels, const WriterType& type) const;
+    std::unique_ptr<PixWriter> GetMovieWriter(const std::string& extension, int width, int height, int channels, const WriterType& type) const;
 
     inline bool IsMovie(const std::string& extension) const { return m_MovieForger.find(extension) != m_MovieForger.end(); }
     inline bool IsImage(const std::string& extension) const { return m_ImageForger.find(extension) != m_ImageForger.end(); }
@@ -95,11 +108,14 @@ private: /* Members */
     std::unordered_map<std::string, PixForge> m_ImageForger;
     std::unordered_map<std::string, MPixForge> m_MovieForger;
     std::unordered_map<std::string, IOpForge> m_IOpForger;
+    std::unordered_map<std::string, PixWriterForge> m_ImageWriters;
+    std::unordered_map<std::string, PixWriterForge> m_MovieWriters;
 
 private: /* Methods */
     void RegisterImageReader(const std::string& extension, PixForge forger);
     void RegisterMovieReader(const std::string& extension, MPixForge forger);
-
+    void RegisterImageWriter(const std::string& extension, PixWriterForge forger);
+    void RegisterMovieWriter(const std::string& extension, PixWriterForge forger);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/include/PixWriter.h
+++ b/src/include/PixWriter.h
@@ -34,7 +34,7 @@ public:
     virtual ~PixWriter() = default;
 
     virtual bool Setup(const std::string& path) = 0;
-    virtual void AddBuffer(const void* buffer, std::size_t size, const BufferType& type) = 0;
+    virtual bool AddBuffer(const void* buffer, std::size_t size, const BufferType& type) = 0;
     virtual bool Write() = 0;
     virtual void Cleanup() = 0;
 

--- a/src/include/PixWriter.h
+++ b/src/include/PixWriter.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _PIX_WRITER_H
+#define _PIX_WRITER_H
+
+/* STD */
+#include <string>
+#include <vector>
+
+/* Internal */
+#include "Definition.h"
+
+VOID_NAMESPACE_OPEN
+
+enum class WriterType
+{
+    Image,
+    Movie
+};
+
+enum class BufferType
+{
+    Uint8,
+    Uint16,
+    Float
+};
+
+class PixWriter
+{
+public:
+    // PixWriter(int width, int height, int channels, const WriterType& type = WriterType::Image) : PixWriter(width, height, channels, type) {}
+    PixWriter(int width, int height, int channels, const WriterType& type) : m_Width(width), m_Height(height), m_Channels(channels), m_Type(type) {}
+    virtual ~PixWriter() = default;
+
+    virtual bool Setup(const std::string& path) = 0;
+    virtual void AddBuffer(const void* buffer, std::size_t size, const BufferType& type) = 0;
+    virtual bool Write() = 0;
+    virtual void Cleanup() = 0;
+
+protected:
+    WriterType m_Type;
+    int m_Width, m_Height;
+    int m_Channels;
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _PIX_WRITER_H


### PR DESCRIPTION
## Feat: Add Image Export system
* Added Base Writer System which allows implementing plugins to allow writing to various extensions.
* Added OIIO writer and FFmpeg Writer
* Added ImageRenderer and MovieRenderer classes to export media frames.
* Implemented current frame and annotated frames export as image/movie through Menu option.

## Details
This is the start of export system for VOID.
**The next set of things to do**
1. Export Queue Core + UI which can run the tasks parallely, (could be used later on for multiple things)
2. Offscreen Renderer
3. Fix issue with glReadPixels, (possibly understand how qt is getting away with the same code)
4. Rescale the image to match required resolutions, right now the QImage is quite low res and we don't want that.
5. FFmpeg exporter is fine, but the codecs and other options like framerate need to be changed/specified through a dedicated Movie config/options UI and the same needs to be supported by the core pix writer.
6. Custom metadata on the exported images?

Upcoming work/PRs on the next set of exporter features, till then this is ready for testing 🙂 
