### PR TITLE
[VOID] Image Processing Updates

### DIFF
--- a/src/VoidCore/Media/Frame.cpp
+++ b/src/VoidCore/Media/Frame.cpp
@@ -21,6 +21,7 @@ Frame::Frame(const MEntry& e)
 Frame::Frame(const MEntry& e, v_frame_t frame)
     : m_MediaEntry(e)
     , m_Framenumber(frame)
+    , m_Writable(nullptr)
 {
     /**
      * Since we have the Media Entry, we can now get the PixReader for the media type
@@ -88,7 +89,15 @@ SharedPixels Frame::Image(bool cached)
     if (cached)
         Cache();
 
-    return m_ImageData;
+    return m_Writable && !m_Writable->Empty() ? m_Writable : m_ImageData;
+}
+
+SharedPixels Frame::Writable()
+{
+    // Ensure we have the image already read, else we can't have a valid writable copy
+    Cache();
+    m_Writable = m_ImageData->Copy();
+    return m_Writable;
 }
 
 void Frame::Cache()
@@ -105,7 +114,7 @@ void Frame::Cache()
      * crashes
      */
     std::lock_guard<std::mutex> guard(m_Mutex);
-    if (m_ImageData->Empty() || m_Dirty)
+    if (m_ImageData->Empty())
     {
         m_ImageData->Read();
         m_Channels = m_ImageData->Channels();
@@ -119,6 +128,12 @@ void Frame::ClearCache(bool dirty)
         // Don't allow concurrent access when clearing the underlying data vector
         std::lock_guard<std::mutex> guard(m_Mutex);
         m_ImageData->Clear();
+    }
+    if (m_Writable && !m_Writable->Empty())
+    {
+        // Don't allow concurrent access when clearing the underlying data vector
+        std::lock_guard<std::mutex> guard(m_Mutex);
+        m_Writable->Clear();
     }
     m_Dirty = dirty;
 }

--- a/src/VoidCore/Media/Frame.cpp
+++ b/src/VoidCore/Media/Frame.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* STD */
+#include <cstring>
+
 /* Internal */
 #include "Frame.h"
 #include "FormatForge.h"
@@ -23,9 +26,7 @@ Frame::Frame(const MEntry& e, v_frame_t frame)
     , m_Framenumber(frame)
     , m_Writable(nullptr)
 {
-    /**
-     * Since we have the Media Entry, we can now get the PixReader for the media type
-     */
+    // Since we have the Media Entry, we can now get the PixReader for the media type
     m_ImageData = std::move(Forge::Instance().GetImageReader(
         m_MediaEntry.Extension(),
         m_MediaEntry.Fullpath(),
@@ -96,7 +97,18 @@ SharedPixels Frame::Writable()
 {
     // Ensure we have the image already read, else we can't have a valid writable copy
     Cache();
-    m_Writable = m_ImageData->Copy();
+
+    // Coming from the fact that everytime the Image buffer is copied into the m_Writable shared pointer
+    // We're continuously allocating and deallocating huge amounts of data
+    // instead here we allocate only once, the first time when the writable buffer does not exist
+    // next time onwards, just copy the underlying original image data onto the writable buffer
+    // save us from the extra memory alloc-dealloc
+    if (m_Writable && m_Writable->FrameSize() == m_ImageData->FrameSize())
+        std::memcpy(m_Writable->Writable(), m_ImageData->Pixels(), m_ImageData->FrameSize());
+    else
+        m_Writable = m_ImageData->Copy();
+
+    // m_Writable = m_ImageData->Copy();
     return m_Writable;
 }
 

--- a/src/VoidCore/Media/Frame.h
+++ b/src/VoidCore/Media/Frame.h
@@ -55,6 +55,7 @@ public:
      * has no effect if the frame has already been read
      */
     SharedPixels Image(bool cached = true);
+    SharedPixels Writable();
 
     /**
      * Returns the underlying metadata from the image
@@ -68,6 +69,7 @@ public:
 protected: /* Members */
     MEntry m_MediaEntry;
     SharedPixels m_ImageData;
+    SharedPixels m_Writable;
     v_frame_t m_Framenumber;
     int m_Channels = {0};
     bool m_Dirty = {false};

--- a/src/VoidCore/Operators/Grader.cpp
+++ b/src/VoidCore/Operators/Grader.cpp
@@ -3,6 +3,7 @@
 
 /* STD */
 #include <algorithm>
+#include <cmath>
 
 /* Internal */
 #include "Grader.h"
@@ -28,6 +29,9 @@ bool GradeOp::Evaluate(ImageRow& row)
     const float r = m_RedGain->GetFloat();
     const float g = m_GreenGain->GetFloat();
     const float b = m_BlueGain->GetFloat();
+
+    // VOID_LOG_INFO("R: {0}, G: {1}, B: {2}", r, g, b);
+
     // const float r = 1.0;
     // const float g = 1.0;
     // const float b = 1.0;
@@ -48,6 +52,52 @@ bool GradeOp::Evaluate(ImageRow& row)
         pixel[0] = std::clamp(static_cast<int>(pixel[0] * r), 0, 255);
         pixel[1] = std::clamp(static_cast<int>(pixel[1] * g), 0, 255);
         pixel[2] = std::clamp(static_cast<int>(pixel[2] * b), 0, 255);
+    }
+
+    return true;
+}
+
+Grade2::Grade2()
+{
+    m_Blackpoint = AddParam(Param("blackpoint", "Blackpoint", 0.f, Param::TypeDesc::Float));
+    m_Whitepoint = AddParam(Param("whitepoint", "Whitepoint", 1.f, Param::TypeDesc::Float));
+    m_Lift = AddParam(Param("lift", "Lift", 0.f, Param::TypeDesc::Float));
+    m_Gain = AddParam(Param("gain", "Gain", 1.f, Param::TypeDesc::Float));
+    m_Multiply = AddParam(Param("multiply", "Multiply", 1.f, Param::TypeDesc::Float));
+    m_Offset = AddParam(Param("offset", "Offset", 0.f, Param::TypeDesc::Float));
+    m_Gamma = AddParam(Param("gamma", "Gamma", 1.f, Param::TypeDesc::Float));
+}
+
+bool Grade2::Evaluate(ImageRow& row)
+{
+    const float blackpoint = m_Blackpoint->GetFloat();
+    const float whitepoint = m_Whitepoint->GetFloat();
+    const float lift = m_Lift->GetFloat();
+    const float gain = m_Gain->GetFloat();
+    const float multiply = m_Multiply->GetFloat();
+    const float offset = m_Offset->GetFloat();
+    const float gamma = m_Gamma->GetFloat();
+
+    // Based on formula from https://www.chrisbturner.com/blog/nukes-grade-node-demystified
+    // pow((((value - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma))
+    for (std::size_t i = 0; i < row.width; ++i)
+    {
+        unsigned char* pixel = row.Pixel<unsigned char>(i);
+        for (std::size_t channel = 0; channel < row.channels; ++channel)
+        {
+            float value = pixel[channel] / 255.f;
+
+            // value = (value - blackpoint) / (whitepoint - blackpoint);
+            // value = (value + lift) * gain;
+            // value = value * multiply + offset;
+            // value = std::pow(value, gamma);
+            value = std::pow((((value - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+
+            // pixel[channel] = static_cast<unsigned char>(std::clamp<int>())
+            // value = std::max(0.f, )
+            // value = std::clamp<float>(value, 0.f, 1.f);
+            pixel[channel] = static_cast<unsigned char>(std::clamp<float>(value, 0.f, 1.f) * 255.f);
+        }
     }
 
     return true;

--- a/src/VoidCore/Operators/Grader.cpp
+++ b/src/VoidCore/Operators/Grader.cpp
@@ -14,9 +14,9 @@ VOID_NAMESPACE_OPEN
 GradeOp::GradeOp()
 {
     // std::string gain = "r_gain";
-    m_RedGain = AddParam(Param("r_gain", "Red", 1.f, Param::TypeDesc::Float));
-    m_GreenGain = AddParam(Param("g_gain", "Green", 1.f, Param::TypeDesc::Float));
-    m_BlueGain = AddParam(Param("b_gain", "Blue", 1.f, Param::TypeDesc::Float));
+    m_RedGain = AddParam("r_gain", "Red", 1.f, Param::TypeDesc::Float);
+    m_GreenGain = AddParam("g_gain", "Green", 1.f, Param::TypeDesc::Float);
+    m_BlueGain = AddParam("b_gain", "Blue", 1.f, Param::TypeDesc::Float);
     // m_GreenGain = Add
 }
 
@@ -59,17 +59,45 @@ bool GradeOp::Evaluate(ImageRow& row)
 
 Grade2::Grade2()
 {
-    m_Blackpoint = AddParam(Param("blackpoint", "Blackpoint", 0.f, Param::TypeDesc::Float));
-    m_Whitepoint = AddParam(Param("whitepoint", "Whitepoint", 1.f, Param::TypeDesc::Float));
-    m_Lift = AddParam(Param("lift", "Lift", 0.f, Param::TypeDesc::Float));
-    m_Gain = AddParam(Param("gain", "Gain", 1.f, Param::TypeDesc::Float));
-    m_Multiply = AddParam(Param("multiply", "Multiply", 1.f, Param::TypeDesc::Float));
-    m_Offset = AddParam(Param("offset", "Offset", 0.f, Param::TypeDesc::Float));
-    m_Gamma = AddParam(Param("gamma", "Gamma", 1.f, Param::TypeDesc::Float));
+    m_ChannelRed = AddParam("channel_red", "Red", true, Param::TypeDesc::Boolean);
+    m_ChannelGreen = AddParam("channel_green", "Green", true, Param::TypeDesc::Boolean);
+    m_ChannelBlue = AddParam("channel_blue", "Blue", true, Param::TypeDesc::Boolean);
+
+    m_Blackpoint = AddParam(
+        "blackpoint", "Blackpoint", "Defines input values that maps to pure black.",
+        0.f, ParamRange(-1.f, 1.f, 0.01f), Param::TypeDesc::Float
+    );
+    m_Whitepoint = AddParam(
+        "whitepoint", "Whitepoint", "Defines input values that maps to pure white.",
+        1.f, ParamRange(1.f, 4.f, 0.01f), Param::TypeDesc::Float
+    );
+    m_Lift = AddParam(
+        "lift", "Lift", "Adjusts the brightness of shadows.",
+        0.f, ParamRange(-1.f, 1.f, 0.1f), Param::TypeDesc::Float
+    );
+    m_Gain = AddParam(
+        "gain", "Gain", "Scales the intensity of highlights.",
+        1.f, ParamRange(0.f, 4.f, 0.1f), Param::TypeDesc::Float
+    );
+    m_Multiply = AddParam(
+        "multiply", "Multiply", "Scales the image brightness.",
+        1.f, ParamRange(0.f, 4.f, 0.1f), Param::TypeDesc::Float
+    );
+    m_Offset = AddParam(
+        "offset", "Offset", "Shifts brighness up or down across pixels.",
+        0.f, ParamRange(-1.f, 1.f, 0.01f), Param::TypeDesc::Float
+    );
+    m_Gamma = AddParam(
+        "gamma", "Gamma", "Controls midtones contrast with non-linear adjustment.",
+        1.f, ParamRange(0.2f, 5.f, 0.1f), Param::TypeDesc::Float
+    );
 }
 
 bool Grade2::Evaluate(ImageRow& row)
 {
+    if (row.channels < 3)
+        return false;
+
     const float blackpoint = m_Blackpoint->GetFloat();
     const float whitepoint = m_Whitepoint->GetFloat();
     const float lift = m_Lift->GetFloat();
@@ -78,25 +106,46 @@ bool Grade2::Evaluate(ImageRow& row)
     const float offset = m_Offset->GetFloat();
     const float gamma = m_Gamma->GetFloat();
 
+    const bool redchan = m_ChannelRed->GetBool();
+    const bool greenchan = m_ChannelGreen->GetBool();
+    const bool bluechan = m_ChannelBlue->GetBool();
+
     // Based on formula from https://www.chrisbturner.com/blog/nukes-grade-node-demystified
-    // pow((((value - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma))
+    // pow((((x - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma))
     for (std::size_t i = 0; i < row.width; ++i)
     {
         unsigned char* pixel = row.Pixel<unsigned char>(i);
-        for (std::size_t channel = 0; channel < row.channels; ++channel)
+
+        // Red
+        if (redchan)
         {
-            float value = pixel[channel] / 255.f;
+            float red = pixel[0] / 255.f;
+            red = std::pow((((red - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+            pixel[0] = static_cast<unsigned char>(std::clamp<float>(red, 0.f, 1.f) * 255.f);
+        }
 
-            // value = (value - blackpoint) / (whitepoint - blackpoint);
-            // value = (value + lift) * gain;
-            // value = value * multiply + offset;
-            // value = std::pow(value, gamma);
-            value = std::pow((((value - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+        // Green
+        if (greenchan)
+        {
+            float green = pixel[1] / 255.f;
+            green = std::pow((((green - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+            pixel[1] = static_cast<unsigned char>(std::clamp<float>(green, 0.f, 1.f) * 255.f);
+        }
 
-            // pixel[channel] = static_cast<unsigned char>(std::clamp<int>())
-            // value = std::max(0.f, )
-            // value = std::clamp<float>(value, 0.f, 1.f);
-            pixel[channel] = static_cast<unsigned char>(std::clamp<float>(value, 0.f, 1.f) * 255.f);
+        // Blue
+        if (bluechan)
+        {
+            float blue = pixel[2] / 255.f;
+            blue = std::pow((((blue - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+            pixel[2] = static_cast<unsigned char>(std::clamp<float>(blue, 0.f, 1.f) * 255.f);
+        }
+
+        // Alpha
+        if (row.channels > 3)
+        {
+            float alpha = pixel[3] / 255.f;
+            alpha = std::pow((((alpha - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+            pixel[3] = static_cast<unsigned char>(std::clamp<float>(alpha, 0.f, 1.f) * 255.f);
         }
     }
 

--- a/src/VoidCore/Operators/Grader.cpp
+++ b/src/VoidCore/Operators/Grader.cpp
@@ -13,11 +13,9 @@ VOID_NAMESPACE_OPEN
 
 GradeOp::GradeOp()
 {
-    // std::string gain = "r_gain";
     m_RedGain = AddParam("r_gain", "Red", 1.f, Param::TypeDesc::Float);
     m_GreenGain = AddParam("g_gain", "Green", 1.f, Param::TypeDesc::Float);
     m_BlueGain = AddParam("b_gain", "Blue", 1.f, Param::TypeDesc::Float);
-    // m_GreenGain = Add
 }
 
 bool GradeOp::Evaluate(ImageRow& row)
@@ -29,8 +27,6 @@ bool GradeOp::Evaluate(ImageRow& row)
     const float r = m_RedGain->GetFloat();
     const float g = m_GreenGain->GetFloat();
     const float b = m_BlueGain->GetFloat();
-
-    // VOID_LOG_INFO("R: {0}, G: {1}, B: {2}", r, g, b);
 
     // const float r = 1.0;
     // const float g = 1.0;

--- a/src/VoidCore/Operators/Grader.h
+++ b/src/VoidCore/Operators/Grader.h
@@ -22,6 +22,22 @@ private:
     Param* m_BlueGain;
 };
 
+class VOID_API Grade2 : public ImageOp
+{
+public:
+    Grade2();
+    bool Evaluate(ImageRow& row) override;
+
+private:
+    Param* m_Blackpoint;
+    Param* m_Whitepoint;
+    Param* m_Lift;
+    Param* m_Gain;
+    Param* m_Multiply;
+    Param* m_Offset;
+    Param* m_Gamma;
+};
+
 VOID_NAMESPACE_CLOSE
 
 #endif // _GRADE_OPERATOR_H

--- a/src/VoidCore/Operators/Grader.h
+++ b/src/VoidCore/Operators/Grader.h
@@ -29,6 +29,10 @@ public:
     bool Evaluate(ImageRow& row) override;
 
 private:
+    Param* m_ChannelRed;
+    Param* m_ChannelGreen;
+    Param* m_ChannelBlue;
+
     Param* m_Blackpoint;
     Param* m_Whitepoint;
     Param* m_Lift;

--- a/src/VoidCore/Operators/Operator.cpp
+++ b/src/VoidCore/Operators/Operator.cpp
@@ -7,22 +7,65 @@
 
 VOID_NAMESPACE_OPEN
 
-Param* ImageOp::AddParam(const Param& param)
+ImageOp::~ImageOp()
 {
-    auto [it, inserted] = m_Params.emplace(param.name, param);
-    return inserted ? &it->second : nullptr;
+    for (auto& param : m_Params)
+    {
+        if (param)
+        {
+            delete param;
+            param = nullptr;
+        }
+    }
+
+    m_Params.clear();
 }
 
-Param* ImageOp::AddParam(Param&& param)
+Param* ImageOp::AddParam(std::string name, std::string label, ParamValue value, const Param::TypeDesc& type)
 {
-    auto [it, inserted] = m_Params.emplace(param.name, std::move(param));
-    return inserted ? &it->second : nullptr;
+    // TODO: Change name and add param....
+    if (GetParam(name))
+        return nullptr;
+
+    return m_Params.emplace_back(new Param(name, label, value, type));
+}
+
+Param* ImageOp::AddParam(std::string name, std::string label, ParamValue value, ParamRange range, const Param::TypeDesc& type)
+{
+    // TODO: Change name and add param....
+    if (GetParam(name))
+        return nullptr;
+
+    return m_Params.emplace_back(new Param(name, label, value, range, type));
+}
+
+Param* ImageOp::AddParam(std::string name, std::string label, std::string description, ParamValue value, const Param::TypeDesc& type)
+{
+    // TODO: Change name and add param....
+    if (GetParam(name))
+        return nullptr;
+
+    return m_Params.emplace_back(new Param(name, label, description, value, type));
+}
+
+Param* ImageOp::AddParam(std::string name, std::string label, std::string description, ParamValue value, ParamRange range, const Param::TypeDesc& type)
+{
+    // TODO: Change name and add param....
+    if (GetParam(name))
+        return nullptr;
+
+    return m_Params.emplace_back(new Param(name, label, description, value, range, type));
 }
 
 Param* ImageOp::GetParam(const std::string& name)
 {
-    auto it = m_Params.find(name);
-    return it == m_Params.end() ? nullptr : &it->second;
+    for (auto& param : m_Params)
+    {
+        if (param->name == name)
+            return param;
+    }
+
+    return nullptr;
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Operators/Registration.h
+++ b/src/VoidCore/Operators/Registration.h
@@ -31,11 +31,21 @@ namespace Internal {
         return Forge::Instance().Register(r);
     }
 
+    bool RegisterGrade2()
+    {
+        IOpRegistry r;
+        r.name = "Grade2";
+        r.iop = []() -> std::unique_ptr<ImageOp> { return std::make_unique<Grade2>(); };
+    
+        return Forge::Instance().Register(r);
+    }
+
 } // namespace Internal
 
 void RegisterOperators()
 {
     Internal::RegisterColorGradeOp();
+    Internal::RegisterGrade2();
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -255,6 +255,22 @@ FFmpegPixReader::~FFmpegPixReader()
     Clear();
 }
 
+SharedPixels FFmpegPixReader::Copy() const
+{
+    auto copy = std::make_shared<FFmpegPixReader>(m_Path, m_Framenumber);
+    copy->m_AChannels = m_AChannels;
+    copy->m_Channels = m_Channels;
+    copy->m_Endframe = m_Endframe;
+    copy->m_Startframe = m_Startframe; 
+    copy->m_Duration = m_Duration;
+    copy->m_Framerate = m_Framerate;
+    copy->m_Width = m_Width;
+    copy->m_Height = m_Height;
+    copy->m_Pixels = m_Pixels;
+
+    return copy;
+}
+
 void FFmpegPixReader::Clear()
 {
     /* Remove any data from the pixels vector and shrink it back in place */
@@ -264,7 +280,7 @@ void FFmpegPixReader::Clear()
 
 ImageRow FFmpegPixReader::Row(std::size_t row)
 {
-    return (row >= m_Pixels.size())
+    return (row >= m_Height)
             ? ImageRow()
             : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(unsigned char));
 }

--- a/src/VoidCore/Readers/FFmpegReader.h
+++ b/src/VoidCore/Readers/FFmpegReader.h
@@ -89,6 +89,8 @@ public:
 
     virtual ~FFmpegPixReader();
 
+    SharedPixels Copy() const override;
+
     /**
      * Reads the provided image file's data into underlying structs
      */

--- a/src/VoidCore/Readers/OIIOReader.cpp
+++ b/src/VoidCore/Readers/OIIOReader.cpp
@@ -24,6 +24,18 @@ OIIOPixReader::~OIIOPixReader()
     Clear();
 }
 
+SharedPixels OIIOPixReader::Copy() const
+{
+    auto copy = std::make_shared<OIIOPixReader>(m_Path, m_Framenumber);
+    copy->m_InputColorSpace = m_InputColorSpace;
+    copy->m_Width = m_Width;
+    copy->m_Height = m_Height;
+    copy->m_Channels = m_Channels;
+    copy->m_Pixels = m_Pixels;
+
+    return copy;
+}
+
 void OIIOPixReader::Clear()
 {
     /* Remove any data from the pixels vector and shrink it back in place */
@@ -33,7 +45,7 @@ void OIIOPixReader::Clear()
 
 ImageRow OIIOPixReader::Row(std::size_t row)
 {
-    return (row >= m_Pixels.size())
+    return (row >= m_Height)
             ? ImageRow()
             : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(unsigned char));
 }

--- a/src/VoidCore/Readers/OIIOReader.h
+++ b/src/VoidCore/Readers/OIIOReader.h
@@ -20,6 +20,8 @@ public:
 
     virtual ~OIIOPixReader();
 
+    SharedPixels Copy() const override;
+
     /**
      * Reads the provided image file's data into underlying structs
      */

--- a/src/VoidCore/Readers/OpenEXRReader.cpp
+++ b/src/VoidCore/Readers/OpenEXRReader.cpp
@@ -43,6 +43,17 @@ OpenEXRReader::~OpenEXRReader()
     Clear();
 }
 
+SharedPixels OpenEXRReader::Copy() const
+{
+    auto copy = std::make_shared<OpenEXRReader>(m_Path, m_Framenumber);
+    copy->m_Channels = m_Channels;
+    copy->m_Width = m_Width;
+    copy->m_Height = m_Height;
+    copy->m_Pixels = m_Pixels;
+
+    return copy;
+}
+
 void OpenEXRReader::Clear()
 {
     /* Remove any data from the pixels vector and shrink it back in place */
@@ -52,7 +63,7 @@ void OpenEXRReader::Clear()
 
 ImageRow OpenEXRReader::Row(std::size_t row)
 {
-    return (row >= m_Pixels.size())
+    return (row >= m_Height)
             ? ImageRow()
             : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(unsigned char));
 }

--- a/src/VoidCore/Readers/OpenEXRReader.h
+++ b/src/VoidCore/Readers/OpenEXRReader.h
@@ -19,6 +19,8 @@ public:
     OpenEXRReader(const std::string& path, v_frame_t framenumber = 0);
     virtual ~OpenEXRReader();
 
+    SharedPixels Copy() const override;
+
     /**
      * Reads the provided image file's data into underlying structs
      */

--- a/src/VoidCore/Readers/TurboJpegReader.cpp
+++ b/src/VoidCore/Readers/TurboJpegReader.cpp
@@ -27,6 +27,18 @@ TurboJpegReader::~TurboJpegReader()
     Clear();
 }
 
+SharedPixels TurboJpegReader::Copy() const
+{
+    auto copy = std::make_shared<TurboJpegReader>(m_Path, m_Framenumber);
+    copy->m_InputColorSpace = m_InputColorSpace;
+    copy->m_Channels = m_Channels;
+    copy->m_Width = m_Width;
+    copy->m_Height = m_Height;
+    copy->m_Pixels = m_Pixels;
+
+    return copy;
+}
+
 void TurboJpegReader::Clear()
 {
     /* Remove any data from the pixels vector and shrink it back in place */
@@ -36,7 +48,7 @@ void TurboJpegReader::Clear()
 
 ImageRow TurboJpegReader::Row(std::size_t row)
 {
-    return (row >= m_Pixels.size())
+    return (row >= m_Height)
             ? ImageRow()
             : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(unsigned char));
 }

--- a/src/VoidCore/Readers/TurboJpegReader.h
+++ b/src/VoidCore/Readers/TurboJpegReader.h
@@ -20,6 +20,8 @@ public:
 
     virtual ~TurboJpegReader();
 
+    SharedPixels Copy() const override;
+
     /**
      * Reads the provided image file's data into underlying structs
      */

--- a/src/VoidObjects/Effects/Effects.h
+++ b/src/VoidObjects/Effects/Effects.h
@@ -53,7 +53,7 @@ public:
     Param* GetParam(const std::string& name) const { return m_Operator->GetParam(name); }
     ImageOp* ImageOperator() { return m_Operator; }
 
-    const std::map<std::string, Param>& Params() const { return m_Operator->Params(); }
+    const std::vector<Param*>& Params() const { return m_Operator->Params(); }
 
 signals:
     void updated();

--- a/src/VoidObjects/Media/MediaClip.cpp
+++ b/src/VoidObjects/Media/MediaClip.cpp
@@ -555,13 +555,12 @@ void MediaClip::Deserialize(std::istream& in)
 SharedPixels MediaClip::Evaluate(v_frame_t frame)
 {
     Frame* f = FramePtr(frame);
-    // SharedPixels ;
 
     if (f->Dirty())
     {
         // Generates a new copy everytime :(
         SharedPixels image = f->Writable();
-        // VOID_LOG_INFO("Image is Unique: {0}", image.unique());
+
         for (auto effect : m_Effects)
         {
             // Only process the effects that are enabled

--- a/src/VoidObjects/Media/MediaClip.cpp
+++ b/src/VoidObjects/Media/MediaClip.cpp
@@ -552,12 +552,16 @@ void MediaClip::Deserialize(std::istream& in)
     }
 }
 
-void MediaClip::Evaluate(v_frame_t frame)
+SharedPixels MediaClip::Evaluate(v_frame_t frame)
 {
     Frame* f = FramePtr(frame);
-    SharedPixels image = f->Image();
+    // SharedPixels ;
+
     if (f->Dirty())
     {
+        // Generates a new copy everytime :(
+        SharedPixels image = f->Writable();
+        // VOID_LOG_INFO("Image is Unique: {0}", image.unique());
         for (auto effect : m_Effects)
         {
             // Only process the effects that are enabled
@@ -566,10 +570,13 @@ void MediaClip::Evaluate(v_frame_t frame)
                 VOID_LOG_INFO("Processing {}", effect->Name());
                 ImageProcessor::Instance().ProcessImage(image, effect->ImageOperator());
             }
-
-            f->SetDirty(false);
         }
+
+        f->SetDirty(false);
+        return image;
     }
+
+    return f->Image();
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Media/MediaClip.h
+++ b/src/VoidObjects/Media/MediaClip.h
@@ -120,7 +120,14 @@ public:
 
     const char* TypeName() const override { return "Media"; }
 
-    void Evaluate(v_frame_t frame);
+    /**
+     * @brief Evaluates any effects added onto the Media, and returns the modified
+     * image buffer with effect applied on the original image data
+     * 
+     * @param frame Frame number.
+     * @return SharedPixels Image Buffer data for reading/rendering.
+     */
+    SharedPixels Evaluate(v_frame_t frame);
 
 signals: /* Signals defining any change that has happened */
     /*

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -23,8 +23,10 @@ set(SOURCES
     Dock/DockSplitter.cpp
 
     # Editors
-    Editor/Properties.cpp
     Editor/Effects.cpp
+    Editor/ParamEditor.cpp
+    Editor/Properties.cpp
+    Editor/RangedParamEditor.cpp
     
     # Core Engine Globals
     Engine/Bridge.cpp

--- a/src/VoidUi/Editor/Effects.cpp
+++ b/src/VoidUi/Editor/Effects.cpp
@@ -9,7 +9,6 @@
 
 /* Internal */
 #include "Effects.h"
-// #include "RangedParamEditor.h"
 #include "VoidUi/Player/PlayerBridge.h"
 #include "VoidUi/Engine/IconForge.h"
 #include "VoidUi/QExtensions/Slider.h"

--- a/src/VoidUi/Editor/Effects.cpp
+++ b/src/VoidUi/Editor/Effects.cpp
@@ -9,8 +9,10 @@
 
 /* Internal */
 #include "Effects.h"
+// #include "RangedParamEditor.h"
 #include "VoidUi/Player/PlayerBridge.h"
 #include "VoidUi/Engine/IconForge.h"
+#include "VoidUi/QExtensions/Slider.h"
 #include "VoidUi/QExtensions/Tooltip.h"
 
 VOID_NAMESPACE_OPEN
@@ -83,7 +85,7 @@ void EffectEditor::Build()
                 SetupBoolParam(grid, ++row, param);
                 break;
             case Param::TypeDesc::Float:
-                SetupFloatParam(grid, ++row, param);
+                param->range ? SetupFloatRangedParam(grid, ++row, param) : SetupFloatParam(grid, ++row, param);
                 break;
             case Param::TypeDesc::Int:
                 SetupIntParam(grid, ++row, param);
@@ -168,21 +170,36 @@ void EffectEditor::SetupIntParam(QGridLayout* grid, int row, const Param* param)
     }, Qt::DirectConnection);
 }
 
+void EffectEditor::SetupFloatRangedParam(QGridLayout* grid, int row, const Param* param)
+{
+    QLabel* label = new QLabel(param->label.c_str());
+    label->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+
+    QuickDoubleSlider* editor = new QuickDoubleSlider;
+
+    editor->SetRange(param->range.lower, param->range.upper);
+    editor->SetSingleStep(param->range.step);
+
+    editor->SetValue(param->GetFloat());
+    editor->setToolTip(ToolTipString(param->name, param->description).c_str());
+
+    grid->addWidget(label, row, 0, Qt::AlignRight);
+    grid->addWidget(editor, row, 1);
+
+    connect(editor, &QuickDoubleSlider::valueChanged, this, [=](double d) -> void
+    {
+        m_Effect->SetValue(param->name, static_cast<float>(d));
+        _PlayerBridge.Refresh();
+    }, Qt::DirectConnection);
+}
+
 void EffectEditor::SetupFloatParam(QGridLayout* grid, int row, const Param* param)
 {
     QLabel* label = new QLabel(param->label.c_str());
     label->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 
     QDoubleSpinBox* editor = new QDoubleSpinBox;
-    if (param->range)
-    {
-        editor->setRange(param->range.lower, param->range.upper);
-        editor->setSingleStep(param->range.step);
-    }
-    else
-    {
-        editor->setSingleStep(0.1);
-    }
+    editor->setSingleStep(0.1);
     editor->setValue(param->GetFloat());
     editor->setToolTip(ToolTipString(param->name, param->description).c_str());
 

--- a/src/VoidUi/Editor/Effects.cpp
+++ b/src/VoidUi/Editor/Effects.cpp
@@ -4,7 +4,6 @@
 /* Qt */
 #include <QCheckBox>
 #include <QDoubleSpinBox>
-#include <QFormLayout>
 #include <QPainter>
 #include <QSpinBox>
 
@@ -12,6 +11,7 @@
 #include "Effects.h"
 #include "VoidUi/Player/PlayerBridge.h"
 #include "VoidUi/Engine/IconForge.h"
+#include "VoidUi/QExtensions/Tooltip.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -73,73 +73,35 @@ void EffectEditor::Build()
     title->addWidget(m_EnableButton);
     title->addWidget(m_CloseButton);
 
-    QFormLayout* form = new QFormLayout;
-
-    for (const auto& [name, param] : m_Effect->Params())
+    QGridLayout* grid = new QGridLayout;
+    int row = 0;
+    for (const auto& param : m_Effect->Params())
     {
-        switch (param.type)
+        switch (param->type)
         {
             case Param::TypeDesc::Boolean:
-            {
-                QCheckBox* editor = new QCheckBox;
-                editor->setChecked(param.GetBool());
-                form->addRow(param.label.c_str(), editor);
-
-                connect(editor, &QCheckBox::toggled, this, [&](bool b) -> void
-                {
-                    m_Effect->SetValue(name, b);
-                    _PlayerBridge.Refresh();
-                }, Qt::DirectConnection);
+                SetupBoolParam(grid, ++row, param);
                 break;
-            }
             case Param::TypeDesc::Float:
-            {
-                QDoubleSpinBox* editor = new QDoubleSpinBox;
-                editor->setValue(param.GetFloat());
-                form->addRow(param.label.c_str(), editor);
-                editor->setSingleStep(0.1);
-
-                connect(editor, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, [&](double d) -> void
-                {
-                    m_Effect->SetValue(name, static_cast<float>(d));
-                    _PlayerBridge.Refresh();
-                }, Qt::DirectConnection);
+                SetupFloatParam(grid, ++row, param);
                 break;
-            }
             case Param::TypeDesc::Int:
-            {
-                QSpinBox* editor = new QSpinBox;
-                editor->setValue(param.GetInt());
-                form->addRow(param.label.c_str(), editor);
-
-                connect(editor, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, [&](int i) -> void
-                {
-                    m_Effect->SetValue(name, i);
-                    _PlayerBridge.Refresh();
-                }, Qt::DirectConnection);
+                SetupIntParam(grid, ++row, param);
                 break;
-            }
             case Param::TypeDesc::String:
             default:
-            {
-                QLineEdit* editor = new QLineEdit;
-                editor->setText(param.GetString().c_str());
-                form->addRow(param.label.c_str(), editor);
-
-                connect(editor, &QLineEdit::editingFinished, this, [&]() -> void
-                {
-                    m_Effect->SetValue(name, editor->text().toStdString());
-                    _PlayerBridge.Refresh();
-                }, Qt::DirectConnection);
+                SetupStringParam(grid, ++row, param);
                 break;
-            }
         }
     }
 
-    form->setContentsMargins(8, 0, 8, 8);
+    grid->setColumnStretch(0, 0);
+    grid->setColumnStretch(1, 1);
+    grid->setRowStretch(++row, 1);
+    grid->setContentsMargins(8, 0, 8, 8);
 
     m_Layout->addLayout(title);
-    m_Layout->addLayout(form);
+    m_Layout->addLayout(grid);
 }
 
 void EffectEditor::Setup()
@@ -178,6 +140,96 @@ void EffectEditor::Connect()
     connect(m_EnableButton, &QToolButton::toggled, this, [this](bool checked) -> void
     {
         m_Effect->SetEnabled(checked);
+        _PlayerBridge.Refresh();
+    }, Qt::DirectConnection);
+}
+
+void EffectEditor::SetupIntParam(QGridLayout* grid, int row, const Param* param)
+{
+    QLabel* label = new QLabel(param->label.c_str());
+    label->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+
+    QSpinBox* editor = new QSpinBox;
+    if (param->range)
+    {
+        editor->setRange(static_cast<int>(param->range.lower), static_cast<int>(param->range.upper));
+        editor->setSingleStep(static_cast<int>(param->range.step));
+    }
+    editor->setValue(param->GetInt());
+    editor->setToolTip(ToolTipString(param->name, param->description).c_str());
+
+    grid->addWidget(label, row, 0, Qt::AlignRight);
+    grid->addWidget(editor, row, 1);
+
+    connect(editor, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, [=](int i) -> void
+    {
+        m_Effect->SetValue(param->name, i);
+        _PlayerBridge.Refresh();
+    }, Qt::DirectConnection);
+}
+
+void EffectEditor::SetupFloatParam(QGridLayout* grid, int row, const Param* param)
+{
+    QLabel* label = new QLabel(param->label.c_str());
+    label->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+
+    QDoubleSpinBox* editor = new QDoubleSpinBox;
+    if (param->range)
+    {
+        editor->setRange(param->range.lower, param->range.upper);
+        editor->setSingleStep(param->range.step);
+    }
+    else
+    {
+        editor->setSingleStep(0.1);
+    }
+    editor->setValue(param->GetFloat());
+    editor->setToolTip(ToolTipString(param->name, param->description).c_str());
+
+    grid->addWidget(label, row, 0, Qt::AlignRight);
+    grid->addWidget(editor, row, 1);
+
+    connect(editor, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, [=](double d) -> void
+    {
+        m_Effect->SetValue(param->name, static_cast<float>(d));
+        _PlayerBridge.Refresh();
+    }, Qt::DirectConnection);
+}
+
+void EffectEditor::SetupBoolParam(QGridLayout* grid, int row, const Param* param)
+{
+    QLabel* label = new QLabel(param->label.c_str());
+    label->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+
+    QCheckBox* editor = new QCheckBox;
+    editor->setChecked(param->GetBool());
+    editor->setToolTip(ToolTipString(param->name, param->description).c_str());
+
+    grid->addWidget(label, row, 0, Qt::AlignRight);
+    grid->addWidget(editor, row, 1);
+
+    connect(editor, &QCheckBox::toggled, this, [=](bool b) -> void
+    {
+        m_Effect->SetValue(param->name, b);
+        _PlayerBridge.Refresh();
+    }, Qt::DirectConnection);
+}
+
+void EffectEditor::SetupStringParam(QGridLayout* grid, int row, const Param* param)
+{
+    QLabel* label = new QLabel(param->label.c_str());
+    label->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+
+    QLineEdit* editor = new QLineEdit;
+    editor->setText(param->GetString().c_str());
+    editor->setToolTip(ToolTipString(param->name, param->description).c_str());
+
+    grid->addWidget(label, row, 0, Qt::AlignRight);
+    grid->addWidget(editor, row, 1);
+
+    connect(editor, &QLineEdit::editingFinished, this, [=]() -> void
+    {
+        m_Effect->SetValue(param->name, editor->text().toStdString());
         _PlayerBridge.Refresh();
     }, Qt::DirectConnection);
 }

--- a/src/VoidUi/Editor/Effects.h
+++ b/src/VoidUi/Editor/Effects.h
@@ -45,6 +45,7 @@ private: /* Methods */
 
     // Param Setup
     void SetupIntParam(QGridLayout* layout, int row, const Param* param);
+    void SetupFloatRangedParam(QGridLayout* layout, int row, const Param* param);
     void SetupFloatParam(QGridLayout* layout, int row, const Param* param);
     void SetupBoolParam(QGridLayout* layout, int row, const Param* param);
     void SetupStringParam(QGridLayout* layout, int row, const Param* param);

--- a/src/VoidUi/Editor/Effects.h
+++ b/src/VoidUi/Editor/Effects.h
@@ -5,10 +5,10 @@
 #define _EFFECTS_EDITOR_H
 
 /* Qt */
-#include <QWidget>
 #include <QLayout>
 #include <QLineEdit>
 #include <QToolButton>
+#include <QWidget>
 
 /* Internal */
 #include "Definition.h"
@@ -42,6 +42,12 @@ private: /* Methods */
     void Build();
     void Setup();
     void Connect();
+
+    // Param Setup
+    void SetupIntParam(QGridLayout* layout, int row, const Param* param);
+    void SetupFloatParam(QGridLayout* layout, int row, const Param* param);
+    void SetupBoolParam(QGridLayout* layout, int row, const Param* param);
+    void SetupStringParam(QGridLayout* layout, int row, const Param* param);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/ParamEditor.cpp
+++ b/src/VoidUi/Editor/ParamEditor.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Internal */
+#include "ParamEditor.h"
+
+VOID_NAMESPACE_OPEN
+
+ParamEditor::ParamEditor(Param* param, QWidget* parent)
+    : QWidget(parent)
+{
+    Build();
+}
+
+ParamEditor::~ParamEditor()
+{
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void ParamEditor::Build()
+{
+    m_Layout = new QHBoxLayout(this);
+    m_Layout->setContentsMargins(0, 0, 0, 0);
+    m_Layout->addWidget(Widget());
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/ParamEditor.h
+++ b/src/VoidUi/Editor/ParamEditor.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _PARAM_EDITOR_H
+#define _PARAM_EDITOR_H
+
+/* Qt */
+#include <QLayout>
+#include <QSlider>
+#include <QLineEdit>
+#include <QWidget>
+
+/* Internal */
+#include "Definition.h"
+#include "Param.h"
+
+VOID_NAMESPACE_OPEN
+
+class ParamEditor : public QWidget
+{
+public:
+    ParamEditor(Param* param, QWidget* parent = nullptr);
+    virtual ~ParamEditor();
+
+protected:
+    virtual QWidget* Widget() = 0;
+
+protected:
+    Param* m_Param;
+
+private: /* Members */
+    QHBoxLayout* m_Layout;
+
+private: /* Methods */
+    void Build();
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _PARAM_EDITOR_H

--- a/src/VoidUi/Editor/RangedParamEditor.cpp
+++ b/src/VoidUi/Editor/RangedParamEditor.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Internal */
+#include "RangedParamEditor.h"
+
+VOID_NAMESPACE_OPEN
+
+// FloatRangedParam::FloatRangedParam(Param* param, QWidget* parent)
+//     : (param, parent)
+// {
+// }
+
+// FloatRangedParam::~FloatRangedParam()
+// {
+// }
+
+// QWidget* FloatRangedParam::Widget()
+// {
+//     m_Slider = new QuickDoubleSlider;
+//     return m_Slider;
+// }
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Editor/RangedParamEditor.h
+++ b/src/VoidUi/Editor/RangedParamEditor.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _RANGED_PARAM_EDITOR_H
+#define _RANGED_PARAM_EDITOR_H
+
+/* Qt */
+#include <QLayout>
+#include <QWidget>
+
+/* Internal */
+#include "Definition.h"
+#include "ParamEditor.h"
+#include "VoidUi/QExtensions/Slider.h"
+
+VOID_NAMESPACE_OPEN
+
+// class FloatRangedParam : public QWidget
+// {
+// public:
+//     FloatRangedParam(Param* param, QWidget* parent = nullptr);
+//     ~FloatRangedParam();
+
+// private:
+//     QHBoxLayout* m_Layout;
+//     QuickDoubleSlider* m_Slider;
+
+// private: /* Methods */
+//     void Build();
+// };
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _RANGED_PARAM_EDITOR_H

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -295,10 +295,8 @@ BufferData ViewerBuffer::ClipData(const v_frame_t frame, bool nearest)
     {
         EnsureCached(frame);
 
-        // Image Processing
-        m_Clip->Evaluate(frame);
-
-        d.image = m_Clip->Image(frame);
+        // Process the image before rendering, if any effect has been applied/pending for process
+        d.image = m_Clip->Evaluate(frame);
         d.annotation = m_Clip->Annotation(frame);
         return d;
     }

--- a/src/VoidUi/QExtensions/Slider.cpp
+++ b/src/VoidUi/QExtensions/Slider.cpp
@@ -62,21 +62,15 @@ void QuickDoubleSlider::SetValue(double value)
 
 void QuickDoubleSlider::SetMinimum(double min)
 {
+    // Ensure that we are working within the integer bounds i.e. not in decimal
+    CalculateFactor(min);
+
     if (min == 0)
-    {
-        // m_Factor = 100;
         m_Slider->setMinimum(0);
-    }
     else if (min < 0)
-    {
-        // m_Factor = std::abs(1 / min);
         m_Slider->setMinimum(min * m_Factor);
-    }
     else
-    {
-        // m_Factor = 1 / min;
         m_Slider->setMinimum(1);
-    }
 }
 
 void QuickDoubleSlider::SetMaximum(double max)
@@ -125,6 +119,27 @@ void QuickDoubleSlider::Setup()
 
         emit valueChanged(static_cast<double>(value) / m_Factor);
     });
+    connect(m_Editor, &QLineEdit::returnPressed, this, &QuickDoubleSlider::EditorUpdated);
+    connect(m_Editor, &QLineEdit::editingFinished, this, &QuickDoubleSlider::EditorUpdated);
+}
+
+void QuickDoubleSlider::EditorUpdated()
+{
+    QString text = m_Editor->text();
+    // User decided to leave this empty, in that case we want to restore the last value from the slider
+    if (text.isEmpty())
+    {
+        m_Editor->setText(QString::number(static_cast<double>(m_Slider->value()) / m_Factor));
+        return;
+    }
+
+    m_Slider->setValue(text.toDouble() * m_Factor);
+}
+
+void QuickDoubleSlider::CalculateFactor(double minimum)
+{
+    if (minimum != 0 && std::abs(minimum * m_Factor) < 1)
+        m_Factor = 1 / minimum;
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/Slider.cpp
+++ b/src/VoidUi/QExtensions/Slider.cpp
@@ -1,10 +1,15 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* Qt */
+#include <QDoubleValidator>
+
 /* Internal */
 #include "Slider.h"
 
 VOID_NAMESPACE_OPEN
+
+/// Frameless Slider
 
 FramelessSlider::FramelessSlider(QWidget* parent)
     : QWidget(parent, Qt::Popup | Qt::FramelessWindowHint)
@@ -29,6 +34,97 @@ void FramelessSlider::Build()
     m_Slider = new QSlider(Qt::Horizontal, this);
 
     m_Layout->addWidget(m_Slider);
+}
+
+/// QuickDoubleSlider
+
+QuickDoubleSlider::QuickDoubleSlider(QWidget* parent)
+    : QWidget(parent)
+    , m_Min(0)
+    , m_Max(100)
+    , m_Factor(100)
+{
+    Build();
+    Setup();
+}
+
+QuickDoubleSlider::~QuickDoubleSlider()
+{
+    m_Layout->deleteLater();
+    delete m_Layout;
+    m_Layout = nullptr;
+}
+
+void QuickDoubleSlider::SetValue(double value)
+{
+    m_Slider->setValue(value * m_Factor);
+}
+
+void QuickDoubleSlider::SetMinimum(double min)
+{
+    if (min == 0)
+    {
+        // m_Factor = 100;
+        m_Slider->setMinimum(0);
+    }
+    else if (min < 0)
+    {
+        // m_Factor = std::abs(1 / min);
+        m_Slider->setMinimum(min * m_Factor);
+    }
+    else
+    {
+        // m_Factor = 1 / min;
+        m_Slider->setMinimum(1);
+    }
+}
+
+void QuickDoubleSlider::SetMaximum(double max)
+{
+    m_Slider->setMaximum(max * m_Factor);
+}
+
+void QuickDoubleSlider::SetRange(double min, double max)
+{
+    SetMinimum(min);
+    SetMaximum(max);
+}
+
+void QuickDoubleSlider::SetSingleStep(double step)
+{
+    m_Slider->setSingleStep(step * m_Factor);
+}
+
+void QuickDoubleSlider::Build()
+{
+    m_Layout = new QHBoxLayout(this);
+
+    m_Editor = new QLineEdit;
+    m_Slider = new QSlider(Qt::Horizontal);
+
+    m_Layout->addWidget(m_Editor);
+    m_Layout->addWidget(m_Slider);
+    m_Layout->setContentsMargins(0, 0, 0, 0);
+}
+
+void QuickDoubleSlider::Setup()
+{
+    QDoubleValidator* validator = new QDoubleValidator;
+    m_Editor->setMaximumWidth(80);
+    m_Editor->setValidator(validator);
+
+    // Default
+    m_Editor->setText(QString::number(static_cast<double>(m_Slider->value()) / m_Factor));
+
+    // Connections
+    connect(m_Slider, &QSlider::valueChanged, this, [this](int value) -> void
+    {
+        bool blocked = m_Editor->blockSignals(true);
+        m_Editor->setText(QString::number(static_cast<double>(value) / m_Factor));
+        m_Editor->blockSignals(blocked);
+
+        emit valueChanged(static_cast<double>(value) / m_Factor);
+    });
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/Slider.cpp
+++ b/src/VoidUi/QExtensions/Slider.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License
 
 /* Qt */
+#include <QPainter>
 #include <QDoubleValidator>
 
 /* Internal */
@@ -34,6 +35,41 @@ void FramelessSlider::Build()
     m_Slider = new QSlider(Qt::Horizontal, this);
 
     m_Layout->addWidget(m_Slider);
+}
+
+/// Simple Slider
+
+SimpleSlider::SimpleSlider(Qt::Orientation orientation, QWidget* parent)
+    : QSlider(orientation, parent)
+{
+}
+
+void SimpleSlider::paintEvent(QPaintEvent* event)
+{
+    QPainter painter(this);
+
+    // Groove
+    painter.setPen(Qt::black);
+    painter.setBrush(palette().color(QPalette::Base));
+    painter.drawRect(0, height() * 0.25, width(), 4);
+
+    if (tickInterval())
+    {
+        for (int i = minimum(); i <= maximum(); i+= tickInterval())
+        {
+            painter.setPen(QPen(Qt::black, 1));
+            int pos = width() * (i - minimum()) / (maximum() - minimum());
+    
+            painter.drawLine(pos, height() * 0.5 + 4, pos, height());
+        }
+    }
+
+    // Handle
+    int hpos = width() * (value() - minimum()) / std::max((maximum() - minimum()), 1);
+    painter.setPen(Qt::black);
+
+    painter.setBrush(isSliderDown() ? palette().color(QPalette::Highlight) : QColor(210, 210, 210));
+    painter.drawRect(hpos - 2, height() * 0.15 , 4, height() - (height() * 0.5));
 }
 
 /// QuickDoubleSlider
@@ -94,7 +130,7 @@ void QuickDoubleSlider::Build()
     m_Layout = new QHBoxLayout(this);
 
     m_Editor = new QLineEdit;
-    m_Slider = new QSlider(Qt::Horizontal);
+    m_Slider = new SimpleSlider(Qt::Horizontal);
 
     m_Layout->addWidget(m_Editor);
     m_Layout->addWidget(m_Slider);
@@ -106,6 +142,9 @@ void QuickDoubleSlider::Setup()
     QDoubleValidator* validator = new QDoubleValidator;
     m_Editor->setMaximumWidth(80);
     m_Editor->setValidator(validator);
+
+    m_Slider->setTickPosition(QSlider::TicksBelow);
+    m_Slider->setTickInterval(m_Slider->singleStep() * m_Factor);
 
     // Default
     m_Editor->setText(QString::number(static_cast<double>(m_Slider->value()) / m_Factor));

--- a/src/VoidUi/QExtensions/Slider.cpp
+++ b/src/VoidUi/QExtensions/Slider.cpp
@@ -2,11 +2,14 @@
 // Licensed under the MIT License
 
 /* Qt */
-#include <QPainter>
 #include <QDoubleValidator>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QStyle>
 
 /* Internal */
 #include "Slider.h"
+#include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -49,27 +52,46 @@ void SimpleSlider::paintEvent(QPaintEvent* event)
     QPainter painter(this);
 
     // Groove
+    int gleft = 2;
+    int gright = width() - 2;
+    int gwidth = gright - gleft;
+
     painter.setPen(Qt::black);
-    painter.setBrush(palette().color(QPalette::Base));
-    painter.drawRect(0, height() * 0.25, width(), 4);
+    painter.setBrush(Qt::transparent);
+    painter.drawRect(0, height() * 0.25, gwidth, 4);
 
     if (tickInterval())
     {
-        for (int i = minimum(); i <= maximum(); i+= tickInterval())
+        for (int i = minimum(); i < maximum(); i+= tickInterval())
         {
             painter.setPen(QPen(Qt::black, 1));
-            int pos = width() * (i - minimum()) / (maximum() - minimum());
+            int pos = gwidth * (i - minimum()) / (maximum() - minimum());
     
             painter.drawLine(pos, height() * 0.5 + 4, pos, height());
         }
+
+        painter.drawLine(gwidth, height() * 0.5 + 4, gwidth, height());
     }
 
     // Handle
-    int hpos = width() * (value() - minimum()) / std::max((maximum() - minimum()), 1);
+    int hpos = gwidth * (value() - minimum()) / std::max((maximum() - minimum()), 1);
     painter.setPen(Qt::black);
 
     painter.setBrush(isSliderDown() ? palette().color(QPalette::Highlight) : QColor(210, 210, 210));
     painter.drawRect(hpos - 2, height() * 0.15 , 4, height() - (height() * 0.5));
+}
+
+void SimpleSlider::mouseMoveEvent(QMouseEvent* event)
+{
+	setValue(QStyle::sliderValueFromPosition(
+                minimum(),
+                maximum(),
+                event->pos().x(),
+                width(),
+                orientation() == Qt::Vertical
+            ));
+
+	SimpleSlider::mousePressEvent(event);
 }
 
 /// QuickDoubleSlider
@@ -144,7 +166,7 @@ void QuickDoubleSlider::Setup()
     m_Editor->setValidator(validator);
 
     m_Slider->setTickPosition(QSlider::TicksBelow);
-    m_Slider->setTickInterval(m_Slider->singleStep() * m_Factor);
+    m_Slider->setTickInterval(m_Slider->singleStep() * m_Factor / 4);
 
     // Default
     m_Editor->setText(QString::number(static_cast<double>(m_Slider->value()) / m_Factor));

--- a/src/VoidUi/QExtensions/Slider.h
+++ b/src/VoidUi/QExtensions/Slider.h
@@ -6,6 +6,7 @@
 
 /* Qt */
 #include <QWidget>
+#include <QLineEdit>
 #include <QSlider>
 #include <QLayout>
 
@@ -38,7 +39,38 @@ private: /* Members */
 
 private: /* Methods */
     void Build();
+};
 
+class QuickDoubleSlider : public QWidget
+{
+    Q_OBJECT
+public:
+    QuickDoubleSlider(QWidget* parent = nullptr);
+    ~QuickDoubleSlider();
+
+    void SetValue(double value);
+    void SetMinimum(double min);
+    void SetMaximum(double max);
+    void SetRange(double min, double max);
+    void SetSingleStep(double step);
+
+    double Value() const { return m_Editor->text().toDouble(); }
+
+signals:
+    void valueChanged(double);
+
+private: /* Members */
+    QHBoxLayout* m_Layout;
+    QLineEdit* m_Editor;
+    QSlider* m_Slider;
+
+    int m_Min;
+    int m_Max;
+    unsigned int m_Factor;
+
+private: /* Methods */
+    void Build();
+    void Setup();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/Slider.h
+++ b/src/VoidUi/QExtensions/Slider.h
@@ -48,6 +48,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
 };
 
 class QuickDoubleSlider : public QWidget

--- a/src/VoidUi/QExtensions/Slider.h
+++ b/src/VoidUi/QExtensions/Slider.h
@@ -41,6 +41,15 @@ private: /* Methods */
     void Build();
 };
 
+class SimpleSlider : public QSlider
+{
+public:
+    SimpleSlider(Qt::Orientation orientation, QWidget* parent = nullptr);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+};
+
 class QuickDoubleSlider : public QWidget
 {
     Q_OBJECT
@@ -62,7 +71,7 @@ signals:
 private: /* Members */
     QHBoxLayout* m_Layout;
     QLineEdit* m_Editor;
-    QSlider* m_Slider;
+    SimpleSlider* m_Slider;
 
     int m_Min;
     int m_Max;

--- a/src/VoidUi/QExtensions/Slider.h
+++ b/src/VoidUi/QExtensions/Slider.h
@@ -71,6 +71,8 @@ private: /* Members */
 private: /* Methods */
     void Build();
     void Setup();
+    void EditorUpdated();
+    void CalculateFactor(double minimum);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/QExtensions/Tooltip.cpp
+++ b/src/VoidUi/QExtensions/Tooltip.cpp
@@ -8,24 +8,30 @@ VOID_NAMESPACE_OPEN
 
 std::string ToolTipString(const std::string& name, const std::string& description)
 {
-    /* The HTML Elements which will be used for ToolTip Formatting */
+    if (description.empty())
+    {
+        std::string boldStart = "<b>";
+        std::string boldEnd = "</b>";
+        std::string result;
+        result.reserve(boldStart.size() + name.size() + boldEnd.size());
+
+        result.append(boldStart);
+        result.append(name);
+        result.append(boldEnd);
+
+        return result;
+    }
+
     std::string boldStart = "<b>";
     std::string boldBreak = "</b><br>";
 
     std::string result;
-    /* Reserve max size upfront */
     result.reserve(boldStart.size() + name.size() + boldBreak.size() + description.size());
-    /* Add to result */
     result.append(boldStart);
     result.append(name);
     result.append(boldBreak);
     result.append(description);
 
-    /**
-     * The resulting string is of the format
-     * <b>Name</b><br>description
-     * This format can be resolved by the QToolTip to make the name bolder and the description in the next line
-     */
     return result;
 }
 

--- a/src/include/Operator.h
+++ b/src/include/Operator.h
@@ -6,7 +6,7 @@
 
 /* STD */
 #include <memory>
-#include <map>
+#include <vector>
 
 /* Internal */
 #include "Definition.h"
@@ -18,19 +18,21 @@ VOID_NAMESPACE_OPEN
 class VOID_API ImageOp
 {
 public:
-    virtual ~ImageOp() = default;
+    virtual ~ImageOp();
 
-    Param* GetParam(const std::string& name);    
+    Param* GetParam(const std::string& name);
     virtual bool Evaluate(ImageRow& row) = 0;
 
-    const std::map<std::string, Param>& Params() const { return m_Params; }
+    const std::vector<Param*>& Params() const { return m_Params; }
 
 protected:
-    Param* AddParam(const Param& param);
-    Param* AddParam(Param&& param);
+    Param* AddParam(std::string name, std::string label, ParamValue value, const Param::TypeDesc& type);
+    Param* AddParam(std::string name, std::string label, ParamValue value, ParamRange range, const Param::TypeDesc& type);
+    Param* AddParam(std::string name, std::string label, std::string description, ParamValue value, const Param::TypeDesc& type);
+    Param* AddParam(std::string name, std::string label, std::string description, ParamValue value, ParamRange range, const Param::TypeDesc& type);
 
 private:
-    std::map<std::string, Param> m_Params;
+    std::vector<Param*> m_Params;
 };
 
 typedef std::shared_ptr<ImageOp> SharedImageOp;

--- a/src/include/Param.h
+++ b/src/include/Param.h
@@ -52,6 +52,38 @@ private:
     ValueType data;
 };
 
+/**
+ * @brief Defines the working range of the parameter
+ * Applicable only for the int and float types, this defines the upper and lower
+ * bounds on the param editor allowing users to play with the values
+ * 
+ */
+struct VOID_API ParamRange
+{
+    float lower;
+    float upper;
+    float step;
+
+    ParamRange() : ParamRange(0, 0, 0.1f) {}
+    /**
+     * @brief Construct a new Param Range
+     * 
+     * @param lower lower bound.
+     * @param upper upper bound.
+     */
+    ParamRange(float lower, float upper) : ParamRange(lower, upper, 0.1f) {}
+    /**
+     * @brief Construct a new Param Range.
+     * 
+     * @param lower lower bound.
+     * @param upper upper bound.
+     * @param step defines how much should change with each delta (increment/decrement).
+     */
+    ParamRange(float lower, float upper, float step) : lower(lower), upper(upper), step(step) {}
+
+    inline explicit operator bool() const noexcept { return lower != upper; }
+};
+
 struct VOID_API Param
 {
     enum class TypeDesc { Int, Float, Boolean, String };
@@ -62,6 +94,7 @@ struct VOID_API Param
     TypeDesc type;
     ParamValue value;
     ParamValue preset;
+    ParamRange range;
 
     Param()
         : name(""), label(""), description(""), type(TypeDesc::Int), value(0), preset(0) {}
@@ -70,9 +103,17 @@ struct VOID_API Param
         : name(std::move(name)), label(std::move(label)), description("")
         , type(type), value(value), preset(std::move(value)) {}
 
+    Param(std::string name, std::string label, ParamValue value, ParamRange range, const TypeDesc& type)
+        : name(std::move(name)), label(std::move(label)), description("")
+        , type(type), value(value), preset(std::move(value)), range(std::move(range)) {}
+
     Param(std::string name, std::string label, std::string description, ParamValue value, const TypeDesc& type)
         : name(std::move(name)), label(std::move(label)), description(std::move(description))
         , type(type), value(value), preset(std::move(value)) {}
+
+    Param(std::string name, std::string label, std::string description, ParamValue value, ParamRange range, const TypeDesc& type)
+        : name(std::move(name)), label(std::move(label)), description(std::move(description))
+        , type(type), value(value), preset(std::move(value)), range(std::move(range)) {}
 
     template <typename _Ty>
     void SetValue(_Ty v) { value.Set(v); }

--- a/src/include/PixReader.h
+++ b/src/include/PixReader.h
@@ -71,7 +71,9 @@ class VoidPixReader
 {
 public:
     VoidPixReader(const std::string& path, v_frame_t framenumber = 0) : m_Path(path), m_Framenumber(framenumber) {}
-    virtual ~VoidPixReader() {}
+    virtual ~VoidPixReader() = default;
+
+    virtual SharedPixels Copy() const = 0;
 
     /**
      * Returns the OpenGL texture type


### PR DESCRIPTION
## Feat: Updates to ImageProcessing
### Media
* Ensure that we copy the image data and then apply any processing to it.
* Use an internal writable buffer on the frame, this is only available if something was to be modified on the frame.

### Image Processor
* Added Grade2 node with similar working as the nuke one, but just the very basic variant of it, to test out workflows and Operators.
* Params on the Operators are now stored as std::vector to retain the add ordering.
* Float params with ranges use QuickDoubleSlider which is a LineEdit and a Slider, both linked to each other.

### Pending
* Began a concept of a ParamEditor, but at the moment, is not really needed as we have const Param*, so that means we can't really own the param directly through the ParamEditor cleanly (ofcourse with a const_cast but not needed at the moment).
* Will need to rethink on the ParamEditor concept, for now each of the Param types are just plain widgets in ParamEditor.
