### PR TITLE
[VOID] Export Options for Media Transcode

### DIFF
--- a/src/VoidApplication/Engine/Engine.cpp
+++ b/src/VoidApplication/Engine/Engine.cpp
@@ -50,8 +50,12 @@ int VoidEngine::Exec(int argc, char** argv)
         #endif
     }
 
+    #if _QT6
+    #else
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+    #endif
+
     QApplication app(argc, argv);
 
     Setup(app);

--- a/src/VoidApplication/Engine/Engine.h
+++ b/src/VoidApplication/Engine/Engine.h
@@ -8,7 +8,7 @@
 #include <QApplication>
 
 /* Internal */
-#include "Definition.h"
+#include "QDefinition.h"
 #include "VoidUi/BaseWindow/MenuSystem.h"
 #include "VoidUi/BaseWindow/PlayerWindow.h"
 #include "VoidApplication/Core/ArgumentParser.h"

--- a/src/VoidCore/FormatForge.cpp
+++ b/src/VoidCore/FormatForge.cpp
@@ -140,16 +140,16 @@ std::unique_ptr<ImageOp> Forge::GetImageOp(const std::string& name) const
     return it == m_IOpForger.end() ? nullptr : it->second();
 }
 
-std::unique_ptr<PixWriter> Forge::GetImageWriter(const std::string& extension, int width, int height, int channels, const WriterType& type) const
+std::unique_ptr<PixWriter> Forge::GetImageWriter(const std::string& extension, const EncodeSpec& spec) const
 {
     auto it = m_ImageWriters.find(extension);
-    return it == m_ImageWriters.end() ? nullptr : it->second(width, height, channels, type);
+    return it == m_ImageWriters.end() ? nullptr : it->second(spec);
 }
 
-std::unique_ptr<PixWriter> Forge::GetMovieWriter(const std::string& extension, int width, int height, int channels, const WriterType& type) const
+std::unique_ptr<PixWriter> Forge::GetMovieWriter(const std::string& extension, const EncodeSpec& spec) const
 {
     auto it = m_MovieWriters.find(extension);
-    return it == m_MovieWriters.end() ? nullptr : it->second(width, height, channels, type);
+    return it == m_MovieWriters.end() ? nullptr : it->second(spec);
 }
 
 bool Forge::IsRegistered(const std::string& extension) const

--- a/src/VoidCore/Media/Filesystem.h
+++ b/src/VoidCore/Media/Filesystem.h
@@ -99,6 +99,7 @@ public:
      * Validates the fullpath to see if this and the other entry are pointing to the exact same path
      */
     inline bool operator==(const MEntry& other) const { return m_Path == other.m_Path; }
+    explicit inline operator bool() const noexcept { return !m_Path.empty(); }
 
 private: /* Members */
     std::string m_Path;

--- a/src/VoidCore/Media/Renderer.cpp
+++ b/src/VoidCore/Media/Renderer.cpp
@@ -14,8 +14,8 @@ VOID_NAMESPACE_OPEN
 
 namespace Renderer {
 
-ImageRenderer::ImageRenderer(const MEntry& entry, int width, int height, int channels)
-    : m_Writer(std::move(Forge::Instance().GetImageWriter(entry.Extension(), width, height, channels, WriterType::Image)))
+ImageRenderer::ImageRenderer(const MEntry& entry, const EncodeSpec& spec)
+    : m_Writer(std::move(Forge::Instance().GetImageWriter(entry.Extension(), spec)))
     , m_MediaEntry(entry)
 {
 }
@@ -26,23 +26,23 @@ ImageRenderer::~ImageRenderer()
     //     m_Writer->Cleanup();
 }
 
-bool ImageRenderer::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+bool ImageRenderer::AddBuffer(const void* buffer, std::size_t size, const InputSpec& spec)
 {
     if (m_Writer)
     {
         if (m_Writer->Setup(m_MediaEntry.Fullpath()))
-            return m_Writer->AddBuffer(buffer, size, type);
+            return m_Writer->AddBuffer(buffer, size, spec);
     }
 
     return false;
 }
 
-bool ImageRenderer::AddBuffer(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type)
+bool ImageRenderer::AddBuffer(v_frame_t frame, const void* buffer, std::size_t size, const InputSpec& spec)
 {
     if (m_Writer)
     {
         if (m_Writer->Setup(m_MediaEntry.ResolvedPath(frame)))
-            return m_Writer->AddBuffer(buffer, size, type);
+            return m_Writer->AddBuffer(buffer, size, spec);
     }
 
     return false;
@@ -62,14 +62,14 @@ bool ImageRenderer::Render()
     return false;
 }
 
-bool ImageRenderer::Render(const void* buffer, std::size_t size, const BufferType& type)
+bool ImageRenderer::Render(const void* buffer, std::size_t size, const InputSpec& spec)
 {
     Tools::VoidProfiler<std::chrono::duration<double>> p("ImageRenderer::Render");
     if (m_Writer)
     {
         if (m_Writer->Setup(m_MediaEntry.Fullpath()))
         {
-            bool ret = m_Writer->AddBuffer(buffer, size, type);
+            bool ret = m_Writer->AddBuffer(buffer, size, spec);
             ret = m_Writer->Write();
             m_Writer->Cleanup();
 
@@ -80,14 +80,14 @@ bool ImageRenderer::Render(const void* buffer, std::size_t size, const BufferTyp
     return false;
 }
 
-bool ImageRenderer::Render(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type)
+bool ImageRenderer::Render(v_frame_t frame, const void* buffer, std::size_t size, const InputSpec& spec)
 {
     Tools::VoidProfiler<std::chrono::duration<double>> p("ImageRenderer::Render");
     if (m_Writer)
     {
         if (m_Writer->Setup(m_MediaEntry.ResolvedPath(frame)))
         {
-            bool ret = m_Writer->AddBuffer(buffer, size, type);
+            bool ret = m_Writer->AddBuffer(buffer, size, spec);
             ret = m_Writer->Write();
             m_Writer->Cleanup();
 
@@ -101,8 +101,8 @@ bool ImageRenderer::Render(v_frame_t frame, const void* buffer, std::size_t size
 
 /// MovieRenderer
 
-MovieRenderer::MovieRenderer(const MEntry& entry, int width, int height, int channels)
-    : m_Writer(std::move(Forge::Instance().GetMovieWriter(entry.Extension(), width, height, channels, WriterType::Movie)))
+MovieRenderer::MovieRenderer(const MEntry& entry, const EncodeSpec& spec)
+    : m_Writer(std::move(Forge::Instance().GetMovieWriter(entry.Extension(), spec)))
     , m_MediaEntry(entry)
 {
     if (m_Writer)
@@ -115,10 +115,10 @@ MovieRenderer::~MovieRenderer()
         m_Writer->Cleanup();
 }
 
-bool MovieRenderer::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+bool MovieRenderer::AddBuffer(const void* buffer, std::size_t size, const InputSpec& spec)
 {
     if (m_Writer)
-        return m_Writer->AddBuffer(buffer, size, type);
+        return m_Writer->AddBuffer(buffer, size, spec);
 
     return false;
 }

--- a/src/VoidCore/Media/Renderer.h
+++ b/src/VoidCore/Media/Renderer.h
@@ -16,17 +16,17 @@ namespace Renderer {
 class VOID_API ImageRenderer
 {
 public:
-    ImageRenderer(const MEntry& entry, int width, int height, int channels);
+    ImageRenderer(const MEntry& entry, const EncodeSpec& spec);
     ~ImageRenderer();
 
     bool Valid() const { return (bool)m_Writer; }
 
-    bool AddBuffer(const void* buf, std::size_t size, const BufferType& type);
-    bool AddBuffer(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type);
+    bool AddBuffer(const void* buf, std::size_t size, const InputSpec& spec);
+    bool AddBuffer(v_frame_t frame, const void* buffer, std::size_t size, const InputSpec& spec);
 
     bool Render();
-    bool Render(const void* buffer, std::size_t size, const BufferType& type);
-    bool Render(v_frame_t frame, const void* buffer, std::size_t size, const BufferType& type);
+    bool Render(const void* buffer, std::size_t size, const InputSpec& spec);
+    bool Render(v_frame_t frame, const void* buffer, std::size_t size, const InputSpec& spec);
 
 private:
     std::unique_ptr<PixWriter> m_Writer;
@@ -36,12 +36,12 @@ private:
 class VOID_API MovieRenderer
 {
 public:
-    MovieRenderer(const MEntry& entry, int width, int height, int channels);
+    MovieRenderer(const MEntry& entry, const EncodeSpec& spec);
     ~MovieRenderer();
 
     bool Valid() const { return (bool)m_Writer; }
 
-    bool AddBuffer(const void* buf, std::size_t size, const BufferType& type);
+    bool AddBuffer(const void* buf, std::size_t size, const InputSpec& spec);
     bool Render();
 
 private:

--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -334,7 +334,6 @@ void FFmpegPixReader::Read()
 const std::map<std::string, std::string> FFmpegPixReader::Metadata() const
 {
     std::map<std::string, std::string> m;
-
     AVFormatContext* formatContext = nullptr;
 
     if (avformat_open_input(&formatContext, m_Path.c_str(), nullptr, nullptr) >= 0)
@@ -360,9 +359,7 @@ const std::map<std::string, std::string> FFmpegPixReader::Metadata() const
         AVDictionaryEntry* tag = nullptr;
         /* Match the starting component of the key to get the find the tag --> None will match every */
         while((tag = av_dict_get(formatContext->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
-        {
             m[tag->key] = tag->value;
-        }
 
         vidStream = formatContext->streams[streamId];
 
@@ -372,6 +369,13 @@ const std::map<std::string, std::string> FFmpegPixReader::Metadata() const
         m["end_frame"] = std::to_string(endframe);
         m["duration"] = std::to_string(endframe - m_Startframe + 1);
         m["framerate"] = std::to_string(framerate);
+
+        const AVCodecDescriptor* desc = avcodec_descriptor_get(vidStream->codecpar->codec_id);
+        m["codec"] = desc->name;
+        m["codec_long_name"] = desc->long_name ? desc->long_name : "N/A";
+
+        const AVCodec* codec = avcodec_find_decoder(vidStream->codecpar->codec_id);
+        m["decoder"] = codec->name;
 
         /* Deallocate internals */
         avformat_close_input(&formatContext);

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -25,12 +25,6 @@ bool FFmpegWriter::Setup(const std::string& path)
         m_Path = path;
 
         avformat_alloc_output_context2(&m_FormatCtx, nullptr, nullptr, path.c_str());
-
-        VOID_LOG_INFO("Media Rate: {0}", m_Spec.rate);
-
-        // H.264 encode
-        // TODO: Enable multi format selection for Movies
-        // How to best implement that?
         const AVCodec* codec = avcodec_find_encoder(Codec());
         m_CodecCtx = avcodec_alloc_context3(codec);
 
@@ -40,9 +34,9 @@ bool FFmpegWriter::Setup(const std::string& path)
         m_CodecCtx->height = m_Spec.outheight;
         m_CodecCtx->time_base = av_make_q(1, m_Spec.rate);
         m_CodecCtx->framerate = av_make_q(m_Spec.rate, 1);
-        m_CodecCtx->pix_fmt = PixelFormat();
-        // m_CodecCtx->bit_rate = 145000000; // 20000000; //145000000;
-        m_CodecCtx->profile = 3;
+
+        // Configure codec context params based on user specified out codec type
+        ContextSetup();
 
         int ret = avcodec_open2(m_CodecCtx, codec, nullptr);
         if (ret < 0)
@@ -67,20 +61,6 @@ bool FFmpegWriter::Setup(const std::string& path)
             Cleanup();
             return false;
         }
-
-        // m_SwsCtx = sws_getContext(
-        //     m_Spec.width,
-        //     m_Spec.height,
-        //     m_Spec.channels == 3 ? AV_PIX_FMT_RGB24 : AV_PIX_FMT_RGBA,
-        //     m_Spec.outwidth,
-        //     m_Spec.outheight,
-        //     PixelFormat(),
-        //     SWS_BILINEAR,
-        //     nullptr,
-        //     nullptr,
-        //     nullptr
-        // );
-
         return true;
     }
 
@@ -132,17 +112,14 @@ bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const InputSp
     {
         char errbuf[256];
         av_strerror(ret, errbuf, sizeof(errbuf));
-
         VOID_LOG_INFO("Unable to send frame: {0}, {1}, {2}", errbuf, ret, ret == AVERROR(EINVAL));
         return false;
     }
 
     AVPacket* packet = av_packet_alloc();
-
-    VOID_LOG_INFO("Frame->pts: {0}, Pkt->dts: {1}, Pkt->dts: {2}, Pkt->duration: {3}", frame->pts, packet->pts, packet->dts, packet->duration);
-
-    if (avcodec_receive_packet(m_CodecCtx, packet) == 0)
+    while (avcodec_receive_packet(m_CodecCtx, packet) == 0)
     {
+        av_packet_rescale_ts(packet, m_CodecCtx->time_base, m_Stream->time_base);
         packet->stream_index = m_Stream->index;
 
         av_interleaved_write_frame(m_FormatCtx, packet);
@@ -151,9 +128,7 @@ bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const InputSp
 
     av_packet_free(&packet);
     av_frame_free(&frame);
-
-    // This ensures that the framerate of the encoded container is the expected
-    m_Pts += av_rescale_q(1, m_CodecCtx->time_base, m_Stream->time_base);
+    m_Pts++;
 
     return true;
 }
@@ -163,8 +138,23 @@ bool FFmpegWriter::Write()
     if (!m_FormatCtx)
         return false;
 
+    avcodec_send_frame(m_CodecCtx, nullptr);
+
+    AVPacket* packet = av_packet_alloc();
+
+    while (avcodec_receive_packet(m_CodecCtx, packet) == 0)
+    {
+        av_packet_rescale_ts(packet, m_CodecCtx->time_base, m_Stream->time_base);
+
+        av_interleaved_write_frame(m_FormatCtx, packet);
+        av_packet_unref(packet);
+    }
+
+    av_packet_free(&packet);
+
     av_write_trailer(m_FormatCtx);
     avio_close(m_FormatCtx->pb);
+
 
     return true;
 }
@@ -207,8 +197,46 @@ AVPixelFormat FFmpegWriter::PixelFormat()
     {
         case MovieCodec::DNXHD: return AV_PIX_FMT_YUV422P;
         case MovieCodec::PRORES: return AV_PIX_FMT_YUV422P10LE;
+        case MovieCodec::MJPEG: return AV_PIX_FMT_YUVJ422P;
+        case MovieCodec::MPEG4:
         case MovieCodec::H264:
         default: return AV_PIX_FMT_YUV420P;
+    }
+}
+
+void FFmpegWriter::ContextSetup()
+{
+    switch (m_Spec.codec)
+    {
+        case MovieCodec::PRORES:
+            m_CodecCtx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
+
+            av_opt_set(m_CodecCtx->priv_data, "profile", "hq", 0);
+            break;
+
+        case MovieCodec::DNXHD:
+            m_CodecCtx->pix_fmt = AV_PIX_FMT_YUV422P;
+            m_CodecCtx->bit_rate = 145000000;
+            break;
+
+        case MovieCodec::MJPEG:
+            m_CodecCtx->pix_fmt = AV_PIX_FMT_YUVJ422P;
+            m_CodecCtx->bit_rate = 50000000;
+            break;
+
+        case MovieCodec::MPEG4:
+            m_CodecCtx->pix_fmt = AV_PIX_FMT_YUV420P;
+            m_CodecCtx->bit_rate = 10000000;
+            break;
+
+        case MovieCodec::H264:
+        default:
+            m_CodecCtx->pix_fmt = AV_PIX_FMT_YUV420P;
+            // m_CodecCtx->gop_size = m_Spec.rate * 2;
+            // m_CodecCtx->max_b_frames = 2;
+            
+            // av_opt_set(m_CodecCtx->priv_data, "crf", "18", 0);
+            break;
     }
 }
 

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -7,8 +7,8 @@
 
 VOID_NAMESPACE_OPEN
 
-FFmpegWriter::FFmpegWriter(int width, int height, int channels, const WriterType& type)
-    : PixWriter(width, height, channels, type)
+FFmpegWriter::FFmpegWriter(const EncodeSpec& spec)
+    : PixWriter(spec)
     , m_FormatCtx(nullptr)
     , m_CodecCtx(nullptr)
     , m_SwsCtx(nullptr)
@@ -26,19 +26,23 @@ bool FFmpegWriter::Setup(const std::string& path)
 
         avformat_alloc_output_context2(&m_FormatCtx, nullptr, nullptr, path.c_str());
 
+        VOID_LOG_INFO("Media Rate: {0}", m_Spec.rate);
+
         // H.264 encode
         // TODO: Enable multi format selection for Movies
         // How to best implement that?
-        const AVCodec* codec = avcodec_find_encoder(AV_CODEC_ID_H264);
+        const AVCodec* codec = avcodec_find_encoder(Codec());
         m_CodecCtx = avcodec_alloc_context3(codec);
 
-        m_CodecCtx->codec_id = AV_CODEC_ID_H264;
+        m_CodecCtx->codec_id = Codec();
         m_CodecCtx->codec_type = AVMEDIA_TYPE_VIDEO;
-        m_CodecCtx->width = m_Width;
-        m_CodecCtx->height = m_Height;
-        m_CodecCtx->time_base = av_make_q(1, 30);
-        m_CodecCtx->framerate = av_make_q(30, 1);
-        m_CodecCtx->pix_fmt = AV_PIX_FMT_YUV420P;
+        m_CodecCtx->width = m_Spec.outwidth;
+        m_CodecCtx->height = m_Spec.outheight;
+        m_CodecCtx->time_base = av_make_q(1, m_Spec.rate);
+        m_CodecCtx->framerate = av_make_q(m_Spec.rate, 1);
+        m_CodecCtx->pix_fmt = PixelFormat();
+        // m_CodecCtx->bit_rate = 145000000; // 20000000; //145000000;
+        m_CodecCtx->profile = 3;
 
         int ret = avcodec_open2(m_CodecCtx, codec, nullptr);
         if (ret < 0)
@@ -53,7 +57,7 @@ bool FFmpegWriter::Setup(const std::string& path)
         // This will change when we call avformat_write_header to something which ffmpeg finds appropriate
         // to ensure this the framerate of the final written container, ensure the the AVFrame* pts is
         // always incremented by av_rescale_q(1, codec_context->time_base, stream->time_base)
-        m_Stream->time_base = av_make_q(1, 30);
+        m_Stream->time_base = av_make_q(1, m_Spec.rate);
 
         // open
         avio_open(&m_FormatCtx->pb, path.c_str(), AVIO_FLAG_WRITE);
@@ -64,17 +68,18 @@ bool FFmpegWriter::Setup(const std::string& path)
             return false;
         }
 
-        m_SwsCtx = sws_getContext(
-            m_Width,
-            m_Height,
-            m_Channels == 3 ? AV_PIX_FMT_RGB24 : AV_PIX_FMT_RGBA,
-            m_Width,
-            m_Height,
-            AV_PIX_FMT_YUV420P,
-            SWS_BILINEAR,
-            nullptr,
-            nullptr,
-            nullptr);
+        // m_SwsCtx = sws_getContext(
+        //     m_Spec.width,
+        //     m_Spec.height,
+        //     m_Spec.channels == 3 ? AV_PIX_FMT_RGB24 : AV_PIX_FMT_RGBA,
+        //     m_Spec.outwidth,
+        //     m_Spec.outheight,
+        //     PixelFormat(),
+        //     SWS_BILINEAR,
+        //     nullptr,
+        //     nullptr,
+        //     nullptr
+        // );
 
         return true;
     }
@@ -82,10 +87,26 @@ bool FFmpegWriter::Setup(const std::string& path)
     return false;
 }
 
-bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec& spec)
 {
     if (!m_FormatCtx)
         return false;
+
+    if (!m_SwsCtx)
+    {
+        m_SwsCtx = sws_getContext(
+            spec.width,
+            spec.height,
+            spec.channels == 3 ? AV_PIX_FMT_RGB24 : AV_PIX_FMT_RGBA,
+            m_Spec.outwidth,
+            m_Spec.outheight,
+            PixelFormat(),
+            SWS_BILINEAR,
+            nullptr,
+            nullptr,
+            nullptr
+        );
+    }
 
     AVFrame* frame = av_frame_alloc();
     frame->format = m_CodecCtx->pix_fmt;
@@ -100,9 +121,9 @@ bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferT
         return false;
 
     const uint8_t* srcSlice[1] = { static_cast<const uint8_t*>(buffer) };
-    int srcStride[1] = { m_Channels * m_Width };
+    int srcStride[1] = { m_Spec.channels * spec.width };
 
-    sws_scale(m_SwsCtx, srcSlice, srcStride, 0, m_Height, frame->data, frame->linesize);
+    sws_scale(m_SwsCtx, srcSlice, srcStride, 0, spec.height, frame->data, frame->linesize);
     frame->pts = m_Pts;
 
     // Encode
@@ -117,6 +138,9 @@ bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const BufferT
     }
 
     AVPacket* packet = av_packet_alloc();
+
+    VOID_LOG_INFO("Frame->pts: {0}, Pkt->dts: {1}, Pkt->dts: {2}, Pkt->duration: {3}", frame->pts, packet->pts, packet->dts, packet->duration);
+
     if (avcodec_receive_packet(m_CodecCtx, packet) == 0)
     {
         packet->stream_index = m_Stream->index;
@@ -162,6 +186,30 @@ void FFmpegWriter::Cleanup()
     }
 
     m_Pts = 0;
+}
+
+AVCodecID FFmpegWriter::Codec()
+{
+    switch (m_Spec.codec)
+    {
+        case MovieCodec::DNXHD: return AV_CODEC_ID_DNXHD;
+        case MovieCodec::MJPEG: return AV_CODEC_ID_MJPEG;
+        case MovieCodec::MPEG4: return AV_CODEC_ID_MPEG4;
+        case MovieCodec::PRORES: return AV_CODEC_ID_PRORES;
+        case MovieCodec::H264:
+        default: return AV_CODEC_ID_H264;
+    }
+}
+
+AVPixelFormat FFmpegWriter::PixelFormat()
+{
+    switch (m_Spec.codec)
+    {
+        case MovieCodec::DNXHD: return AV_PIX_FMT_YUV422P;
+        case MovieCodec::PRORES: return AV_PIX_FMT_YUV422P10LE;
+        case MovieCodec::H264:
+        default: return AV_PIX_FMT_YUV420P;
+    }
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -197,7 +197,7 @@ AVPixelFormat FFmpegWriter::PixelFormat()
     {
         case MovieCodec::DNXHD: return AV_PIX_FMT_YUV422P;
         case MovieCodec::PRORES: return AV_PIX_FMT_YUV422P10LE;
-        case MovieCodec::MJPEG: return AV_PIX_FMT_YUVJ422P;
+        case MovieCodec::MJPEG: return AV_PIX_FMT_YUV422P;
         case MovieCodec::MPEG4:
         case MovieCodec::H264:
         default: return AV_PIX_FMT_YUV420P;
@@ -220,8 +220,9 @@ void FFmpegWriter::ContextSetup()
             break;
 
         case MovieCodec::MJPEG:
-            m_CodecCtx->pix_fmt = AV_PIX_FMT_YUVJ422P;
+            m_CodecCtx->pix_fmt = AV_PIX_FMT_YUV422P;
             m_CodecCtx->bit_rate = 50000000;
+            m_CodecCtx->color_range = AVCOL_RANGE_JPEG;
             break;
 
         case MovieCodec::MPEG4:

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -30,8 +30,8 @@ bool FFmpegWriter::Setup(const std::string& path)
 
         m_CodecCtx->codec_id = Codec();
         m_CodecCtx->codec_type = AVMEDIA_TYPE_VIDEO;
-        m_CodecCtx->width = m_Spec.outwidth;
-        m_CodecCtx->height = m_Spec.outheight;
+        m_CodecCtx->width = m_Spec.width;
+        m_CodecCtx->height = m_Spec.height;
         m_CodecCtx->time_base = av_make_q(1, m_Spec.rate);
         m_CodecCtx->framerate = av_make_q(m_Spec.rate, 1);
 
@@ -78,8 +78,8 @@ bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const InputSp
             spec.width,
             spec.height,
             spec.channels == 3 ? AV_PIX_FMT_RGB24 : AV_PIX_FMT_RGBA,
-            m_Spec.outwidth,
-            m_Spec.outheight,
+            m_Spec.width,
+            m_Spec.height,
             PixelFormat(),
             SWS_BILINEAR,
             nullptr,

--- a/src/VoidCore/Writers/FFmpegWriter.h
+++ b/src/VoidCore/Writers/FFmpegWriter.h
@@ -20,14 +20,14 @@ VOID_NAMESPACE_OPEN
 class VOID_API FFmpegWriter : public PixWriter
 {
 public:
-    FFmpegWriter(int width, int height, int channels, const WriterType& type);
+    FFmpegWriter(const EncodeSpec& spec);
 
     bool Setup(const std::string& path) override;
-    bool AddBuffer(const void* buffer, std::size_t size, const BufferType& type) override;
+    bool AddBuffer(const void* buffer, std::size_t size, const InputSpec& type) override;
     bool Write() override;
     void Cleanup() override;
 
-private:
+private: /* Members */
     AVFormatContext* m_FormatCtx;
     AVCodecContext* m_CodecCtx;
     SwsContext* m_SwsCtx;
@@ -35,6 +35,10 @@ private:
     int64_t m_Pts;
 
     std::string m_Path;
+
+private: /* Methods */
+    AVCodecID Codec();
+    AVPixelFormat PixelFormat();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/FFmpegWriter.h
+++ b/src/VoidCore/Writers/FFmpegWriter.h
@@ -9,6 +9,7 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
+#include <libavutil/opt.h>
 }
 
 /* Internal */
@@ -39,6 +40,7 @@ private: /* Members */
 private: /* Methods */
     AVCodecID Codec();
     AVPixelFormat PixelFormat();
+    void ContextSetup();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/OIIOWriter.cpp
+++ b/src/VoidCore/Writers/OIIOWriter.cpp
@@ -6,6 +6,7 @@
 
 /* OpenImageIO */
 #include <OpenImageIO/imageio.h>
+#include <OpenImageIO/imagebufalgo.h>
 
 /* Internal */
 #include "OIIOWriter.h"
@@ -15,58 +16,90 @@ VOID_NAMESPACE_OPEN
 
 OIIOWriter::OIIOWriter(const EncodeSpec& spec)
     : PixWriter(spec)
-    , m_OutPtr(nullptr)
 {
 }
 
 bool OIIOWriter::Setup(const std::string& path)
 {
-    m_OutPtr = OIIO::ImageOutput::create(path);
-    if (!m_OutPtr)
-    {
-        VOID_LOG_WARN("OIIOWriter::Unable to create out file at: {0}", path);
-        return false;
-    }
-
-    OIIO::ImageSpec spec(m_Spec.outwidth, m_Spec.outheight, m_Spec.channels, OIIO::TypeDesc::UINT8);
-    m_OutPtr->open(path, spec);
-
+    m_Path = path;
     return true;
 }
 
 bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec& spec)
 {
-    if (m_OutPtr)
-    {
-        switch (spec.type)
-        {
-            case BufferType::Uint16:
-                m_OutPtr->write_image(OIIO::TypeDesc::UINT16, buffer);
-                break;
-            case BufferType::Float:
-                m_OutPtr->write_image(OIIO::TypeDesc::FLOAT, buffer);
-                break;
-            case BufferType::Uint8:
-            default:
-                m_OutPtr->write_image(OIIO::TypeDesc::UINT8, buffer);
-        }
+    bool status = false;
+    OIIO::ROI roi(0, m_Spec.width, 0, m_Spec.height, 0, 1, 0, m_Spec.channels);
 
-        VOID_LOG_INFO("Image written to file");
-        return true;
+    switch (spec.type)
+    {
+        case BufferType::Uint16:
+        {
+            OIIO::ImageSpec inspec(spec.width, spec.height, spec.channels, OIIO::TypeDesc::UINT16);
+            OIIO::ImageBuf inbuf(inspec, const_cast<void*>(buffer));
+
+            std::vector<unsigned short> out(m_Spec.outwidth * m_Spec.outheight * m_Spec.channels);
+            OIIO::ImageSpec outspec(m_Spec.outwidth, m_Spec.outheight, m_Spec.channels, OIIO::TypeDesc::UINT16);
+            OIIO::ImageBuf outbuf(outspec, out.data());
+
+            status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);
+            if (!status)
+            {
+                VOID_LOG_ERROR("Unable to resize image: {0}", outbuf.geterror());
+                return false;
+            }
+            
+            return outbuf.write(m_Path);
+        }
+        case BufferType::Float:
+        {
+
+            OIIO::ImageSpec inspec(spec.width, spec.height, spec.channels, OIIO::TypeDesc::FLOAT);
+            OIIO::ImageBuf inbuf(inspec, const_cast<void*>(buffer));
+
+            std::vector<float> out(m_Spec.outwidth * m_Spec.outheight * m_Spec.channels);
+            OIIO::ImageSpec outspec(m_Spec.outwidth, m_Spec.outheight, m_Spec.channels, OIIO::TypeDesc::FLOAT);
+            OIIO::ImageBuf outbuf(outspec, out.data());
+
+            status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);
+            if (!status)
+            {
+                VOID_LOG_ERROR("Unable to resize image: {0}", outbuf.geterror());
+                return false;
+            }
+            
+            return outbuf.write(m_Path);
+        }
+        case BufferType::Uint8:
+        default:
+        {
+            OIIO::ImageSpec inspec(spec.width, spec.height, spec.channels, OIIO::TypeDesc::UINT8);
+            OIIO::ImageBuf inbuf(inspec, const_cast<void*>(buffer));
+
+            std::vector<unsigned char> out(m_Spec.outwidth * m_Spec.outheight * m_Spec.channels);
+            OIIO::ImageSpec outspec(m_Spec.outwidth, m_Spec.outheight, m_Spec.channels, OIIO::TypeDesc::UINT8);
+            OIIO::ImageBuf outbuf(outspec, out.data());
+
+            status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);
+            if (!status)
+            {
+                VOID_LOG_ERROR("Unable to resize image: {0}", outbuf.geterror());
+                return false;
+            }
+            
+            return outbuf.write(m_Path);
+        }
     }
 
-    return false;
+    return status;
 }
 
 bool OIIOWriter::Write()
 {
-    return (bool)m_OutPtr;
+    return true;
 }
 
 void OIIOWriter::Cleanup()
 {
-    if (m_OutPtr)
-        m_OutPtr->close();
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/OIIOWriter.cpp
+++ b/src/VoidCore/Writers/OIIOWriter.cpp
@@ -37,8 +37,8 @@ bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec
             OIIO::ImageSpec inspec(spec.width, spec.height, spec.channels, OIIO::TypeDesc::UINT16);
             OIIO::ImageBuf inbuf(inspec, const_cast<void*>(buffer));
 
-            std::vector<unsigned short> out(m_Spec.outwidth * m_Spec.outheight * m_Spec.channels);
-            OIIO::ImageSpec outspec(m_Spec.outwidth, m_Spec.outheight, m_Spec.channels, OIIO::TypeDesc::UINT16);
+            std::vector<unsigned short> out(m_Spec.width * m_Spec.height * m_Spec.channels);
+            OIIO::ImageSpec outspec(m_Spec.width, m_Spec.height, m_Spec.channels, OIIO::TypeDesc::UINT16);
             OIIO::ImageBuf outbuf(outspec, out.data());
 
             status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);
@@ -56,8 +56,8 @@ bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec
             OIIO::ImageSpec inspec(spec.width, spec.height, spec.channels, OIIO::TypeDesc::FLOAT);
             OIIO::ImageBuf inbuf(inspec, const_cast<void*>(buffer));
 
-            std::vector<float> out(m_Spec.outwidth * m_Spec.outheight * m_Spec.channels);
-            OIIO::ImageSpec outspec(m_Spec.outwidth, m_Spec.outheight, m_Spec.channels, OIIO::TypeDesc::FLOAT);
+            std::vector<float> out(m_Spec.width * m_Spec.height * m_Spec.channels);
+            OIIO::ImageSpec outspec(m_Spec.width, m_Spec.height, m_Spec.channels, OIIO::TypeDesc::FLOAT);
             OIIO::ImageBuf outbuf(outspec, out.data());
 
             status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);
@@ -75,8 +75,8 @@ bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec
             OIIO::ImageSpec inspec(spec.width, spec.height, spec.channels, OIIO::TypeDesc::UINT8);
             OIIO::ImageBuf inbuf(inspec, const_cast<void*>(buffer));
 
-            std::vector<unsigned char> out(m_Spec.outwidth * m_Spec.outheight * m_Spec.channels);
-            OIIO::ImageSpec outspec(m_Spec.outwidth, m_Spec.outheight, m_Spec.channels, OIIO::TypeDesc::UINT8);
+            std::vector<unsigned char> out(m_Spec.width * m_Spec.height * m_Spec.channels);
+            OIIO::ImageSpec outspec(m_Spec.width, m_Spec.height, m_Spec.channels, OIIO::TypeDesc::UINT8);
             OIIO::ImageBuf outbuf(outspec, out.data());
 
             status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);

--- a/src/VoidCore/Writers/OIIOWriter.cpp
+++ b/src/VoidCore/Writers/OIIOWriter.cpp
@@ -13,8 +13,8 @@
 
 VOID_NAMESPACE_OPEN
 
-OIIOWriter::OIIOWriter(int width, int height, int channels, const WriterType& type)
-    : PixWriter(width, height, channels, type)
+OIIOWriter::OIIOWriter(const EncodeSpec& spec)
+    : PixWriter(spec)
     , m_OutPtr(nullptr)
 {
 }
@@ -28,17 +28,17 @@ bool OIIOWriter::Setup(const std::string& path)
         return false;
     }
 
-    OIIO::ImageSpec spec(m_Width, m_Height, m_Channels, OIIO::TypeDesc::UINT8);
+    OIIO::ImageSpec spec(m_Spec.outwidth, m_Spec.outheight, m_Spec.channels, OIIO::TypeDesc::UINT8);
     m_OutPtr->open(path, spec);
 
     return true;
 }
 
-bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const BufferType& type)
+bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec& spec)
 {
     if (m_OutPtr)
     {
-        switch (type)
+        switch (spec.type)
         {
             case BufferType::Uint16:
                 m_OutPtr->write_image(OIIO::TypeDesc::UINT16, buffer);

--- a/src/VoidCore/Writers/OIIOWriter.h
+++ b/src/VoidCore/Writers/OIIOWriter.h
@@ -16,7 +16,6 @@ VOID_NAMESPACE_OPEN
 class VOID_API OIIOWriter : public PixWriter
 {
 public:
-    // OIIOWriter(int width, int height, int channels, const WriterType& type);
     OIIOWriter(const EncodeSpec& spec);
 
     bool Setup(const std::string& path) override;
@@ -25,7 +24,7 @@ public:
     void Cleanup() override;
 
 private:
-    OIIO::ImageOutput::unique_ptr m_OutPtr;
+    std::string m_Path;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/OIIOWriter.h
+++ b/src/VoidCore/Writers/OIIOWriter.h
@@ -16,10 +16,11 @@ VOID_NAMESPACE_OPEN
 class VOID_API OIIOWriter : public PixWriter
 {
 public:
-    OIIOWriter(int width, int height, int channels, const WriterType& type);
+    // OIIOWriter(int width, int height, int channels, const WriterType& type);
+    OIIOWriter(const EncodeSpec& spec);
 
     bool Setup(const std::string& path) override;
-    bool AddBuffer(const void* buffer, std::size_t size, const BufferType& type) override;
+    bool AddBuffer(const void* buffer, std::size_t size, const InputSpec& spec) override;
     bool Write() override;
     void Cleanup() override;
 

--- a/src/VoidCore/Writers/Registration.h
+++ b/src/VoidCore/Writers/Registration.h
@@ -17,9 +17,9 @@ namespace Internal {
         f.name = "OIIO Writer";
         f.extensions = { "png", "jpg" };
         f.type = WriterType::Image;
-        f.writer = [](int width, int height, int channels, const WriterType& type) -> std::unique_ptr<OIIOWriter>
+        f.writer = [](const EncodeSpec& spec) -> std::unique_ptr<OIIOWriter>
                         {
-                            return std::make_unique<OIIOWriter>(width, height, channels, type);
+                            return std::make_unique<OIIOWriter>(spec);
                         };
 
         return Forge::Instance().Register(f);
@@ -31,9 +31,9 @@ namespace Internal {
         f.name = "FFmpeg Writer";
         f.extensions = { "mov", "mp4" };
         f.type = WriterType::Movie;
-        f.writer = [](int width, int height, int channels, const WriterType& type) -> std::unique_ptr<FFmpegWriter>
+        f.writer = [](const EncodeSpec& spec) -> std::unique_ptr<FFmpegWriter>
                         {
-                            return std::make_unique<FFmpegWriter>(width, height, channels, type);
+                            return std::make_unique<FFmpegWriter>(spec);
                         };
 
         return Forge::Instance().Register(f);

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -30,6 +30,11 @@ set(SOURCES
     Engine/Bridge.cpp
     Engine/Globals.cpp
     Engine/IconForge.cpp
+
+    # Exporter
+    Exporter/Exporter.cpp
+    Exporter/ExportOptions.cpp
+    Exporter/MediaExporter.cpp
     
     # Media
     Media/Browser.cpp
@@ -65,7 +70,6 @@ set(SOURCES
     Preferences/PlayerPreferences.cpp
 
     # Player
-    Player/Exporter.cpp
     Player/OverlayWidget.cpp
     Player/Player.cpp
     Player/PlayerBridge.cpp
@@ -100,6 +104,7 @@ set(SOURCES
     Toolkit/ViewerController.cpp
 
     # Tools
+    Tools/Delegates/LogDelegate.cpp
     Tools/Task.cpp
     Tools/TaskView.cpp
     Tools/LogWindow.cpp

--- a/src/VoidUi/Exporter/ExportOptions.cpp
+++ b/src/VoidUi/Exporter/ExportOptions.cpp
@@ -1,0 +1,232 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QLabel>
+
+/* Internal */
+#include "ExportOptions.h"
+#include "VoidUi/Tools/Delegates/LogDelegate.h"
+
+VOID_NAMESPACE_OPEN
+
+/// Movie Options
+
+MovieOptions::MovieOptions(QWidget* parent)
+    : QWidget(parent)
+{
+    Build();
+    Setup();
+    Connect();
+}
+
+MovieOptions::~MovieOptions()
+{
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void MovieOptions::SetRate(double rate)
+{
+    m_RateEdit->setText(QString::number(rate, 'f', 1));
+}
+
+void MovieOptions::Build()
+{
+    m_RateValidator = new QDoubleValidator(this);
+
+    m_Layout = new QVBoxLayout(this);
+
+    m_CodecCombo = new QComboBox;
+    m_RateEdit = new QLineEdit;
+    // m_RespeedCheck = new QCheckBox;
+
+    QGridLayout* optionsLayout = new QGridLayout;
+    optionsLayout->addWidget(new QLabel("Codec:", this), 0, 0, 1, 1);
+    optionsLayout->addWidget(m_CodecCombo, 0, 1, 1, 3);
+    optionsLayout->addWidget(new QLabel("Framerate:", this), 1, 0, 1, 1);
+    optionsLayout->addWidget(m_RateEdit, 1, 1, 1, 3);
+    // optionsLayout->addWidget(new QLabel("Respeed:", this), 2, 0, 1, 1);
+    // optionsLayout->addWidget(m_RespeedCheck, 2, 1, 1, 2);
+
+    m_Layout->addLayout(optionsLayout);
+    m_Layout->setContentsMargins(0, 0, 0, 0);
+}
+
+void MovieOptions::Setup()
+{
+    m_CodecCombo->addItems({
+        "H.264",
+        "DNxHD",
+        "MJpeg",
+        "Mpeg4",
+        "ProRes"
+    });
+
+    m_RateEdit->setValidator(m_RateValidator);
+}
+
+void MovieOptions::Connect()
+{
+
+}
+
+/// Export Options
+
+ExportOptions::ExportOptions(QWidget* parent)
+    : QDialog(parent)
+{
+    Build();
+    Setup();
+    Connect();
+}
+
+ExportOptions::~ExportOptions()
+{
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void ExportOptions::SetRange(int start, int end)
+{
+    m_RangeValidator->setBottom(start);
+    m_RangeValidator->setTop(end);
+
+    m_StartEdit->setText(QString::number(start));
+    m_EndEdit->setText(QString::number(end));
+}
+
+void ExportOptions::Build()
+{
+    m_LogModel = new TaskLogModel(this);
+    m_RangeValidator = new QIntValidator(this);
+
+    m_Layout = new QVBoxLayout(this);
+
+    QHBoxLayout* inputLayout = new QHBoxLayout;
+
+    m_OutputEdit = new QLineEdit;
+    m_BrowseButton = new QPushButton;
+
+    inputLayout->addWidget(m_OutputEdit);
+    inputLayout->addWidget(m_BrowseButton);
+
+    QGridLayout* optionsLayout = new QGridLayout;
+
+    // QHBoxLayout* rangeLayout = new QHBoxLayout;
+
+    m_StartEdit = new QLineEdit;
+    m_EndEdit = new QLineEdit;
+
+    m_OverrideRangeCheck = new QCheckBox("Override Media Range");
+
+    m_ResolutionCombo = new QComboBox;
+    m_OutProcessorCombo = new QComboBox;
+
+    m_MovieGroup = new QGroupBox("Movie Options:");
+    QHBoxLayout* mgroupLayout = new QHBoxLayout(m_MovieGroup);
+
+    m_MovieOptions = new MovieOptions;
+    mgroupLayout->addWidget(m_MovieOptions);
+
+    m_Logger = new QListView;
+
+    optionsLayout->addWidget(new QLabel("Render Range:", this), 0, 0, 1, 1);
+    optionsLayout->addWidget(m_StartEdit, 0, 1, 1, 1);
+    optionsLayout->addWidget(m_EndEdit, 0, 2, 1, 1);
+    optionsLayout->addWidget(m_OverrideRangeCheck, 0, 3, 1, 2);    
+    optionsLayout->addWidget(new QLabel("Render Resolution:"), 1, 0, 1, 1);
+    optionsLayout->addWidget(m_ResolutionCombo, 1, 1, 1, 3);
+    optionsLayout->addWidget(new QLabel("Process as:"), 2, 0, 1, 1);
+    optionsLayout->addWidget(m_OutProcessorCombo, 2, 1, 1, 3);
+    optionsLayout->addWidget(m_MovieGroup, 3, 0, 2, 5);
+    optionsLayout->addWidget(m_Logger, 5, 0, 4, 5);
+
+    QHBoxLayout* buttonLayout = new QHBoxLayout;
+
+    m_ExportButton = new QPushButton("Export");
+    m_CancelButton = new QPushButton("Cancel");
+
+    buttonLayout->addStretch(1);
+    buttonLayout->addWidget(m_ExportButton);
+    buttonLayout->addWidget(m_CancelButton);
+
+    m_Layout->addLayout(inputLayout);
+    m_Layout->addLayout(optionsLayout);
+
+    m_Layout->addStretch(1);
+    m_Layout->addLayout(buttonLayout);
+}
+
+void ExportOptions::Setup()
+{
+    m_BrowseButton->setIcon(style()->standardIcon(style()->SP_DirOpenIcon));
+    m_ResolutionCombo->addItems({
+        "Same as input sequence",
+        "Half resolution",
+        "Quarter resolution",
+    });
+    m_OutProcessorCombo->addItems({
+        "Image Sequence",
+        "Movie"
+    });
+
+    m_MovieGroup->setVisible(false);
+
+    m_StartEdit->setEnabled(m_OverrideRangeCheck->isChecked());
+    m_EndEdit->setEnabled(m_OverrideRangeCheck->isChecked());
+
+    // Read-only for the user to only see, selection only happens through the browse option
+    m_OutputEdit->setEnabled(false);
+
+    m_StartEdit->setValidator(m_RangeValidator);
+    m_EndEdit->setValidator(m_RangeValidator);
+
+    m_Logger->setModel(m_LogModel);
+    m_Logger->setItemDelegate(new ColoredLogDelegate(m_Logger));
+}
+
+void ExportOptions::Connect()
+{
+    connect(m_BrowseButton, &QPushButton::clicked, this, &ExportOptions::Browse);
+    connect(m_OutProcessorCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this](int index) -> void
+    {
+        m_MovieGroup->setVisible(index == 1);
+        // Whenever the Process as mode changes, simplest is to clear the path selected by the user as opposed to
+        // Guessing the extension and setting it as a default
+        m_OutputEdit->clear();
+    });
+    connect(m_OverrideRangeCheck, &QCheckBox::toggled, this, [this](bool checked) -> void
+    {
+        m_StartEdit->setEnabled(checked);
+        m_EndEdit->setEnabled(checked);
+    });
+    connect(m_ExportButton, &QPushButton::clicked, this, &ExportOptions::exported);
+    connect(m_CancelButton, &QPushButton::clicked, this, &ExportOptions::close);
+}
+
+void ExportOptions::Browse()
+{
+    MediaExportBrowser browser;
+    if (browser.Save())
+    {
+        m_Descriptor = browser.File();
+        m_OutputEdit->setText(m_Descriptor.entry.Fullpath().c_str());
+
+        bool blocked = m_OutProcessorCombo->blockSignals(true);
+
+        m_OutProcessorCombo->setCurrentIndex(static_cast<int>(m_Descriptor.type));
+        m_MovieGroup->setVisible(static_cast<int>(m_Descriptor.type) == 1);
+
+        m_OutProcessorCombo->blockSignals(blocked);
+    }
+}
+
+void ExportOptions::Log(const QString& text, const TaskLog::Level& level)
+{
+    m_LogModel->AddLog(text, level);
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Exporter/ExportOptions.h
+++ b/src/VoidUi/Exporter/ExportOptions.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _EXPORT_OPTIONS_H
+#define _EXPORT_OPTIONS_H
+
+/* Qt */
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialog>
+#include <QDoubleValidator>
+#include <QGroupBox>
+#include <QIntValidator>
+#include <QLayout>
+#include <QLineEdit>
+#include <QPushButton>
+
+/* Internal */
+#include "Definition.h"
+#include "VoidObjects/Media/MediaClip.h"
+#include "VoidUi/Media/Browser.h"
+#include "VoidUi/Tools/LogWindow.h"
+
+VOID_NAMESPACE_OPEN
+
+class MovieOptions : public QWidget
+{
+    Q_OBJECT
+public:
+    MovieOptions(QWidget* parent = nullptr);
+    ~MovieOptions();
+
+    void SetRate(double rate);
+    double Rate() const { return m_RateEdit->text().toDouble(); }
+    MovieCodec Codec() const { return static_cast<MovieCodec>(m_CodecCombo->currentIndex()); }
+
+private: /* Members */
+    QVBoxLayout* m_Layout;
+    QComboBox* m_CodecCombo;
+    QLineEdit* m_RateEdit;
+    // QCheckBox* m_RespeedCheck;
+    QDoubleValidator* m_RateValidator;
+
+private: /* Methods */
+    void Build();
+    void Setup();
+    void Connect();
+};
+
+class ExportOptions : public QDialog
+{
+    Q_OBJECT
+public:
+    ExportOptions(QWidget* parent = nullptr);
+    virtual ~ExportOptions();
+
+    inline QSize sizeHint() const override { return QSize(350, 350); }
+
+    inline void SetRate(double rate) { m_MovieOptions->SetRate(rate); }
+    inline double Rate() const { return m_MovieOptions->Rate(); }
+
+    void SetRange(int start, int end);
+    inline MFrameRange Range() const { return {m_StartEdit->text().toInt(), m_EndEdit->text().toInt()}; }
+    inline bool RangeOverridden() const { return m_OverrideRangeCheck->isChecked(); }
+    inline MovieCodec Codec() const { return m_MovieOptions->Codec(); }
+
+    inline MediaExportDescriptor FileDescriptor() const { return m_Descriptor; }
+    inline void ClearLog() { m_LogModel->Clear(); }
+
+signals:
+    void exported();
+
+private: /* Members */
+    QVBoxLayout* m_Layout;
+    QLineEdit* m_OutputEdit;
+    QLineEdit* m_StartEdit;
+    QLineEdit* m_EndEdit;
+    QCheckBox* m_OverrideRangeCheck;
+    QComboBox* m_ResolutionCombo;
+    QComboBox* m_OutProcessorCombo;
+
+    QGroupBox* m_MovieGroup;
+    MovieOptions* m_MovieOptions;
+
+    TaskLogModel* m_LogModel;
+    QListView* m_Logger;
+
+    QPushButton* m_BrowseButton;
+    QPushButton* m_ExportButton;
+    QPushButton* m_CancelButton;
+
+    QIntValidator* m_RangeValidator;
+
+protected: /* Members */
+    MediaExportDescriptor m_Descriptor;
+
+private: /* Methods */
+    void Build();
+    void Connect();
+    void Setup();
+
+    void Browse();
+
+protected: /* Methods */
+    void Log(const QString& text, const TaskLog::Level& level);
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _EXPORT_OPTIONS_H

--- a/src/VoidUi/Exporter/ExportOptions.h
+++ b/src/VoidUi/Exporter/ExportOptions.h
@@ -63,6 +63,7 @@ public:
     inline MFrameRange Range() const { return {m_StartEdit->text().toInt(), m_EndEdit->text().toInt()}; }
     inline bool RangeOverridden() const { return m_OverrideRangeCheck->isChecked(); }
     inline MovieCodec Codec() const { return m_MovieOptions->Codec(); }
+    inline int ScaleIndex() const { return m_ResolutionCombo->currentIndex(); }
 
     inline MediaExportDescriptor FileDescriptor() const { return m_Descriptor; }
     inline void ClearLog() { m_LogModel->Clear(); }

--- a/src/VoidUi/Exporter/Exporter.cpp
+++ b/src/VoidUi/Exporter/Exporter.cpp
@@ -153,6 +153,10 @@ bool ExportMediaFramesTask::Work()
                     Log(QString("Unable to render current frame: %1").arg(i), TaskLog::Level::ErrorLog);
                     return false;
                 }
+                // Don't want to take up additional memory, so clear as we go...
+                // We definitely need a better way to handle this
+                // Other way could be to read through the ViewerBuffer, but that's something will eventually come
+                image->Clear();
 
                 count++;
                 SetProgress(count);
@@ -195,6 +199,10 @@ bool ExportMediaFramesTask::Work()
                     Log(QString("Unable to buffer current frame: %1").arg(i), TaskLog::Level::ErrorLog);
                     return false;
                 }
+                // Don't want to take up additional memory, so clear as we go...
+                // We definitely need a better way to handle this
+                // Other way could be to read through the ViewerBuffer, but that's something will eventually come
+                image->Clear();
 
                 count++;
                 SetProgress(count);

--- a/src/VoidUi/Exporter/Exporter.cpp
+++ b/src/VoidUi/Exporter/Exporter.cpp
@@ -3,7 +3,7 @@
 
 /* Internal */
 #include "Exporter.h"
-#include "Player.h"
+#include "VoidUi/Player/Player.h"
 #include "VoidCore/Media/Renderer.h"
 
 VOID_NAMESPACE_OPEN
@@ -29,7 +29,7 @@ bool ExportAnnotatedFramesTask::Work()
     if (m_Descriptor.type == WriterType::Image && m_Descriptor.entry.Templated())
     {
         const Renderer::RenderData r = m_Player->m_Renderer->FrameBuffer();
-        Renderer::ImageRenderer ir(m_Descriptor.entry, r.width, r.height, r.channels);
+        Renderer::ImageRenderer ir(m_Descriptor.entry, {r.width, r.height, r.channels, r.type});
 
         for (auto& [frame, _] : annotations)
         {
@@ -38,7 +38,7 @@ bool ExportAnnotatedFramesTask::Work()
                 m_Player->m_Renderer->Render(data.image, data.annotation);
                 const Renderer::RenderData r = m_Player->m_Renderer->FrameBuffer();
 
-                if (!ir.Render(frame, r.pixels.data(), r.Size(), r.type))
+                if (!ir.Render(frame, r.pixels.data(), r.Size(), {r.width, r.height, r.channels, r.type}))
                 {
                     // ErrorMessageBox box("There was an error in exporting media.", "Error", this);
                     // box.exec();
@@ -61,7 +61,7 @@ bool ExportAnnotatedFramesTask::Work()
     else if (m_Descriptor.type == WriterType::Movie)
     {
         const Renderer::RenderData r = m_Player->m_Renderer->FrameBuffer();
-        Renderer::MovieRenderer mr(m_Descriptor.entry, r.width, r.height, r.channels);
+        Renderer::MovieRenderer mr(m_Descriptor.entry, {r.width, r.height, r.channels, r.type});
 
         for (auto& [frame, _] : annotations)
         {
@@ -69,7 +69,7 @@ bool ExportAnnotatedFramesTask::Work()
             {
                 m_Player->m_Renderer->Render(data.image, data.annotation);
                 const Renderer::RenderData r = m_Player->m_Renderer->FrameBuffer();
-                if (!mr.AddBuffer(r.pixels.data(), r.Size(), r.type))
+                if (!mr.AddBuffer(r.pixels.data(), r.Size(), {r.width, r.height, r.channels, r.type}))
                 {
                     // ErrorMessageBox box("There was an error in exporting media.", "Error", this);
                     // box.exec();
@@ -97,10 +97,12 @@ bool ExportAnnotatedFramesTask::Work()
 
 /// ExportMediaFramesTask
 
-ExportMediaFramesTask::ExportMediaFramesTask(const SharedMediaClip& media, const MediaExportDescriptor& descriptor)
+ExportMediaFramesTask::ExportMediaFramesTask(const SharedMediaClip& media, const MediaExportDescriptor& descriptor, const EncodeSpec& spec, const MFrameRange& range)
     : Task("Transcode Media")
     , m_Media(media)
     , m_Descriptor(descriptor)
+    , m_Spec(spec)
+    , m_Range(range)
 {
 }
 
@@ -109,7 +111,8 @@ bool ExportMediaFramesTask::Work()
     if (SharedMediaClip media = m_Media.lock())
     {
         int count = 0;
-        SetMax(media->Duration());
+        SetMax(m_Range.duration);
+
         if (m_Descriptor.type == WriterType::Image)
         {
             if (!m_Descriptor.entry.Templated())
@@ -123,26 +126,29 @@ bool ExportMediaFramesTask::Work()
             }
 
             Log(
-                QString("Starting Image render. Output will be saved to: %1")
-                    .arg(m_Descriptor.entry.Fullpath().c_str()),
+                QString("Starting Image render. Output will be saved to: %1, Range: %2 - %3")
+                    .arg(m_Descriptor.entry.Fullpath().c_str())
+                    .arg(m_Range.startframe)
+                    .arg(m_Range.endframe),
                     TaskLog::Level::InfoLog
                 );
 
-            Renderer::ImageRenderer ir(
-                m_Descriptor.entry,
-                media->FirstImage()->Width(),
-                media->FirstImage()->Height(),
-                media->FirstImage()->Channels()
-            );
+            Renderer::ImageRenderer ir(m_Descriptor.entry, m_Spec);
     
-            for (int i = media->FirstFrame(); i <= media->LastFrame(); ++i)
+            for (int i = m_Range.startframe; i <= m_Range.endframe; ++i)
             {
                 // Check for whether the task was cancelled
                 if (Cancelled())
                     return false;
 
+                if (!media->Contains(i))
+                {
+                    Log(QString("Media does not contain frame %1 for render. Skipping.").arg(i), TaskLog::Level::WarningLog);
+                    continue;
+                }
+
                 SharedPixels image = media->Image(i);
-                if (!ir.Render(i, image->Pixels(), image->FrameSize(), BufferType::Uint8))
+                if (!ir.Render(i, image->Pixels(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Uint8}))
                 {
                     Log(QString("Unable to render current frame: %1").arg(i), TaskLog::Level::ErrorLog);
                     return false;
@@ -151,7 +157,7 @@ bool ExportMediaFramesTask::Work()
                 count++;
                 SetProgress(count);
                 Log(
-                    QString("ImageRenderer: Frame %1 of %2 rendered").arg(i).arg(media->LastFrame()),
+                    QString("ImageRenderer: Frame %1 of %2 rendered").arg(i).arg(m_Range.endframe),
                     TaskLog::Level::InfoLog
                 );
             }
@@ -162,25 +168,29 @@ bool ExportMediaFramesTask::Work()
         else if (m_Descriptor.type == WriterType::Movie)
         {
             Log(
-                QString("Starting Movie render. Output will be saved to: %1").arg(m_Descriptor.entry.Fullpath().c_str()),
+                QString("Starting Movie render. Output will be saved to: %1, Range: %2 - %3")
+                    .arg(m_Descriptor.entry.Fullpath().c_str())
+                    .arg(m_Range.startframe)
+                    .arg(m_Range.endframe),
                 TaskLog::Level::InfoLog
             );
             
-            Renderer::MovieRenderer mr(
-                m_Descriptor.entry,
-                media->FirstImage()->Width(),
-                media->FirstImage()->Height(),
-                media->FirstImage()->Channels()
-            );
+            Renderer::MovieRenderer mr(m_Descriptor.entry, m_Spec);
     
-            for (int i = media->FirstFrame(); i <= media->LastFrame(); ++i)
+            for (int i = m_Range.startframe; i <= m_Range.endframe; ++i)
             {
                 // Check for whether the task was cancelled
                 if (Cancelled())
                     return false;
 
+                if (!media->Contains(i))
+                {
+                    Log(QString("Media does not contain frame %1 for render. Skipping.").arg(i), TaskLog::Level::WarningLog);
+                    continue;
+                }
+
                 SharedPixels image = media->Image(i);
-                if (!mr.AddBuffer(image->Pixels(), image->FrameSize(), BufferType::Uint8))
+                if (!mr.AddBuffer(image->Pixels(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Uint8}))
                 {
                     Log(QString("Unable to buffer current frame: %1").arg(i), TaskLog::Level::ErrorLog);
                     return false;
@@ -189,7 +199,7 @@ bool ExportMediaFramesTask::Work()
                 count++;
                 SetProgress(count);
                 Log(
-                    QString("MovieRenderer: Frame %1 of %2 buffered").arg(i).arg(media->LastFrame()),
+                    QString("MovieRenderer: Frame %1 of %2 buffered").arg(i).arg(m_Range.endframe),
                     TaskLog::Level::InfoLog
                 );
             }

--- a/src/VoidUi/Exporter/Exporter.h
+++ b/src/VoidUi/Exporter/Exporter.h
@@ -31,7 +31,7 @@ private:
 class ExportMediaFramesTask : public Task
 {
 public:
-    ExportMediaFramesTask(const SharedMediaClip& media, const MediaExportDescriptor& descriptor);
+    ExportMediaFramesTask(const SharedMediaClip& media, const MediaExportDescriptor& descriptor, const EncodeSpec& spec, const MFrameRange& range);
     inline std::string Label() const override { return m_Descriptor.entry.TemplatedName(); }
 
 protected:
@@ -40,6 +40,8 @@ protected:
 private:
     std::weak_ptr<MediaClip> m_Media;
     MediaExportDescriptor m_Descriptor;
+    EncodeSpec m_Spec;
+    MFrameRange m_Range;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Exporter/MediaExporter.cpp
+++ b/src/VoidUi/Exporter/MediaExporter.cpp
@@ -39,8 +39,6 @@ void MediaExporter::Export()
         int outheight = m_Media->FirstImage()->Height() / divisor;
 
         EncodeSpec spec(
-            m_Media->FirstImage()->Width(),
-            m_Media->FirstImage()->Height(),
             outwidth,
             outheight,
             m_Media->FirstImage()->Channels(),

--- a/src/VoidUi/Exporter/MediaExporter.cpp
+++ b/src/VoidUi/Exporter/MediaExporter.cpp
@@ -33,12 +33,16 @@ void MediaExporter::Export()
 {
     if (Validate())
     {
-        //EncodeSpec(int w, int h, int outw, int outh, int ch, float r, const BufferType& ty, const MovieCodec& codec, bool respeed)
+        // Resolution options provide a way for user to select half or quarter
+        const int divisor = ScaleIndex() == 2 ? 4 : ScaleIndex() == 1 ? 2 : 1;
+        int outwidth = m_Media->FirstImage()->Width() / divisor;
+        int outheight = m_Media->FirstImage()->Height() / divisor;
+
         EncodeSpec spec(
             m_Media->FirstImage()->Width(),
             m_Media->FirstImage()->Height(),
-            m_Media->FirstImage()->Width(),
-            m_Media->FirstImage()->Height(),
+            outwidth,
+            outheight,
             m_Media->FirstImage()->Channels(),
             Rate(),
             BufferType::Uint8,

--- a/src/VoidUi/Exporter/MediaExporter.cpp
+++ b/src/VoidUi/Exporter/MediaExporter.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Internal */
+#include "Exporter.h"
+#include "MediaExporter.h"
+#include "VoidUi/Engine/Globals.h"
+#include "VoidCore/Logging.h"
+
+VOID_NAMESPACE_OPEN
+
+MediaExporter::MediaExporter(const SharedMediaClip& media, QWidget* parent)
+    : ExportOptions(parent)
+    , m_Media(media)
+{
+    Setup();
+    connect(this, &ExportOptions::exported, this, &MediaExporter::Export);
+}
+
+MediaExporter::~MediaExporter()
+{
+}
+
+void MediaExporter::Setup()
+{
+    setWindowTitle("Export Media");
+
+    SetRange(m_Media->FirstFrame(), m_Media->LastFrame());
+    SetRate(m_Media->Framerate());
+}
+
+void MediaExporter::Export()
+{
+    if (Validate())
+    {
+        //EncodeSpec(int w, int h, int outw, int outh, int ch, float r, const BufferType& ty, const MovieCodec& codec, bool respeed)
+        EncodeSpec spec(
+            m_Media->FirstImage()->Width(),
+            m_Media->FirstImage()->Height(),
+            m_Media->FirstImage()->Width(),
+            m_Media->FirstImage()->Height(),
+            m_Media->FirstImage()->Channels(),
+            Rate(),
+            BufferType::Uint8,
+            Codec(),
+            false
+        );
+        UIGlobals::QueueTask(new ExportMediaFramesTask(m_Media, m_Descriptor, spec, Range()));
+        close();
+    }
+}
+
+bool MediaExporter::Validate()
+{
+    ClearLog();
+
+    // TODO: Write the actual validator mechanism
+    if (!m_Descriptor.entry.Valid())
+    {
+        Log("Missing export path.", TaskLog::Level::ErrorLog);
+        return false;
+    }
+
+    MFrameRange range = Range();
+    if (range.duration < 0)
+    {
+        Log("Invalid start and end frame", TaskLog::Level::ErrorLog);
+        return false;
+    }
+
+    if (range.startframe < m_Media->FirstFrame() || range.endframe > m_Media->LastFrame())
+    {
+        Log(
+            QString("Provided range is out of bounds of the selected media frame range, %1 - %2")
+                .arg(m_Media->FirstFrame())
+                .arg(m_Media->LastFrame()),
+            TaskLog::Level::ErrorLog
+        );
+        return false;
+    }
+
+    // Just to let the user know that they have it set but not change anything, maybe they forgot?
+    if (RangeOverridden() && range.startframe == m_Media->FirstFrame() && range.endframe == m_Media->LastFrame())
+        Log("Media range is overridden but not changed", TaskLog::Level::WarningLog);
+
+    if (m_Descriptor.type == WriterType::Movie &&
+            (Codec() == MovieCodec::DNXHD || Codec() == MovieCodec::PRORES) &&
+                m_Descriptor.entry.Extension() != "mov")
+    {
+        Log("Selected Movie codec can only be exported as a quicktime with .mov extension", TaskLog::Level::ErrorLog);
+        return false;
+    }
+
+    if (m_Descriptor.type == WriterType::Movie && Rate() < 1.f)
+    {
+        Log("Invalid output media framerate", TaskLog::Level::ErrorLog);
+        return false;
+    }
+
+    if (m_Descriptor.type == WriterType::Image && !m_Descriptor.entry.Templated())
+    {
+        Log("Provided path is not templated .i.e. does not contain tokens for replacement '####'", TaskLog::Level::ErrorLog);
+        return false;
+    }
+
+    Log(
+        m_Descriptor.type == WriterType::Movie ? "Processing as movie" : "Processing as image sequence",
+        TaskLog::Level::InfoLog
+    );
+    return true;
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Exporter/MediaExporter.h
+++ b/src/VoidUi/Exporter/MediaExporter.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _MEDIA_EXPORTER_H
+#define _MEDIA_EXPORTER_H
+
+/* Internal */
+#include "Definition.h"
+#include "ExportOptions.h"
+#include "VoidObjects/Media/MediaClip.h"
+
+VOID_NAMESPACE_OPEN
+
+class MediaExporter : public ExportOptions
+{
+public:
+    MediaExporter(const SharedMediaClip& media, QWidget* parent = nullptr);
+    ~MediaExporter();
+
+private:
+    SharedMediaClip m_Media;
+
+protected: /* Methods */
+    void Setup();
+    void Export();
+    bool Validate();
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _MEDIA_EXPORTER_H

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -7,13 +7,14 @@
 
 /* Internal */
 #include "Player.h"
-#include "Exporter.h"
 #include "VoidCore/Timekeeper.h"
 #include "VoidCore/Media/Renderer.h"
 #include "VoidUi/Descriptors.h"
 #include "VoidUi/Media/Browser.h"
 #include "VoidUi/Media/MediaBridge.h"
 #include "VoidUi/Engine/Globals.h"
+#include "VoidUi/Exporter/Exporter.h"
+#include "VoidUi/Exporter/MediaExporter.h"
 #include "VoidUi/QExtensions/MessageBox.h"
 
 VOID_NAMESPACE_OPEN
@@ -524,8 +525,8 @@ void Player::RenderCurrentFrame()
         const MediaExportDescriptor descriptor = browser.File();
         const Renderer::RenderData r = m_Renderer->FrameBuffer();
 
-        Renderer::ImageRenderer ir(descriptor.entry, r.width, r.height, r.channels);
-        ir.Render(r.pixels.data(), r.Size(), r.type);
+        Renderer::ImageRenderer ir(descriptor.entry, {r.width, r.height, r.channels, r.type});
+        ir.Render(r.pixels.data(), r.Size(), {r.width, r.height, r.channels, r.type});
 
         InfoMessageBox box("Frame exported.", "Success", this);
         box.exec();
@@ -549,7 +550,7 @@ void Player::RenderAnnotatedFrames()
         if (descriptor.type == WriterType::Image && descriptor.entry.Templated())
         {
             const Renderer::RenderData r = m_Renderer->FrameBuffer();
-            Renderer::ImageRenderer ir(descriptor.entry, r.width, r.height, r.channels);
+            Renderer::ImageRenderer ir(descriptor.entry, {r.width, r.height, r.channels, r.type});
 
             for (auto& [frame, _] : annotations)
             {
@@ -557,7 +558,7 @@ void Player::RenderAnnotatedFrames()
                 {
                     m_Renderer->Render(data.image, data.annotation);
                     const Renderer::RenderData r = m_Renderer->FrameBuffer();
-                    if (!ir.Render(frame, r.pixels.data(), r.Size(), r.type))
+                    if (!ir.Render(frame, r.pixels.data(), r.Size(), {r.width, r.height, r.channels, r.type}))
                     {
                         ErrorMessageBox box("There was an error in exporting media.", "Error", this);
                         box.exec();
@@ -577,7 +578,7 @@ void Player::RenderAnnotatedFrames()
         else if (descriptor.type == WriterType::Movie)
         {
             const Renderer::RenderData r = m_Renderer->FrameBuffer();
-            Renderer::MovieRenderer mr(descriptor.entry, r.width, r.height, r.channels);
+            Renderer::MovieRenderer mr(descriptor.entry, {r.width, r.height, r.channels, r.type});
 
             for (auto& [frame, _] : annotations)
             {
@@ -585,7 +586,7 @@ void Player::RenderAnnotatedFrames()
                 {
                     m_Renderer->Render(data.image, data.annotation);
                     const Renderer::RenderData r = m_Renderer->FrameBuffer();
-                    if (!mr.AddBuffer(r.pixels.data(), r.Size(), r.type))
+                    if (!mr.AddBuffer(r.pixels.data(), r.Size(), {r.width, r.height, r.channels, r.type}))
                     {
                         ErrorMessageBox box("There was an error in exporting media.", "Error", this);
                         box.exec();
@@ -609,11 +610,16 @@ void Player::RenderAnnotatedFrames()
 
 void Player::TranscodeMedia()
 {
-    MediaExportBrowser browser;
-    if (browser.Save())
+    const SharedMediaClip& media = m_ActiveViewBuffer->GetMediaClip();
+    if (!media->Valid())
     {
-        UIGlobals::QueueTask(new ExportMediaFramesTask(m_ActiveViewBuffer->GetMediaClip(), browser.File()));
+        ErrorMessageBox box("No valid media found in the active viewer to export.", "Error", this);
+        box.exec();
+        return;
     }
+
+    MediaExporter exporter(media);
+    exporter.exec();
 }
 
 void Player::ToggleChannels(int channel)

--- a/src/VoidUi/Tools/Delegates/LogDelegate.cpp
+++ b/src/VoidUi/Tools/Delegates/LogDelegate.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QPainter>
+
+/* Internal */
+#include "LogDelegate.h"
+#include "VoidObjects/Core/TaskLog.h"
+
+VOID_NAMESPACE_OPEN
+
+ColoredLogDelegate::ColoredLogDelegate(QObject* parent)
+    : QStyledItemDelegate(parent)
+{
+}
+
+void ColoredLogDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    painter->save();
+
+    const TaskLog::Level level = static_cast<TaskLog::Level>(
+            index.data(static_cast<int>(TaskLogModel::Roles::LevelRole)).toInt()
+        );
+
+    switch (level)
+    {
+        case TaskLog::Level::InfoLog:
+            painter->setPen(QPen(QColor(140, 230, 50)));
+            break;
+        case TaskLog::Level::WarningLog:
+            painter->setPen(QPen(QColor(230, 180, 50)));
+            break;
+        case TaskLog::Level::ErrorLog:
+            painter->setPen(QPen(QColor(210, 0, 0)));
+            break;
+    }
+
+    painter->drawText(option.rect, index.data(Qt::DisplayRole).toString());
+    painter->restore();
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Tools/Delegates/LogDelegate.h
+++ b/src/VoidUi/Tools/Delegates/LogDelegate.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _LOGGING_DELEGATE_H
+#define _LOGGING_DELEGATE_H
+
+/* Qt */
+#include <QStyledItemDelegate>
+
+/* Internal */
+#include "Definition.h"
+
+VOID_NAMESPACE_OPEN
+
+class ColoredLogDelegate : public QStyledItemDelegate
+{
+public:
+    explicit ColoredLogDelegate(QObject* parent = nullptr);
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _LOGGING_DELEGATE_H

--- a/src/VoidUi/Tools/Task.cpp
+++ b/src/VoidUi/Tools/Task.cpp
@@ -53,11 +53,11 @@ void TaskWidget::Build()
     m_Layout = new QGridLayout(this);
 
     m_TaskLabel = new QLabel;
-    m_ActionButton = new QPushButton;
+    m_ActionButton = new QToolButton;
 
     m_StateLabel = new QLabel;
     m_ProgressBar = new QProgressBar;
-    m_LogButton = new QPushButton;
+    m_LogButton = new QToolButton;
 
     m_Layout->addWidget(m_TaskLabel, 0, 0, 1, 10, Qt::AlignLeft);
     m_Layout->addWidget(m_ActionButton, 0, 10, 1, 1, Qt::AlignRight);
@@ -83,11 +83,11 @@ void TaskWidget::Connect()
         m_ProgressBar->setValue(steps);
     });
 
-    connect(m_ActionButton, &QPushButton::clicked, this, [this]() -> void
+    connect(m_ActionButton, &QToolButton::clicked, this, [this]() -> void
     {
         m_ActionState == ActionState::Cancel ? Cancel() : Restart();
     });
-    connect(m_LogButton, &QPushButton::clicked, this, &TaskWidget::ShowLog);
+    connect(m_LogButton, &QToolButton::clicked, this, &TaskWidget::ShowLog);
 }
 
 void TaskWidget::Setup()
@@ -95,6 +95,9 @@ void TaskWidget::Setup()
     m_TaskLabel->setText(Label());
     m_LogButton->setIcon(IconForge::GetIcon(IconType::icon_assignment, _DARK_COLOR(QPalette::Text, 100)));
     m_ProgressBar->setVisible(false);
+
+    m_ActionButton->setAutoRaise(true);
+    m_LogButton->setAutoRaise(true);
 
     UpdateActionState(ActionState::Cancel);
     UpdateState(m_Task->State());
@@ -153,6 +156,9 @@ QString TaskWidget::Label()
 
 void TaskWidget::Cancel()
 {
+    if (!m_Task || m_Task->Completed())
+        return;
+
     UpdateState(m_Task->Started() ? TaskState::Cancelling : TaskState::Cancelled);
     m_Task->Cancel();
     UpdateActionState(ActionState::Retry);

--- a/src/VoidUi/Tools/Task.h
+++ b/src/VoidUi/Tools/Task.h
@@ -8,7 +8,7 @@
 #include <QLabel>
 #include <QLayout>
 #include <QProgressBar>
-#include <QPushButton>
+#include <QToolButton>
 #include <QWidget>
 
 /* Internal */
@@ -45,8 +45,8 @@ private: /* Members */
     QGridLayout* m_Layout;
     QLabel* m_TaskLabel;
     QLabel* m_StateLabel;
-    QPushButton* m_LogButton;
-    QPushButton* m_ActionButton;
+    QToolButton* m_LogButton;
+    QToolButton* m_ActionButton;
     QProgressBar* m_ProgressBar;
 
     Task* m_Task;

--- a/src/include/FormatForge.h
+++ b/src/include/FormatForge.h
@@ -22,7 +22,7 @@ VOID_NAMESPACE_OPEN
 using PixForge = std::function<std::unique_ptr<VoidPixReader>(const std::string&, v_frame_t)>;
 using MPixForge = std::function<std::unique_ptr<VoidMPixReader>(const std::string&, v_frame_t)>;
 using IOpForge = std::function<std::unique_ptr<ImageOp>()>;
-using PixWriterForge = std::function<std::unique_ptr<PixWriter>(int, int, int, const WriterType&)>;
+using PixWriterForge = std::function<std::unique_ptr<PixWriter>(const EncodeSpec&)>;
 
 /**
  * Registry describing the Plugin
@@ -96,8 +96,8 @@ public:
     std::unique_ptr<VoidPixReader> GetImageReader(const std::string& extension, const std::string& path, v_frame_t framenumber = 0) const;
     std::unique_ptr<VoidMPixReader> GetMovieReader(const std::string& extension, const std::string& path, v_frame_t framenumber = 0) const;
     std::unique_ptr<ImageOp> GetImageOp(const std::string& name) const;
-    std::unique_ptr<PixWriter> GetImageWriter(const std::string& extension, int width, int height, int channels, const WriterType& type) const;
-    std::unique_ptr<PixWriter> GetMovieWriter(const std::string& extension, int width, int height, int channels, const WriterType& type) const;
+    std::unique_ptr<PixWriter> GetImageWriter(const std::string& extension, const EncodeSpec& spec) const;
+    std::unique_ptr<PixWriter> GetMovieWriter(const std::string& extension, const EncodeSpec& spec) const;
 
     inline bool IsMovie(const std::string& extension) const { return m_MovieForger.find(extension) != m_MovieForger.end(); }
     inline bool IsImage(const std::string& extension) const { return m_ImageForger.find(extension) != m_ImageForger.end(); }

--- a/src/include/PixWriter.h
+++ b/src/include/PixWriter.h
@@ -38,7 +38,6 @@ enum class MovieCodec : uint8_t
 struct EncodeSpec
 {
     int width, height;
-    int outwidth, outheight;
     int channels;
     float rate = { 24.f };
     BufferType type = { BufferType::Uint8 };
@@ -46,14 +45,10 @@ struct EncodeSpec
     bool respeed = { false };
 
     EncodeSpec(int w, int h, int ch, const BufferType& ty)
-        : width(w), height(h), outwidth(w), outheight(h), channels(ch), type(ty) {}
+        : width(w), height(h), channels(ch), type(ty) {}
 
-    EncodeSpec(int w, int h, int outw, int outh, int ch, const BufferType& ty)
-        : width(w), height(h), outwidth(outw), outheight(outh), channels(ch), type(ty) {}
-
-    EncodeSpec(int w, int h, int outw, int outh, int ch, float r, const BufferType& ty, const MovieCodec& codec, bool respeed)
-        : width(w), height(h), outwidth(outw), outheight(outh)
-        , channels(ch), rate(r), type(ty), codec(codec), respeed(respeed) {}
+    EncodeSpec(int w, int h, int ch, float r, const BufferType& ty, const MovieCodec& codec, bool respeed)
+        : width(w), height(h), channels(ch), rate(r), type(ty), codec(codec), respeed(respeed) {}
 };
 
 struct InputSpec
@@ -68,8 +63,6 @@ struct InputSpec
 class PixWriter
 {
 public:
-    // PixWriter(int width, int height, int channels, const WriterType& type = WriterType::Image) : PixWriter(width, height, channels, type) {}
-    // PixWriter(int width, int height, int channels, const WriterType& type) : m_Width(width), m_Height(height), m_Channels(channels), m_Type(type) {}
     PixWriter(const EncodeSpec& spec) : m_Spec(spec) {}
     virtual ~PixWriter() = default;
 
@@ -79,9 +72,6 @@ public:
     virtual void Cleanup() = 0;
 
 protected:
-    // WriterType m_Type;
-    // int m_Width, m_Height;
-    // int m_Channels;
     EncodeSpec m_Spec;
 };
 

--- a/src/include/PixWriter.h
+++ b/src/include/PixWriter.h
@@ -19,29 +19,70 @@ enum class WriterType
     Movie
 };
 
-enum class BufferType
+enum class BufferType : uint8_t
 {
     Uint8,
     Uint16,
     Float
 };
 
+enum class MovieCodec : uint8_t
+{
+    H264,
+    DNXHD,
+    MJPEG,
+    MPEG4,
+    PRORES
+};
+
+struct EncodeSpec
+{
+    int width, height;
+    int outwidth, outheight;
+    int channels;
+    float rate = { 24.f };
+    BufferType type = { BufferType::Uint8 };
+    MovieCodec codec = { MovieCodec::H264 };
+    bool respeed = { false };
+
+    EncodeSpec(int w, int h, int ch, const BufferType& ty)
+        : width(w), height(h), outwidth(w), outheight(h), channels(ch), type(ty) {}
+
+    EncodeSpec(int w, int h, int outw, int outh, int ch, const BufferType& ty)
+        : width(w), height(h), outwidth(outw), outheight(outh), channels(ch), type(ty) {}
+
+    EncodeSpec(int w, int h, int outw, int outh, int ch, float r, const BufferType& ty, const MovieCodec& codec, bool respeed)
+        : width(w), height(h), outwidth(outw), outheight(outh)
+        , channels(ch), rate(r), type(ty), codec(codec), respeed(respeed) {}
+};
+
+struct InputSpec
+{
+    int width, height;
+    int channels;
+    BufferType type = { BufferType::Uint8 };
+
+    InputSpec(int w, int h, int ch, const BufferType& type) : width(w), height(h), channels(ch), type(type) {}
+};
+
 class PixWriter
 {
 public:
     // PixWriter(int width, int height, int channels, const WriterType& type = WriterType::Image) : PixWriter(width, height, channels, type) {}
-    PixWriter(int width, int height, int channels, const WriterType& type) : m_Width(width), m_Height(height), m_Channels(channels), m_Type(type) {}
+    // PixWriter(int width, int height, int channels, const WriterType& type) : m_Width(width), m_Height(height), m_Channels(channels), m_Type(type) {}
+    PixWriter(const EncodeSpec& spec) : m_Spec(spec) {}
     virtual ~PixWriter() = default;
 
     virtual bool Setup(const std::string& path) = 0;
-    virtual bool AddBuffer(const void* buffer, std::size_t size, const BufferType& type) = 0;
+    virtual bool AddBuffer(const void* buffer, std::size_t size, const InputSpec& spec) = 0;
     virtual bool Write() = 0;
     virtual void Cleanup() = 0;
 
 protected:
-    WriterType m_Type;
-    int m_Width, m_Height;
-    int m_Channels;
+    // WriterType m_Type;
+    // int m_Width, m_Height;
+    // int m_Channels;
+    EncodeSpec m_Spec;
 };
 
 VOID_NAMESPACE_CLOSE


### PR DESCRIPTION
## Feat: Provide options to the user for exporting Media
* Updated the base input for the PixWriter constructor to be struct EncodeSpec.
* EncodeSpec is a representation of how the encoded output is supposed to be.
* AddBuffer method now takes in InputSpec which holds the information about the provided input.
* TaskUI in the task Queue now uses a QToolButton in place of the regular push button purely because of the the autoRaise functionality.
* Added base exporter options.
* Added Media Exporter which takes in the active media from the buffer and provides user a way to set the export through options.
* Player uses MediaExporter directly.
* Media exporter validates the user settings before proceeding for render to reduce the errors during Render phase.
* OpenImageIO writer uses ImageBufAlgo::resize for resizing the buffer before writing to the output file.

### Fixes:
* Fixed the issue of missing frames for h.264 codec.
* Ensure to handle all supported codec types for writing to movie file.

### Additional changes
* MEntry gets a bool operator method overload.
* Self setting for HighDPI is set only on Qt5, as in qt6 it appears to be enabled by default and throws warning while compiling.
* FFmpeg Metadata now includes codec metadata.