### PR TITLE
[VOID] Exporter: Support for Color Transforms before writing media

### DIFF
--- a/config/void-default.ocio
+++ b/config/void-default.ocio
@@ -73,7 +73,7 @@ displays:
 
 active_displays: [sRGB, Rec.709, Rec.2020, P3-D60, P3-D65, P3-DCI, None]
 active_views: [ACES 1.0 - SDR Video, ACES 1.0 - SDR Video (D60 sim on D65), ACES 1.1 - SDR Video (P3 lim), ACES 1.1 - SDR Video (Rec.709 lim), ACES 1.1 - HDR Video (1000 nits & Rec.2020 lim), ACES 1.1 - HDR Video (2000 nits & Rec.2020 lim), ACES 1.1 - HDR Video (4000 nits & Rec.2020 lim), ACES 1.1 - HDR Video (1000 nits & P3 lim), ACES 1.1 - HDR Video (2000 nits & P3 lim), ACES 1.1 - HDR Video (4000 nits & P3 lim), ACES 1.0 - SDR Cinema, ACES 1.1 - SDR Cinema (D60 sim on D65), ACES 1.1 - SDR Cinema (Rec.709 lim), ACES 1.0 - SDR Cinema (D60 sim on DCI), ACES 1.1 - SDR Cinema (D65 sim on DCI), ACES 1.1 - HDR Cinema (108 nits & P3 lim), Un-tone-mapped, Raw]
-inactive_colorspaces: [CIE-XYZ-D65, sRGB, Rec.709, Rec.2020, sRGB, Rec.709, Rec.2020, Rec.2020, Rec.2100-HLG - Display, Rec.2100-PQ - Display, Rec.2100-PQ - Display, Rec.2100-PQ - Display, ST2084-P3-D65, ST2084-P3-D65, ST2084-P3-D65, P3-D60, P3-D65, P3-D65, P3-D65, P3-DCI, P3-DCI, ST2084-P3-D65]
+inactive_colorspaces: [CIE-XYZ-D65, Rec.2100-HLG - Display, Rec.2100-PQ - Display, Rec.2100-PQ - Display, Rec.2100-PQ - Display, ST2084-P3-D65, ST2084-P3-D65, ST2084-P3-D65, P3-D60, P3-D65, P3-D65, P3-D65, P3-DCI, P3-DCI, ST2084-P3-D65]
 
 looks:
   - !<Look>

--- a/src/VoidCore/ColorProcessor.cpp
+++ b/src/VoidCore/ColorProcessor.cpp
@@ -75,16 +75,16 @@ std::vector<std::string> ColorProcessor::Views(const std::string& display) const
 
 std::vector<std::string> ColorProcessor::Colorspaces() const
 {
-    std::vector<std::string> colospaces;
+    std::vector<std::string> colorspaces;
 
     /* Number of Colorspaces */
     int num = m_Config->getNumColorSpaces();
-    colospaces.reserve(num);
+    colorspaces.reserve(num);
 
     for (int i = 0; i < num; ++i)
-        colospaces.emplace_back(m_Config->getColorSpaceNameByIndex(i));
+        colorspaces.emplace_back(m_Config->getColorSpaceNameByIndex(i));
 
-    return colospaces;
+    return colorspaces;
 }
 
 void ColorProcessor::Create()
@@ -150,6 +150,46 @@ std::string ColorProcessor::Shader(const std::string& function) const
 
     /* The Fragment Shader Code */
     return shaderDesc->getShaderText();
+}
+
+void ColorProcessor::ProcessImage(float* pixels, int width, int height, int channels, const std::string& display) const
+{
+    const char* view = m_Config->getDefaultView(display.c_str());
+    OCIO::ConstProcessorRcPtr processor = m_Config->getProcessor(OCIO::ROLE_SCENE_LINEAR, display.c_str());
+    OCIO::ConstCPUProcessorRcPtr cpuproc = processor->getDefaultCPUProcessor();
+
+    OCIO::PackedImageDesc imgdesc(pixels, width, height, channels);
+    cpuproc->apply(imgdesc);
+}
+
+void ColorProcessor::ProcessImage(float* pixels, int width, int height, int channels, const std::string& incolorspace, const std::string& outcolorspace) const
+{
+    OCIO::ConstProcessorRcPtr processor = m_Config->getProcessor(incolorspace.c_str(), outcolorspace.c_str());
+    OCIO::ConstCPUProcessorRcPtr cpuproc = processor->getDefaultCPUProcessor();
+
+    OCIO::PackedImageDesc imgdesc(pixels, width, height, channels);
+    cpuproc->apply(imgdesc);
+}
+
+void ColorProcessor::ProcessImage(float* pixels, int width, int height, int channels, const ColorSpace& colorspace, const std::string& outcolorspace) const
+{
+    OCIO::ConstProcessorRcPtr processor = nullptr;
+    switch (colorspace)
+    {
+        case ColorSpace::Linear:
+            processor = m_Config->getProcessor(OCIO::ROLE_SCENE_LINEAR, outcolorspace.c_str());
+            break;
+        case ColorSpace::sRGB:
+            processor = m_Config->getProcessor("None", outcolorspace.c_str());
+            break;
+        default:
+            processor = m_Config->getProcessor(OCIO::ROLE_DEFAULT, outcolorspace.c_str());
+    }
+
+    OCIO::ConstCPUProcessorRcPtr cpuproc = processor->getDefaultCPUProcessor();
+
+    OCIO::PackedImageDesc imgdesc(pixels, width, height, channels);
+    cpuproc->apply(imgdesc);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/ColorProcessor.h
+++ b/src/VoidCore/ColorProcessor.h
@@ -12,6 +12,7 @@
 
 /* Internal */
 #include "Definition.h"
+#include "Colorspace.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -68,6 +69,11 @@ public:
      * Returns the Generated shader code from the Constructed GPU Processor
      */
     std::string Shader(const std::string& function) const;
+
+    // CPU processing for the image from the source to destination colorspace
+    void ProcessImage(float* pixels, int width, int height, int channels, const std::string& display) const;
+    void ProcessImage(float* pixels, int width, int height, int channels, const std::string& incolorspace, const std::string& outcolorspace) const;
+    void ProcessImage(float* pixels, int width, int height, int channels, const ColorSpace& colorspace, const std::string& outcolorspace) const;
 
 private:
     OCIO_NAMESPACE::ConstConfigRcPtr m_Config;

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -1,6 +1,17 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* STD */
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+/* FFmpeg */
+extern "C" {
+#include <libavutil/opt.h>
+#include <libavutil/imgutils.h>
+}
+
 /* Internal */
 #include "FFmpegWriter.h"
 #include "VoidCore/Logging.h"
@@ -13,8 +24,15 @@ FFmpegWriter::FFmpegWriter(const EncodeSpec& spec)
     , m_CodecCtx(nullptr)
     , m_SwsCtx(nullptr)
     , m_Stream(nullptr)
+    , m_SourceFrame(nullptr)
+    , m_DestinationFrame(nullptr)
     , m_Pts(0)
 {
+}
+
+FFmpegWriter::~FFmpegWriter()
+{
+    Cleanup();
 }
 
 bool FFmpegWriter::Setup(const std::string& path)
@@ -73,46 +91,36 @@ bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const InputSp
         return false;
 
     if (!m_SwsCtx)
+        InitFrameContext(spec);
+
+    switch (spec.type)
     {
-        m_SwsCtx = sws_getContext(
-            spec.width,
-            spec.height,
-            spec.channels == 3 ? AV_PIX_FMT_RGB24 : AV_PIX_FMT_RGBA,
-            m_Spec.width,
-            m_Spec.height,
-            PixelFormat(),
-            SWS_BILINEAR,
-            nullptr,
-            nullptr,
-            nullptr
-        );
+        case BufferType::Float:
+            CopyBuffer(static_cast<const float*>(buffer), m_SourceFrame->data[0], size);
+            break;
+        case BufferType::Uint16:
+            CopyBuffer(static_cast<const uint16_t*>(buffer), m_SourceFrame->data[0], size);
+            break;
+        case BufferType::Uint8:
+        default:
+            CopyBuffer(static_cast<const uint8_t*>(buffer), m_SourceFrame->data[0], size);
     }
 
-    AVFrame* frame = av_frame_alloc();
-    frame->format = m_CodecCtx->pix_fmt;
-    frame->width = m_CodecCtx->width;
-    frame->height = m_CodecCtx->height;
+    sws_scale(
+        m_SwsCtx,
+        m_SourceFrame->data, m_SourceFrame->linesize,
+        0, spec.height,
+        m_DestinationFrame->data, m_DestinationFrame->linesize
+    );
 
-    // 32 byte align
-    if (av_frame_get_buffer(frame, 32) < 0)
-        return false;
+    m_DestinationFrame->pts = m_Pts;
 
-    if (av_frame_make_writable(frame) < 0)
-        return false;
-
-    const uint8_t* srcSlice[1] = { static_cast<const uint8_t*>(buffer) };
-    int srcStride[1] = { m_Spec.channels * spec.width };
-
-    sws_scale(m_SwsCtx, srcSlice, srcStride, 0, spec.height, frame->data, frame->linesize);
-    frame->pts = m_Pts;
-
-    // Encode
-    int ret = avcodec_send_frame(m_CodecCtx, frame);
-    if ( ret < 0)
+    int ret = avcodec_send_frame(m_CodecCtx, m_DestinationFrame);
+    if (ret < 0)
     {
-        char errbuf[256];
-        av_strerror(ret, errbuf, sizeof(errbuf));
-        VOID_LOG_INFO("Unable to send frame: {0}, {1}, {2}", errbuf, ret, ret == AVERROR(EINVAL));
+        char err[256];
+        av_strerror(ret, err, sizeof(err));
+        VOID_LOG_ERROR("Unable to send frame: {0}, {1}, {2}", err, ret, ret == AVERROR(EINVAL));
         return false;
     }
 
@@ -127,7 +135,6 @@ bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const InputSp
     }
 
     av_packet_free(&packet);
-    av_frame_free(&frame);
     m_Pts++;
 
     return true;
@@ -139,28 +146,26 @@ bool FFmpegWriter::Write()
         return false;
 
     avcodec_send_frame(m_CodecCtx, nullptr);
-
     AVPacket* packet = av_packet_alloc();
 
     while (avcodec_receive_packet(m_CodecCtx, packet) == 0)
     {
         av_packet_rescale_ts(packet, m_CodecCtx->time_base, m_Stream->time_base);
-
         av_interleaved_write_frame(m_FormatCtx, packet);
         av_packet_unref(packet);
     }
 
     av_packet_free(&packet);
-
     av_write_trailer(m_FormatCtx);
     avio_close(m_FormatCtx->pb);
-
 
     return true;
 }
 
 void FFmpegWriter::Cleanup()
 {
+    if (m_SourceFrame) av_frame_free(&m_SourceFrame);
+    if (m_DestinationFrame) av_frame_free(&m_DestinationFrame);
     #if LIBSWSCALE_VERSION_MAJOR < 9
     if (m_SwsCtx) sws_freeContext(m_SwsCtx);
     m_SwsCtx = nullptr;
@@ -239,6 +244,71 @@ void FFmpegWriter::ContextSetup()
             // av_opt_set(m_CodecCtx->priv_data, "crf", "18", 0);
             break;
     }
+}
+
+void FFmpegWriter::InitFrameContext(const InputSpec& spec)
+{
+    m_SourceFrame = av_frame_alloc();
+    m_SourceFrame->width = spec.width;
+    m_SourceFrame->height = spec.height;
+
+    // At the moment, specifically about the 4 channel inputs, AV_PIX_FMT_RGBAF32 doesn't seem to work
+    // So using standard unsigned char buffers with RGB and RGBA formats and safely casting the data from
+    // float and uint16_t (unsigned short) buffers to unsigned char buffers for writing out
+    m_SourceFrame->format = spec.channels == 3 ? AV_PIX_FMT_RGB24 : AV_PIX_FMT_RGBA;
+
+    av_image_alloc(
+        m_SourceFrame->data,
+        m_SourceFrame->linesize,
+        spec.width,
+        spec.height,
+        (AVPixelFormat)m_SourceFrame->format,
+        32
+    );
+
+    m_DestinationFrame = av_frame_alloc();
+    m_DestinationFrame->width = m_Spec.width;
+    m_DestinationFrame->height = m_Spec.height;
+    m_DestinationFrame->format = m_CodecCtx->pix_fmt;
+
+    av_image_alloc(
+        m_DestinationFrame->data,
+        m_DestinationFrame->linesize,
+        m_Spec.width,
+        m_Spec.height,
+        (AVPixelFormat)m_DestinationFrame->format,
+        32
+    );
+
+    m_SwsCtx = sws_getContext(
+        m_SourceFrame->width,
+        m_SourceFrame->height,
+        (AVPixelFormat)m_SourceFrame->format,
+        m_DestinationFrame->width,
+        m_DestinationFrame->height,
+        (AVPixelFormat)m_DestinationFrame->format,
+        SWS_BICUBIC,
+        nullptr,
+        nullptr,
+        nullptr
+    );
+}
+
+void FFmpegWriter::CopyBuffer(const uint8_t* src, uint8_t* dest, std::size_t size)
+{
+    std::memcpy(dest, src, size);
+}
+
+void FFmpegWriter::CopyBuffer(const uint16_t* src, uint8_t* dest, std::size_t size)
+{
+    for (int i = 0; i < static_cast<int>(size); ++i)
+        dest[i] = static_cast<uint8_t>(src[i] / (UINT16_MAX / UINT8_MAX));
+}
+
+void FFmpegWriter::CopyBuffer(const float* src, uint8_t* dest, std::size_t size)
+{
+    for (int i = 0; i < static_cast<int>(size); ++i)
+        dest[i] = static_cast<uint8_t>(std::clamp(src[i], 0.f, 1.f) * 255.f);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/FFmpegWriter.h
+++ b/src/VoidCore/Writers/FFmpegWriter.h
@@ -9,7 +9,6 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
-#include <libavutil/opt.h>
 }
 
 /* Internal */
@@ -22,9 +21,10 @@ class VOID_API FFmpegWriter : public PixWriter
 {
 public:
     FFmpegWriter(const EncodeSpec& spec);
+    ~FFmpegWriter();
 
     bool Setup(const std::string& path) override;
-    bool AddBuffer(const void* buffer, std::size_t size, const InputSpec& type) override;
+    bool AddBuffer(const void* buffer, std::size_t size, const InputSpec& spec) override;
     bool Write() override;
     void Cleanup() override;
 
@@ -34,6 +34,8 @@ private: /* Members */
     SwsContext* m_SwsCtx;
     AVStream* m_Stream;
     int64_t m_Pts;
+    AVFrame* m_SourceFrame;
+    AVFrame* m_DestinationFrame;
 
     std::string m_Path;
 
@@ -41,6 +43,11 @@ private: /* Methods */
     AVCodecID Codec();
     AVPixelFormat PixelFormat();
     void ContextSetup();
+    void InitFrameContext(const InputSpec& spec);
+
+    void CopyBuffer(const uint8_t* src, uint8_t* dest, std::size_t size);
+    void CopyBuffer(const uint16_t* src, uint8_t* dest, std::size_t size);
+    void CopyBuffer(const float* src, uint8_t* dest, std::size_t size);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/OIIOWriter.cpp
+++ b/src/VoidCore/Writers/OIIOWriter.cpp
@@ -41,7 +41,11 @@ bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec
             OIIO::ImageSpec outspec(m_Spec.width, m_Spec.height, m_Spec.channels, OIIO::TypeDesc::UINT16);
             OIIO::ImageBuf outbuf(outspec, out.data());
 
+            #if OIIO_VERSION_MAJOR < 3
             status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);
+            #else
+            status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, OIIO::ImageBufAlgo::KWArgs(), roi);
+            #endif
             if (!status)
             {
                 VOID_LOG_ERROR("Unable to resize image: {0}", outbuf.geterror());
@@ -60,7 +64,11 @@ bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec
             OIIO::ImageSpec outspec(m_Spec.width, m_Spec.height, m_Spec.channels, OIIO::TypeDesc::FLOAT);
             OIIO::ImageBuf outbuf(outspec, out.data());
 
+            #if OIIO_VERSION_MAJOR < 3
             status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);
+            #else
+            status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, OIIO::ImageBufAlgo::KWArgs(), roi);
+            #endif
             if (!status)
             {
                 VOID_LOG_ERROR("Unable to resize image: {0}", outbuf.geterror());
@@ -79,7 +87,11 @@ bool OIIOWriter::AddBuffer(const void* buffer, std::size_t size, const InputSpec
             OIIO::ImageSpec outspec(m_Spec.width, m_Spec.height, m_Spec.channels, OIIO::TypeDesc::UINT8);
             OIIO::ImageBuf outbuf(outspec, out.data());
 
+            #if OIIO_VERSION_MAJOR < 3
             status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, "", 0.f, roi);
+            #else
+            status = OIIO::ImageBufAlgo::resize(outbuf, inbuf, OIIO::ImageBufAlgo::KWArgs(), roi);
+            #endif
             if (!status)
             {
                 VOID_LOG_ERROR("Unable to resize image: {0}", outbuf.geterror());

--- a/src/VoidUi/BaseWindow/WorkspaceManager.cpp
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.cpp
@@ -27,8 +27,7 @@ WorkspaceManager::~WorkspaceManager()
 void WorkspaceManager::QueueTask(Task* task)
 {
     m_TaskQueue->AddTask(task);
-    if (!m_TaskQueue->isVisible())
-        ShowComponent(Component::TaskQueue);
+    ShowComponent(Component::TaskQueue);
 }
 
 QWidget* WorkspaceManager::Widget(const Component& component) const
@@ -161,11 +160,7 @@ void WorkspaceManager::Clear()
 void WorkspaceManager::InspectMetadata(const SharedMediaClip& media)
 {
     m_MetadataViewer->SetFromMedia(media);
-
-    // Show if it's not already being shown
-    const DockStruct d = DockManager::Instance().Dock(static_cast<int>(Component::MetadataViewer));
-    if (!d.widget->isVisible())
-        ShowComponent(Component::MetadataViewer);
+    ShowComponent(Component::MetadataViewer);
 }
 
 void WorkspaceManager::UpdateMediaQueue(Playlist* playlist)
@@ -181,13 +176,16 @@ void WorkspaceManager::EditEffects(const SharedMediaClip& media)
     for (auto effect : media->Effects())
         m_PropertiesEditor->EditEffect(effect);
 
-    const DockStruct d = DockManager::Instance().Dock(static_cast<int>(Component::Properties));
-    if (!d.widget->isVisible())
-        ShowComponent(Component::Properties);
+    ShowComponent(Component::Properties);
 }
 
 void WorkspaceManager::ShowComponent(const Component& component) const
 {
+    DockStruct d = DockManager::Instance().Dock(static_cast<int>(component));
+
+    if (d.widget->isVisible() || ShowIfDocked(d.name.c_str()))
+        return;
+
     MainWindow* window = new MainWindow;
 	DockSplitter* splitter = new DockSplitter(Qt::Horizontal, window);
 	DockWidget* undocked = new DockWidget(splitter, true);
@@ -195,6 +193,21 @@ void WorkspaceManager::ShowComponent(const Component& component) const
 
 	undocked->AddDockManagerWidget(static_cast<int>(component));
 	window->show();
+}
+
+bool WorkspaceManager::ShowIfDocked(const QString& name) const
+{
+    for (const auto& docker : findChildren<DockWidget*>())
+    {
+        int id = docker->DockTabIndex(name);
+        if (id > -1)
+        {
+            docker->setCurrentIndex(id);
+            return true;
+        }
+    }
+
+    return false;
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/BaseWindow/WorkspaceManager.h
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.h
@@ -88,6 +88,7 @@ private: /* Members */
     void UpdateMediaQueue(Playlist* playlist);
     void EditEffects(const SharedMediaClip& media);
     void ShowComponent(const Component& component) const;
+    bool ShowIfDocked(const QString& name) const;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Dock/DockSplitter.cpp
+++ b/src/VoidUi/Dock/DockSplitter.cpp
@@ -61,8 +61,6 @@ int DockSplitter::AddSplitPane(int idA, int idB, const Qt::Orientation& orientat
 
 void DockSplitter::RemovePane(int index)
 {
-	VOID_LOG_INFO("INDEX: {0}", index);
-
 	QWidget* w = findChild<QWidget*>(QString::number(index));
 
 	/* Set parent of internal children as null as to not delete them when the Pane is deleted/removed */

--- a/src/VoidUi/Dock/Docker.cpp
+++ b/src/VoidUi/Dock/Docker.cpp
@@ -135,7 +135,7 @@ DockWidget::DockWidget(DockSplitter* parent, bool floating)
 	Connect();
 }
 
-void DockWidget::AddDock(QWidget* widget, const std::string& title, bool closable)
+DockPanel* DockWidget::AddDock(QWidget* widget, const std::string& title, bool closable)
 {
 	/* Create a dockable panel for the widget */
 	DockPanel* panel = new DockPanel(widget, this);
@@ -145,6 +145,8 @@ void DockWidget::AddDock(QWidget* widget, const std::string& title, bool closabl
 
 	if (closable)
 		SetTabClosable(index);
+
+	return panel;
 }
 
 void DockWidget::AddDockManagerWidget(int index)
@@ -157,7 +159,20 @@ void DockWidget::AddDockManagerWidget(int index)
 		return;
 
 	/* All Dock Manager Widgets shall be closable */
-	AddDock(d.widget, d.name, true);
+	DockPanel* panel = AddDock(d.widget, d.name, true);
+	panel->setObjectName(d.widget->objectName());
+}
+
+int DockWidget::DockTabIndex(const QString& name) const
+{
+	for (int i = 0; i < count(); ++i)
+	{
+		if (tabText(i) == name)
+			return i;
+	}
+
+	// Not found
+	return -1;
 }
 
 void DockWidget::dragEnterEvent(QDragEnterEvent* event)

--- a/src/VoidUi/Dock/Docker.h
+++ b/src/VoidUi/Dock/Docker.h
@@ -68,8 +68,10 @@ class DockWidget : public QTabWidget
 public:
 	DockWidget(DockSplitter* parent = nullptr, bool floating = false);
 
-	void AddDock(QWidget* panel, const std::string& title, bool closable = false);
+	DockPanel* AddDock(QWidget* panel, const std::string& title, bool closable = false);
 	void AddDockManagerWidget(int index);
+
+	int DockTabIndex(const QString& name) const;
 
 protected:
 	void dragEnterEvent(QDragEnterEvent* event) override;

--- a/src/VoidUi/Engine/IconTypes.h
+++ b/src/VoidUi/Engine/IconTypes.h
@@ -24,6 +24,7 @@ enum class IconType : char16_t
     icon_close              = 0xe5cd,
     icon_computer_cancel    = 0xf2f6,
     icon_delete             = 0xe872,
+    icon_deployed_cube      = 0xf720,
     icon_draw               = 0xe746,
     icon_expand_circle_down = 0xe7cd,
     icon_expand_circle_up   = 0xf5d2,

--- a/src/VoidUi/Exporter/ExportOptions.cpp
+++ b/src/VoidUi/Exporter/ExportOptions.cpp
@@ -6,6 +6,8 @@
 
 /* Internal */
 #include "ExportOptions.h"
+#include "VoidCore/ColorProcessor.h"
+#include "VoidUi/Engine/IconForge.h"
 #include "VoidUi/Tools/Delegates/LogDelegate.h"
 
 VOID_NAMESPACE_OPEN
@@ -123,6 +125,7 @@ void ExportOptions::Build()
     m_OverrideRangeCheck = new QCheckBox("Override Media Range");
 
     m_ResolutionCombo = new QComboBox;
+    m_OutColorspaceCombo = new QComboBox;
     m_OutProcessorCombo = new QComboBox;
 
     m_MovieGroup = new QGroupBox("Movie Options:");
@@ -139,10 +142,12 @@ void ExportOptions::Build()
     optionsLayout->addWidget(m_OverrideRangeCheck, 0, 3, 1, 2);    
     optionsLayout->addWidget(new QLabel("Render Resolution:"), 1, 0, 1, 1);
     optionsLayout->addWidget(m_ResolutionCombo, 1, 1, 1, 3);
-    optionsLayout->addWidget(new QLabel("Process as:"), 2, 0, 1, 1);
-    optionsLayout->addWidget(m_OutProcessorCombo, 2, 1, 1, 3);
-    optionsLayout->addWidget(m_MovieGroup, 3, 0, 2, 5);
-    optionsLayout->addWidget(m_Logger, 5, 0, 4, 5);
+    optionsLayout->addWidget(new QLabel("Out Colorspace:"), 2, 0, 1, 1);
+    optionsLayout->addWidget(m_OutColorspaceCombo, 2, 1, 1, 3);
+    optionsLayout->addWidget(new QLabel("Process as:"), 3, 0, 1, 1);
+    optionsLayout->addWidget(m_OutProcessorCombo, 3, 1, 1, 3);
+    optionsLayout->addWidget(m_MovieGroup, 4, 0, 2, 5);
+    optionsLayout->addWidget(m_Logger, 6, 0, 4, 5);
 
     QHBoxLayout* buttonLayout = new QHBoxLayout;
 
@@ -172,6 +177,14 @@ void ExportOptions::Setup()
         "Image Sequence",
         "Movie"
     });
+
+    for (const auto& colorspace : ColorProcessor::Instance().Colorspaces())
+    {
+        m_OutColorspaceCombo->addItem(
+            IconForge::GetIcon(IconType::icon_deployed_cube, _DARK_COLOR(QPalette::Text, 100)),
+            colorspace.c_str()
+        );
+    }
 
     m_MovieGroup->setVisible(false);
 

--- a/src/VoidUi/Exporter/ExportOptions.h
+++ b/src/VoidUi/Exporter/ExportOptions.h
@@ -64,6 +64,7 @@ public:
     inline bool RangeOverridden() const { return m_OverrideRangeCheck->isChecked(); }
     inline MovieCodec Codec() const { return m_MovieOptions->Codec(); }
     inline int ScaleIndex() const { return m_ResolutionCombo->currentIndex(); }
+    inline QString Colorspace() const { return m_OutColorspaceCombo->currentText(); }
 
     inline MediaExportDescriptor FileDescriptor() const { return m_Descriptor; }
     inline void ClearLog() { m_LogModel->Clear(); }
@@ -78,6 +79,7 @@ private: /* Members */
     QLineEdit* m_EndEdit;
     QCheckBox* m_OverrideRangeCheck;
     QComboBox* m_ResolutionCombo;
+    QComboBox* m_OutColorspaceCombo;
     QComboBox* m_OutProcessorCombo;
 
     QGroupBox* m_MovieGroup;

--- a/src/VoidUi/Exporter/Exporter.cpp
+++ b/src/VoidUi/Exporter/Exporter.cpp
@@ -3,6 +3,7 @@
 
 /* Internal */
 #include "Exporter.h"
+#include "VoidCore/ColorProcessor.h"
 #include "VoidUi/Player/Player.h"
 #include "VoidCore/Media/Renderer.h"
 
@@ -97,13 +98,25 @@ bool ExportAnnotatedFramesTask::Work()
 
 /// ExportMediaFramesTask
 
-ExportMediaFramesTask::ExportMediaFramesTask(const SharedMediaClip& media, const MediaExportDescriptor& descriptor, const EncodeSpec& spec, const MFrameRange& range)
+ExportMediaFramesTask::ExportMediaFramesTask(const SharedMediaClip& media, const MediaExportDescriptor& descriptor, const EncodeSpec& spec, const MFrameRange& range, const std::string& colorspace)
     : Task("Transcode Media")
     , m_Media(media)
     , m_Descriptor(descriptor)
     , m_Spec(spec)
     , m_Range(range)
+    , m_Colorspace(colorspace)
 {
+}
+
+void ExportMediaFramesTask::ProcessImage(const void* pixels, int width, int height, int channels, const ColorSpace& incolorspace)
+{
+    const unsigned char* cpixels = static_cast<const unsigned char*>(pixels);
+
+    for (int i = 0; i < (width * height * channels); ++i)
+        m_Pixels[i] = cpixels[i] / 255.0f;
+
+    // Image processing
+    ColorProcessor::Instance().ProcessImage(m_Pixels.data(), width, height, channels, incolorspace, m_Colorspace);
 }
 
 bool ExportMediaFramesTask::Work()
@@ -112,6 +125,9 @@ bool ExportMediaFramesTask::Work()
     {
         int count = 0;
         SetMax(m_Range.duration);
+
+        // All the media frames would have the same size
+        m_Pixels.resize(media->FirstImage()->FrameSize());
 
         if (m_Descriptor.type == WriterType::Image)
         {
@@ -134,7 +150,7 @@ bool ExportMediaFramesTask::Work()
                 );
 
             Renderer::ImageRenderer ir(m_Descriptor.entry, m_Spec);
-    
+
             for (int i = m_Range.startframe; i <= m_Range.endframe; ++i)
             {
                 // Check for whether the task was cancelled
@@ -148,7 +164,10 @@ bool ExportMediaFramesTask::Work()
                 }
 
                 SharedPixels image = media->Image(i);
-                if (!ir.Render(i, image->Pixels(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Uint8}))
+
+                /// Colorspace processor
+                ProcessImage(image->Pixels(), image->Width(), image->Height(), image->Channels(), image->InputColorSpace());
+                if (!ir.Render(i, m_Pixels.data(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Float}))
                 {
                     Log(QString("Unable to render current frame: %1").arg(i), TaskLog::Level::ErrorLog);
                     return false;
@@ -178,9 +197,9 @@ bool ExportMediaFramesTask::Work()
                     .arg(m_Range.endframe),
                 TaskLog::Level::InfoLog
             );
-            
+
             Renderer::MovieRenderer mr(m_Descriptor.entry, m_Spec);
-    
+
             for (int i = m_Range.startframe; i <= m_Range.endframe; ++i)
             {
                 // Check for whether the task was cancelled
@@ -194,7 +213,10 @@ bool ExportMediaFramesTask::Work()
                 }
 
                 SharedPixels image = media->Image(i);
-                if (!mr.AddBuffer(image->Pixels(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Uint8}))
+
+                /// Colorspace processor
+                ProcessImage(image->Pixels(), image->Width(), image->Height(), image->Channels(), image->InputColorSpace());
+                if (!mr.AddBuffer(m_Pixels.data(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Float}))
                 {
                     Log(QString("Unable to buffer current frame: %1").arg(i), TaskLog::Level::ErrorLog);
                     return false;

--- a/src/VoidUi/Exporter/Exporter.h
+++ b/src/VoidUi/Exporter/Exporter.h
@@ -4,6 +4,9 @@
 #ifndef _PLAYER_EXPORTER_H
 #define _PLAYER_EXPORTER_H
 
+/* STD */
+#include <vector>
+
 /* Internal */
 #include "Definition.h"
 #include "VoidObjects/Core/Task.h"
@@ -31,17 +34,22 @@ private:
 class ExportMediaFramesTask : public Task
 {
 public:
-    ExportMediaFramesTask(const SharedMediaClip& media, const MediaExportDescriptor& descriptor, const EncodeSpec& spec, const MFrameRange& range);
+    ExportMediaFramesTask(const SharedMediaClip& media, const MediaExportDescriptor& descriptor, const EncodeSpec& spec, const MFrameRange& range, const std::string& colorspace);
     inline std::string Label() const override { return m_Descriptor.entry.TemplatedName(); }
 
 protected:
     bool Work() override;
 
-private:
+private: /* Members */
     std::weak_ptr<MediaClip> m_Media;
     MediaExportDescriptor m_Descriptor;
     EncodeSpec m_Spec;
     MFrameRange m_Range;
+    std::string m_Colorspace;
+    std::vector<float> m_Pixels;
+
+private: /* Methods */
+    void ProcessImage(const void* pixels, int width, int height, int channels, const ColorSpace& incolorspace);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Exporter/MediaExporter.cpp
+++ b/src/VoidUi/Exporter/MediaExporter.cpp
@@ -47,7 +47,7 @@ void MediaExporter::Export()
             Codec(),
             false
         );
-        UIGlobals::QueueTask(new ExportMediaFramesTask(m_Media, m_Descriptor, spec, Range()));
+        UIGlobals::QueueTask(new ExportMediaFramesTask(m_Media, m_Descriptor, spec, Range(), Colorspace().toStdString()));
         close();
     }
 }


### PR DESCRIPTION
## Feat: Support Color transformation on the Media before writing to File(s)
* FFmpegWriter: Support for uint16_t and float buffers.
* Use ImageBufAlgo::KWargs for OpenImageIO 3.x (rids of the deprecation warnings).
* Implemented methods for colorspace processing on CPU for input images.
* Added Colorspace Combobox read from the OCIO config.
* Support for baking user selected colorspace on the image buffer before writing

## Details
As a temp measure these data buffers are casted to uint8_t type and then pushed to ffmpeg for writing.
Need to understand on the RGBAF32 as an invalid input type before allowing direct writes for additional buffers.

### Additional Changes:
* Workspace Manager now checks if a particular component has already been added to any of the child docks and shows that instead of creating a new instance.