### PR TITLE
[VOID] Linear Input Image Buffer

### DIFF
--- a/src/VoidCore/ColorProcessor.cpp
+++ b/src/VoidCore/ColorProcessor.cpp
@@ -152,19 +152,9 @@ std::string ColorProcessor::Shader(const std::string& function) const
     return shaderDesc->getShaderText();
 }
 
-void ColorProcessor::ProcessImage(float* pixels, int width, int height, int channels, const std::string& display) const
+void ColorProcessor::ProcessImage(float* pixels, int width, int height, int channels, const std::string& outcolorspace) const
 {
-    const char* view = m_Config->getDefaultView(display.c_str());
-    OCIO::ConstProcessorRcPtr processor = m_Config->getProcessor(OCIO::ROLE_SCENE_LINEAR, display.c_str());
-    OCIO::ConstCPUProcessorRcPtr cpuproc = processor->getDefaultCPUProcessor();
-
-    OCIO::PackedImageDesc imgdesc(pixels, width, height, channels);
-    cpuproc->apply(imgdesc);
-}
-
-void ColorProcessor::ProcessImage(float* pixels, int width, int height, int channels, const std::string& incolorspace, const std::string& outcolorspace) const
-{
-    OCIO::ConstProcessorRcPtr processor = m_Config->getProcessor(incolorspace.c_str(), outcolorspace.c_str());
+    OCIO::ConstProcessorRcPtr processor = processor = m_Config->getProcessor(OCIO::ROLE_SCENE_LINEAR, outcolorspace.c_str());
     OCIO::ConstCPUProcessorRcPtr cpuproc = processor->getDefaultCPUProcessor();
 
     OCIO::PackedImageDesc imgdesc(pixels, width, height, channels);

--- a/src/VoidCore/ColorProcessor.h
+++ b/src/VoidCore/ColorProcessor.h
@@ -71,8 +71,7 @@ public:
     std::string Shader(const std::string& function) const;
 
     // CPU processing for the image from the source to destination colorspace
-    void ProcessImage(float* pixels, int width, int height, int channels, const std::string& display) const;
-    void ProcessImage(float* pixels, int width, int height, int channels, const std::string& incolorspace, const std::string& outcolorspace) const;
+    void ProcessImage(float* pixels, int width, int height, int channels, const std::string& outcolorspace) const;
     void ProcessImage(float* pixels, int width, int height, int channels, const ColorSpace& colorspace, const std::string& outcolorspace) const;
 
 private:

--- a/src/VoidCore/Operators/Grader.cpp
+++ b/src/VoidCore/Operators/Grader.cpp
@@ -114,38 +114,19 @@ bool Grade2::Evaluate(ImageRow& row)
 
         // Red
         if (redchan)
-        {
-            // float red = pixel[0] / 255.f;
-            // red = std::pow((((red - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
             pixel[0] = pow((((pixel[0] - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-        }
 
         // Green
         if (greenchan)
-        {
-            // float green = pixel[1] / 255.f;
-            // green = std::pow((((green - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-            // pixel[1] = static_cast<unsigned char>(std::clamp<float>(green, 0.f, 1.f) * 255.f);
             pixel[1] = pow((((pixel[1] - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-        }
 
         // Blue
         if (bluechan)
-        {
-            // float blue = pixel[2] / 255.f;
-            // blue = std::pow((((blue - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-            // pixel[2] = static_cast<unsigned char>(std::clamp<float>(blue, 0.f, 1.f) * 255.f);
             pixel[2] = pow((((pixel[2] - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-        }
 
         // Alpha
         if (row.channels > 3)
-        {
-            // float alpha = pixel[3] / 255.f;
-            // alpha = std::pow((((alpha - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-            // pixel[3] = static_cast<unsigned char>(std::clamp<float>(alpha, 0.f, 1.f) * 255.f);
             pixel[3] = pow((((pixel[3] - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-        }
     }
 
     return true;

--- a/src/VoidCore/Operators/Grader.cpp
+++ b/src/VoidCore/Operators/Grader.cpp
@@ -43,11 +43,11 @@ bool GradeOp::Evaluate(ImageRow& row)
 
     for (std::size_t i = 0; i < row.width; ++i)
     {
-        unsigned char* pixel = row.Pixel<unsigned char>(i);
+        float* pixel = row.Pixel<float>(i);
         
-        pixel[0] = std::clamp(static_cast<int>(pixel[0] * r), 0, 255);
-        pixel[1] = std::clamp(static_cast<int>(pixel[1] * g), 0, 255);
-        pixel[2] = std::clamp(static_cast<int>(pixel[2] * b), 0, 255);
+        pixel[0] = std::clamp((pixel[0] * r), 0.f, 1.f);
+        pixel[1] = std::clamp((pixel[1] * g), 0.f, 1.f);
+        pixel[2] = std::clamp((pixel[2] * b), 0.f, 1.f);
     }
 
     return true;
@@ -110,38 +110,41 @@ bool Grade2::Evaluate(ImageRow& row)
     // pow((((x - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma))
     for (std::size_t i = 0; i < row.width; ++i)
     {
-        unsigned char* pixel = row.Pixel<unsigned char>(i);
+        float* pixel = row.Pixel<float>(i);
 
         // Red
         if (redchan)
         {
-            float red = pixel[0] / 255.f;
-            red = std::pow((((red - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-            pixel[0] = static_cast<unsigned char>(std::clamp<float>(red, 0.f, 1.f) * 255.f);
+            // float red = pixel[0] / 255.f;
+            // red = std::pow((((red - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+            pixel[0] = pow((((pixel[0] - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
         }
 
         // Green
         if (greenchan)
         {
-            float green = pixel[1] / 255.f;
-            green = std::pow((((green - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-            pixel[1] = static_cast<unsigned char>(std::clamp<float>(green, 0.f, 1.f) * 255.f);
+            // float green = pixel[1] / 255.f;
+            // green = std::pow((((green - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+            // pixel[1] = static_cast<unsigned char>(std::clamp<float>(green, 0.f, 1.f) * 255.f);
+            pixel[1] = pow((((pixel[1] - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
         }
 
         // Blue
         if (bluechan)
         {
-            float blue = pixel[2] / 255.f;
-            blue = std::pow((((blue - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-            pixel[2] = static_cast<unsigned char>(std::clamp<float>(blue, 0.f, 1.f) * 255.f);
+            // float blue = pixel[2] / 255.f;
+            // blue = std::pow((((blue - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+            // pixel[2] = static_cast<unsigned char>(std::clamp<float>(blue, 0.f, 1.f) * 255.f);
+            pixel[2] = pow((((pixel[2] - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
         }
 
         // Alpha
         if (row.channels > 3)
         {
-            float alpha = pixel[3] / 255.f;
-            alpha = std::pow((((alpha - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
-            pixel[3] = static_cast<unsigned char>(std::clamp<float>(alpha, 0.f, 1.f) * 255.f);
+            // float alpha = pixel[3] / 255.f;
+            // alpha = std::pow((((alpha - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
+            // pixel[3] = static_cast<unsigned char>(std::clamp<float>(alpha, 0.f, 1.f) * 255.f);
+            pixel[3] = pow((((pixel[3] - blackpoint) / (whitepoint - blackpoint) * ((gain * multiply) - lift)) + lift) + offset, (1 / gamma));
         }
     }
 

--- a/src/VoidCore/Operators/Inverter.cpp
+++ b/src/VoidCore/Operators/Inverter.cpp
@@ -14,14 +14,14 @@ bool InvertOp::Evaluate(ImageRow& row)
 
     for (std::size_t i = 0; i < row.width; ++i)
     {
-        unsigned char* pixel = row.Pixel<unsigned char>(i);
+        float* pixel = row.Pixel<float>(i);
 
         // Skip the alpha channel inversion, it causes issues at the moment with exr based data
         // If we go back to using exrs as float data, then it might work fine, need to check that
         // exr with float are very heavy as well (4 byte per channel vs 1 byte -- 8 bits for unsigned char), 
         // need to check that as well for later
         for (std::size_t channel = 0; channel < 3; ++channel)
-            pixel[channel] = 255 - pixel[channel];
+            pixel[channel] = 1.f - pixel[channel];
     }
 
     return true;

--- a/src/VoidCore/Operators/Registration.h
+++ b/src/VoidCore/Operators/Registration.h
@@ -7,6 +7,7 @@
 #include "Definition.h"
 #include "FormatForge.h"
 #include "Grader.h"
+#include "Inverter.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -14,7 +15,11 @@ namespace Internal {
 
     bool RegisterInvertOp()
     {
-        return false;
+        IOpRegistry r;
+        r.name = "Invert";
+        r.iop = []() -> std::unique_ptr<ImageOp> { return std::make_unique<InvertOp>(); };
+
+        return Forge::Instance().Register(r);
     }
     
     bool RegisterFlipOp()
@@ -44,6 +49,7 @@ namespace Internal {
 
 void RegisterOperators()
 {
+    Internal::RegisterInvertOp();
     Internal::RegisterColorGradeOp();
     Internal::RegisterGrade2();
 }

--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -3,6 +3,7 @@
 
 /* STD */
 #include <memory>
+#include <algorithm>
 
 /* Internal */
 #include "FFmpegReader.h"
@@ -88,8 +89,8 @@ void FFmpegDecoder::Open()
     const AVCodec* codec = avcodec_find_decoder(codecParams->codec_id);
     m_CodecContext = avcodec_alloc_context3(codec);
 
-    if (m_CodecContext->pix_fmt == AV_PIX_FMT_RGBA)
-        m_Channels = 4;
+    // if (m_CodecContext->pix_fmt == AV_PIX_FMT_RGBA)
+    //     m_Channels = 4;
 
     /* Update the codec context based on the values from the codec params */
     avcodec_parameters_to_context(m_CodecContext, codecParams);
@@ -119,7 +120,7 @@ void FFmpegDecoder::Close()
     m_StreamID = -1;
 }
 
-bool FFmpegDecoder::Decode(const std::string& path, const int framenumber, std::vector<unsigned char>& pixels)
+bool FFmpegDecoder::Decode(const std::string& path, const int framenumber, std::vector<float>& pixels)
 {
     /**
      * At the moment, this is not accessible concurrently throught multiple threads
@@ -137,15 +138,11 @@ bool FFmpegDecoder::Decode(const std::string& path, const int framenumber, std::
         Open();
     }
 
-    pixels.resize(av_image_get_buffer_size(AV_PIX_FMT_RGB24, m_Width, m_Height, 1));
+    m_Buffer.Resize(av_image_get_buffer_size(AV_PIX_FMT_RGB24, m_Width, m_Height, 1));
+    pixels.resize(m_Buffer.Size());
 
-    /* Setup data pointers */
-    av_image_fill_arrays(m_RGBFrame->data, m_RGBFrame->linesize, pixels.data(), AV_PIX_FMT_RGB24, m_Width, m_Height, 1);
+    av_image_fill_arrays(m_RGBFrame->data, m_RGBFrame->linesize, m_Buffer.Data(), AV_PIX_FMT_RGB24, m_Width, m_Height, 1);
 
-    /**
-     * Allocate the sws context
-     * not scaling the image, have set the destination width and height to be the same as the source for now
-     */
     m_SwsContext = sws_getContext(m_Width, m_Height, m_CodecContext->pix_fmt, m_Width, m_Height, AV_PIX_FMT_RGB24, SWS_BILINEAR, nullptr, nullptr, nullptr);
 
     /* Now we start */
@@ -188,8 +185,9 @@ bool FFmpegDecoder::Decode(const std::string& path, const int framenumber, std::
         }
         else if (ret == framenumber)
         {
-            /* We found the frame */
+            // Frame found, fillup the float input buffer
             found = true;
+            FillBuffer(pixels);
             break;
         }
         else if (distance > 20 && !seeked)
@@ -231,6 +229,17 @@ v_frame_t FFmpegDecoder::DecodeNextFrame(bool save)
 
     /* The decoded frame number*/
     return m_CurrentFrame;
+}
+
+void FFmpegDecoder::FillBuffer(std::vector<float>& out)
+{
+    for (std::size_t i = 0; i < (m_Width * m_Height); ++i)
+    {
+        int index = i * 3;
+        out[index] = Linear(m_Buffer[index] / 255.f);
+        out[index + 1] = Linear(m_Buffer[index + 1] / 255.f);
+        out[index + 2] = Linear(m_Buffer[index + 2] / 255.f);
+    }
 }
 
 /* }}} */
@@ -278,11 +287,34 @@ void FFmpegPixReader::Clear()
     m_Pixels.shrink_to_fit();
 }
 
+const unsigned char* FFmpegPixReader::ThumbnailPixels()
+{
+    if (m_TPixels.empty())
+    {
+        m_TPixels.resize(m_Pixels.size());
+        unsigned char* pixels = m_TPixels.data();
+
+        for (std::size_t i = 0; i < (m_Width * m_Height); ++i)
+        {
+            int index = i * m_Channels;
+
+            pixels[index] = static_cast<unsigned char>(std::clamp(m_Pixels[index], 0.f, 1.f) * 255.f);
+            pixels[index + 1] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 1], 0.f, 1.f) * 255.f);
+            pixels[index + 2] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 2], 0.f, 1.f) * 255.f);
+
+            // if (m_Channels == 4)
+            pixels[index + 3] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 3], 0.f, 1.f) * 255.f);
+        }
+    }
+
+    return m_TPixels.data();
+}
+
 ImageRow FFmpegPixReader::Row(std::size_t row)
 {
     return (row >= m_Height)
             ? ImageRow()
-            : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(unsigned char));
+            : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(float));
 }
 
 void FFmpegPixReader::ProcessInformation()
@@ -335,7 +367,6 @@ double FFmpegPixReader::Framerate()
 
 void FFmpegPixReader::Read()
 {
-    /* Decoder */
     FFmpegDecoder& decoder = FFmpegDecoder::Instance(m_Path);
     if (decoder.Decode(m_Path, m_Framenumber, m_Pixels))
     {

--- a/src/VoidCore/Readers/FFmpegReader.h
+++ b/src/VoidCore/Readers/FFmpegReader.h
@@ -25,6 +25,24 @@ extern "C"
 
 VOID_NAMESPACE_OPEN
 
+template <typename _Ty>
+struct Buffer
+{
+    std::vector<_Ty> _buf;
+    _Ty* Data() noexcept { return _buf.data(); }
+    std::size_t Size() const noexcept { return _buf.size(); }
+
+    auto operator[](std::size_t _index) { return _buf[_index]; }
+    void Resize(std::size_t size)
+    {
+        _buf.resize(size);
+
+        // The buffer was shrunk down, no need to hold the extra memory
+        if (_buf.capacity() > _buf.size())
+            _buf.shrink_to_fit();
+    }
+};
+
 class FFmpegDecoder
 {
 public:
@@ -47,7 +65,7 @@ public:
      * O(n) as the iterator might have to loop over all frames to get to the one we're looking at which also
      * caches the other frames so next frame queries could directly result in direct data transfer
      */
-    bool Decode(const std::string& path, const int framenumber, std::vector<unsigned char>& pixels);
+    bool Decode(const std::string& path, const int framenumber, std::vector<float>& pixels);
 
     [[nodiscard]] int Width() const { return m_Width; }
     [[nodiscard]] int Height() const { return m_Height; }
@@ -69,6 +87,8 @@ private: /* Members */
     AVStream* m_Stream;
     int m_StreamID;
 
+    Buffer<unsigned char> m_Buffer;
+
     std::mutex m_Mutex;
 
 private: /* Methods */
@@ -80,6 +100,8 @@ private: /* Methods */
      * returns back the frame number (converted from av time base to signed long)
      */
     v_frame_t DecodeNextFrame(bool save = true);
+    void FillBuffer(std::vector<float>& out);
+    inline static float Linear(float pixel) { return (pixel <= 0.04045f) ? pixel / 12.92f : powf((pixel + 0.055f) / 1.055f, 2.4f); }
 };
 
 class VOID_API FFmpegPixReader : public VoidMPixReader
@@ -100,7 +122,7 @@ public:
      * Returns the OpenGL data type
      * e.g. GL_UNSIGNED_BYTE, GL_FLOAT
      */
-    inline virtual unsigned int GLType() const override { return VOID_GL_UNSIGNED_BYTE; }
+    inline virtual unsigned int GLType() const override { return VOID_GL_FLOAT; }
 
     /**
      * Specifies the number of color components in the texture
@@ -129,7 +151,7 @@ public:
      * Not all frames will be used so this function can create a vector on the fly if unsigned char
      * is not the base datatype of the class
      */
-    inline virtual const unsigned char* ThumbnailPixels() override { return m_Pixels.data(); }
+    virtual const unsigned char* ThumbnailPixels() override;
 
     /**
      * Image Specifications
@@ -163,12 +185,12 @@ public:
     /**
      * Retrieve the input colorspace of the media file
      */
-    inline virtual ColorSpace InputColorSpace() const override { return ColorSpace::sRGB; }
+    inline virtual ColorSpace InputColorSpace() const override { return ColorSpace::Linear; }
 
     /**
      * Returns the Size of the frame data
      */
-    virtual size_t FrameSize() const override { return sizeof(unsigned char) * m_Pixels.size(); }
+    virtual size_t FrameSize() const override { return sizeof(float) * m_Pixels.size(); }
 
     /**
      * Read the metadata from the underlying image/frame
@@ -197,7 +219,8 @@ private: /* Members */
     double m_Framerate;
 
     /* Internal data store */
-    std::vector<unsigned char> m_Pixels;
+    std::vector<float> m_Pixels;
+    std::vector<unsigned char> m_TPixels;
 
 private: /* Methods */
     /**

--- a/src/VoidCore/Readers/OIIOReader.cpp
+++ b/src/VoidCore/Readers/OIIOReader.cpp
@@ -1,8 +1,12 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* STD */
+#include <algorithm>
+
 /* OpenImageIO */
-#include "OpenImageIO/imageio.h"
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/imagebufalgo.h>
 
 /* Internal */
 #include "OIIOReader.h"
@@ -22,6 +26,29 @@ OIIOPixReader::OIIOPixReader(const std::string& path, v_frame_t framenumber)
 OIIOPixReader::~OIIOPixReader()
 {
     Clear();
+}
+
+const unsigned char* OIIOPixReader::ThumbnailPixels()
+{
+    if (m_TPixels.empty())
+    {
+        m_TPixels.resize(m_Pixels.size());
+        unsigned char* pixels = m_TPixels.data();
+
+        for (std::size_t i = 0; i < (m_Width * m_Height); ++i)
+        {
+            int index = i * m_Channels;
+
+            pixels[index] = static_cast<unsigned char>(std::clamp(m_Pixels[index], 0.f, 1.f) * 255.f);
+            pixels[index + 1] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 1], 0.f, 1.f) * 255.f);
+            pixels[index + 2] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 2], 0.f, 1.f) * 255.f);
+
+            if (m_Channels == 4)
+                pixels[index + 3] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 3], 0.f, 1.f) * 255.f);
+        }
+    }
+
+    return m_TPixels.data();
 }
 
 SharedPixels OIIOPixReader::Copy() const
@@ -47,7 +74,7 @@ ImageRow OIIOPixReader::Row(std::size_t row)
 {
     return (row >= m_Height)
             ? ImageRow()
-            : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(unsigned char));
+            : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(float));
 }
 
 void OIIOPixReader::Read()
@@ -89,17 +116,18 @@ void OIIOPixReader::Read()
     /* Read requisites */
     int subimage = 0;
     int miplevel = 0;
-    /* Channels to read from - to */
     int chbegin = 0, chend = m_Channels;
 
-    /* Resize the Pixels */
+    std::vector<unsigned char> original(m_Width * m_Height * m_Channels);
     m_Pixels.resize(m_Width * m_Height * m_Channels);
 
-    /* Read the image pixels */
-    input->read_image(subimage, miplevel, chbegin, chend, OIIO::TypeDesc::UINT8, m_Pixels.data());
-
-    /* Close the image after reading */
+    input->read_image(subimage, miplevel, chbegin, chend, OIIO::TypeDesc::UINT8, original.data());
     input->close();
+
+    OIIO::ImageBuf src(spec, original.data());
+    OIIO::ImageBuf linear;
+    OIIO::ImageBufAlgo::colorconvert(linear, src, "sRGB", "Linear");
+    linear.get_pixels(OIIO::ROI::All(), OIIO::TypeDesc::FLOAT, m_Pixels.data());
 }
 
 const std::map<std::string, std::string> OIIOPixReader::Metadata() const

--- a/src/VoidCore/Readers/OIIOReader.h
+++ b/src/VoidCore/Readers/OIIOReader.h
@@ -31,7 +31,7 @@ public:
      * Returns the OpenGL data type
      * e.g. GL_UNSIGNED_BYTE, GL_FLOAT
      */
-    inline virtual unsigned int GLType() const override { return VOID_GL_UNSIGNED_BYTE; }
+    inline virtual unsigned int GLType() const override { return VOID_GL_FLOAT; }
 
     /**
      * Specifies the number of color components in the texture
@@ -60,7 +60,7 @@ public:
      * Not all frames will be used so this function can create a vector on the fly if unsigned char
      * is not the base datatype of the class
      */
-    inline virtual const unsigned char* ThumbnailPixels() override { return m_Pixels.data(); }
+    inline virtual const unsigned char* ThumbnailPixels() override;
 
     /**
      * Image Specifications
@@ -84,12 +84,12 @@ public:
     /**
      * Retrieve the input colorspace of the media file
      */
-    inline virtual ColorSpace InputColorSpace() const override { return m_InputColorSpace; }
+    inline virtual ColorSpace InputColorSpace() const override { return ColorSpace::Linear; }
 
     /**
      * Returns the Size of the frame data
      */
-    virtual size_t FrameSize() const override { return sizeof(unsigned char) * m_Pixels.size(); }
+    virtual size_t FrameSize() const override { return sizeof(float) * m_Pixels.size(); }
 
     /**
      * Read the metadata from the underlying image/frame
@@ -108,7 +108,8 @@ private: /* Members */
     ColorSpace m_InputColorSpace;
 
     /* Internal data store */
-    std::vector<unsigned char> m_Pixels;
+    std::vector<unsigned char> m_TPixels;
+    std::vector<float> m_Pixels;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Readers/OpenEXRReader.cpp
+++ b/src/VoidCore/Readers/OpenEXRReader.cpp
@@ -65,12 +65,28 @@ ImageRow OpenEXRReader::Row(std::size_t row)
 {
     return (row >= m_Height)
             ? ImageRow()
-            : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(unsigned char));
+            : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(float));
 }
 
 const unsigned char* OpenEXRReader::ThumbnailPixels()
 {
-    return m_Pixels.data();
+    if (m_TPixels.empty())
+    {
+        m_TPixels.resize(m_Pixels.size());
+        unsigned char* pixels = m_TPixels.data();
+
+        for (std::size_t i = 0; i < (m_Width * m_Height); ++i)
+        {
+            int index = i * m_Channels;
+
+            pixels[index] = static_cast<unsigned char>(std::clamp(m_Pixels[index], 0.f, 1.f) * 255.f);
+            pixels[index + 1] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 1], 0.f, 1.f) * 255.f);
+            pixels[index + 2] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 2], 0.f, 1.f) * 255.f);
+            pixels[index + 3] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 3], 0.f, 1.f) * 255.f);
+        }
+    }
+
+    return m_TPixels.data();
 }
 
 void OpenEXRReader::Read()
@@ -113,34 +129,21 @@ void OpenEXRReader::Read()
      * TODO: Check if we can use this data onto Renderer directly without casting this ?
      */
     /* Convert floating point exr pixels to 8-bit RGB/RGBA format */
-    std::vector<float> ipixels(m_Width * m_Height * m_Channels);
     m_Pixels.resize(m_Width * m_Height * m_Channels);
 
     for (int y = 0; y < m_Height; y++)
     {
         for (int x = 0; x < m_Width; x++)
         {
-            /* The pixel from the buffer */
             const Imf::Rgba& pixel = pixels[y][x];
-            /* Find the index at which we will be writing to on the pixel buffer */
+            // Find the index at which we will be writing to on the pixel buffer
             int index = (y * m_Width + x) * m_Channels;
 
-            ipixels[index] = pixel.r;
-            ipixels[index + 1] = pixel.g;
-            ipixels[index + 2] = pixel.b;
-            ipixels[index + 3] = pixel.a;
+            m_Pixels[index] = pixel.r;
+            m_Pixels[index + 1] = pixel.g;
+            m_Pixels[index + 2] = pixel.b;
+            m_Pixels[index + 3] = pixel.a;
         }
-    }
-
-    unsigned char* dest = m_Pixels.data();
-
-    for (size_t i = 0; i < (m_Width * m_Height); ++i)
-    {
-        int index = i * 4;
-        dest[index + 0] = static_cast<unsigned char>(std::clamp(ipixels[index + 0], 0.f, 1.f) * 255.f);
-        dest[index + 1] = static_cast<unsigned char>(std::clamp(ipixels[index + 1], 0.f, 1.f) * 255.f);
-        dest[index + 2] = static_cast<unsigned char>(std::clamp(ipixels[index + 2], 0.f, 1.f) * 255.f);
-        dest[index + 3] = static_cast<unsigned char>(std::clamp(ipixels[index + 3], 0.f, 1.f) * 255.f);
     }
 }
 

--- a/src/VoidCore/Readers/OpenEXRReader.h
+++ b/src/VoidCore/Readers/OpenEXRReader.h
@@ -30,7 +30,7 @@ public:
      * Returns the OpenGL data type
      * e.g. GL_UNSIGNED_BYTE, GL_FLOAT
      */
-    inline virtual unsigned int GLType() const override { return VOID_GL_UNSIGNED_BYTE; }
+    inline virtual unsigned int GLType() const override { return VOID_GL_FLOAT; }
 
     /**
      * Specifies the number of color components in the texture
@@ -88,7 +88,7 @@ public:
     /**
      * Returns the Size of the frame data
      */
-    virtual size_t FrameSize() const override { return sizeof(unsigned char) * m_Pixels.size(); }
+    virtual size_t FrameSize() const override { return sizeof(float) * m_Pixels.size(); }
 
     /**
      * Read the metadata from the underlying image/frame
@@ -104,8 +104,8 @@ private: /* Methods */
     int m_Channels;
 
     /* Internal data store */
-    // std::vector<unsigned char> m_TPixels;
-    std::vector<unsigned char> m_Pixels;
+    std::vector<unsigned char> m_TPixels;
+    std::vector<float> m_Pixels;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Readers/TurboJpegReader.cpp
+++ b/src/VoidCore/Readers/TurboJpegReader.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License
 
 /* STD */
+#include <algorithm>
 #include <fstream>
 
 /* TurboJPEG */
@@ -27,6 +28,27 @@ TurboJpegReader::~TurboJpegReader()
     Clear();
 }
 
+const unsigned char* TurboJpegReader::ThumbnailPixels()
+{
+    if (m_TPixels.empty())
+    {
+        m_TPixels.resize(m_Pixels.size());
+        unsigned char* pixels = m_TPixels.data();
+
+        for (std::size_t i = 0; i < (m_Width * m_Height); ++i)
+        {
+            int index = i * m_Channels;
+
+            pixels[index] = static_cast<unsigned char>(std::clamp(m_Pixels[index], 0.f, 1.f) * 255.f);
+            pixels[index + 1] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 1], 0.f, 1.f) * 255.f);
+            pixels[index + 2] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 2], 0.f, 1.f) * 255.f);
+            pixels[index + 3] = static_cast<unsigned char>(std::clamp(m_Pixels[index + 3], 0.f, 1.f) * 255.f);
+        }
+    }
+
+    return m_TPixels.data();
+}
+
 SharedPixels TurboJpegReader::Copy() const
 {
     auto copy = std::make_shared<TurboJpegReader>(m_Path, m_Framenumber);
@@ -50,7 +72,7 @@ ImageRow TurboJpegReader::Row(std::size_t row)
 {
     return (row >= m_Height)
             ? ImageRow()
-            : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(unsigned char));
+            : ImageRow(m_Pixels.data(), row, m_Width, m_Channels, sizeof(float));
 }
 
 void TurboJpegReader::Read()
@@ -100,8 +122,9 @@ void TurboJpegReader::Read()
     VOID_LOG_INFO("TurboJPEG Reader: Height {0}, Width {1}, Channels: {2}", m_Width, m_Height, m_Channels);
 
     m_Pixels.resize(pitch * m_Height);
+    std::vector<unsigned char> out(pitch * m_Height);
 
-    if (tjDecompress2(handle, jpegBuffer.data(), jpegSize, m_Pixels.data(), m_Width, pitch, m_Height, TJPF_RGBA, TJFLAG_FASTDCT) != 0)
+    if (tjDecompress2(handle, jpegBuffer.data(), jpegSize, out.data(), m_Width, pitch, m_Height, TJPF_RGBA, TJFLAG_FASTDCT) != 0)
     {
         VOID_LOG_ERROR("Failed to decompress JPEG: {0}", tjGetErrorStr());
 
@@ -110,6 +133,15 @@ void TurboJpegReader::Read()
     }
 
     tjDestroy(handle);
+
+    for (std::size_t i = 0; i < (m_Width * m_Height); ++i)
+    {
+        int index = i * m_Channels;
+        m_Pixels[index] = Linear(static_cast<float>(out[index]) / 255.f);
+        m_Pixels[index + 1] = Linear(static_cast<float>(out[index + 1]) / 255.f);
+        m_Pixels[index + 2] = Linear(static_cast<float>(out[index + 2]) / 255.f);
+        m_Pixels[index + 3] = Linear(static_cast<float>(out[index + 3]) / 255.f);
+    }
 }
 
 const std::map<std::string, std::string> TurboJpegReader::Metadata() const

--- a/src/VoidCore/Readers/TurboJpegReader.h
+++ b/src/VoidCore/Readers/TurboJpegReader.h
@@ -5,6 +5,7 @@
 #define _VOID_TURBO_JPEG_READER_H
 
 /* STD */
+#include <cmath>
 #include <vector>
 
 /* Internal */
@@ -31,7 +32,7 @@ public:
      * Returns the OpenGL data type
      * e.g. GL_UNSIGNED_BYTE, GL_FLOAT
      */
-    inline virtual unsigned int GLType() const override { return VOID_GL_UNSIGNED_BYTE; }
+    inline virtual unsigned int GLType() const override { return VOID_GL_FLOAT; }
 
     /**
      * Specifies the number of color components in the texture
@@ -43,7 +44,7 @@ public:
      * Returns OpenGL format of the pixel data
      * GL_RGBA | GL_RGB
      */
-    inline virtual unsigned int GLFormat() const override { return (m_Channels == 3) ? VOID_GL_RGB : VOID_GL_RGBA; }
+    inline virtual unsigned int GLFormat() const override { return VOID_GL_RGBA; }
 
     /**
      * Returns the Pointer to the underlying pixel data which will be rendered on the Renderer
@@ -60,7 +61,7 @@ public:
      * Not all frames will be used so this function can create a vector on the fly if unsigned char
      * is not the base datatype of the class
      */
-    inline virtual const unsigned char* ThumbnailPixels() override { return m_Pixels.data(); }
+    inline virtual const unsigned char* ThumbnailPixels() override;
 
     /**
      * Image Specifications
@@ -84,12 +85,12 @@ public:
     /**
      * Retrieve the input colorspace of the media file
      */
-    inline virtual ColorSpace InputColorSpace() const override { return m_InputColorSpace; }
+    inline virtual ColorSpace InputColorSpace() const override { return ColorSpace::Linear; }
 
     /**
      * Returns the Size of the frame data
      */
-    virtual size_t FrameSize() const override { return sizeof(unsigned char) * m_Pixels.size(); }
+    virtual size_t FrameSize() const override { return sizeof(float) * m_Pixels.size(); }
 
     /**
      * Read the metadata from the underlying image/frame
@@ -106,9 +107,11 @@ private: /* Members */
 
     /* Colorspace of the Media */
     ColorSpace m_InputColorSpace;
+    std::vector<float> m_Pixels;
+    std::vector<unsigned char> m_TPixels;
 
-    /* Internal data store */
-    std::vector<unsigned char> m_Pixels;
+private: /* Methods */
+    inline static float Linear(float pixel) { return (pixel <= 0.04045f) ? pixel / 12.92f : powf((pixel + 0.055f) / 1.055f, 2.4f); }
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Writers/FFmpegWriter.cpp
+++ b/src/VoidCore/Writers/FFmpegWriter.cpp
@@ -96,14 +96,14 @@ bool FFmpegWriter::AddBuffer(const void* buffer, std::size_t size, const InputSp
     switch (spec.type)
     {
         case BufferType::Float:
-            CopyBuffer(static_cast<const float*>(buffer), m_SourceFrame->data[0], size);
+            CopyBuffer(static_cast<const float*>(buffer), m_SourceFrame->data[0], spec.width * spec.height * spec.channels);
             break;
         case BufferType::Uint16:
-            CopyBuffer(static_cast<const uint16_t*>(buffer), m_SourceFrame->data[0], size);
+            CopyBuffer(static_cast<const uint16_t*>(buffer), m_SourceFrame->data[0], spec.width * spec.height * spec.channels);
             break;
         case BufferType::Uint8:
         default:
-            CopyBuffer(static_cast<const uint8_t*>(buffer), m_SourceFrame->data[0], size);
+            CopyBuffer(static_cast<const uint8_t*>(buffer), m_SourceFrame->data[0], spec.width * spec.height * spec.channels);
     }
 
     sws_scale(

--- a/src/VoidUi/Editor/Effects.cpp
+++ b/src/VoidUi/Editor/Effects.cpp
@@ -142,7 +142,7 @@ void EffectEditor::Connect()
     {
         m_Effect->SetEnabled(checked);
         _PlayerBridge.Refresh();
-    }, Qt::DirectConnection);
+    });
 }
 
 void EffectEditor::SetupIntParam(QGridLayout* grid, int row, const Param* param)
@@ -166,7 +166,7 @@ void EffectEditor::SetupIntParam(QGridLayout* grid, int row, const Param* param)
     {
         m_Effect->SetValue(param->name, i);
         _PlayerBridge.Refresh();
-    }, Qt::DirectConnection);
+    });
 }
 
 void EffectEditor::SetupFloatRangedParam(QGridLayout* grid, int row, const Param* param)
@@ -189,7 +189,7 @@ void EffectEditor::SetupFloatRangedParam(QGridLayout* grid, int row, const Param
     {
         m_Effect->SetValue(param->name, static_cast<float>(d));
         _PlayerBridge.Refresh();
-    }, Qt::DirectConnection);
+    });
 }
 
 void EffectEditor::SetupFloatParam(QGridLayout* grid, int row, const Param* param)
@@ -209,7 +209,7 @@ void EffectEditor::SetupFloatParam(QGridLayout* grid, int row, const Param* para
     {
         m_Effect->SetValue(param->name, static_cast<float>(d));
         _PlayerBridge.Refresh();
-    }, Qt::DirectConnection);
+    });
 }
 
 void EffectEditor::SetupBoolParam(QGridLayout* grid, int row, const Param* param)
@@ -228,7 +228,7 @@ void EffectEditor::SetupBoolParam(QGridLayout* grid, int row, const Param* param
     {
         m_Effect->SetValue(param->name, b);
         _PlayerBridge.Refresh();
-    }, Qt::DirectConnection);
+    });
 }
 
 void EffectEditor::SetupStringParam(QGridLayout* grid, int row, const Param* param)
@@ -247,7 +247,7 @@ void EffectEditor::SetupStringParam(QGridLayout* grid, int row, const Param* par
     {
         m_Effect->SetValue(param->name, editor->text().toStdString());
         _PlayerBridge.Refresh();
-    }, Qt::DirectConnection);
+    });
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Exporter/Exporter.cpp
+++ b/src/VoidUi/Exporter/Exporter.cpp
@@ -108,17 +108,6 @@ ExportMediaFramesTask::ExportMediaFramesTask(const SharedMediaClip& media, const
 {
 }
 
-void ExportMediaFramesTask::ProcessImage(const void* pixels, int width, int height, int channels, const ColorSpace& incolorspace)
-{
-    const unsigned char* cpixels = static_cast<const unsigned char*>(pixels);
-
-    for (int i = 0; i < (width * height * channels); ++i)
-        m_Pixels[i] = cpixels[i] / 255.0f;
-
-    // Image processing
-    ColorProcessor::Instance().ProcessImage(m_Pixels.data(), width, height, channels, incolorspace, m_Colorspace);
-}
-
 bool ExportMediaFramesTask::Work()
 {
     if (SharedMediaClip media = m_Media.lock())
@@ -166,8 +155,8 @@ bool ExportMediaFramesTask::Work()
                 SharedPixels image = media->Image(i);
 
                 /// Colorspace processor
-                ProcessImage(image->Pixels(), image->Width(), image->Height(), image->Channels(), image->InputColorSpace());
-                if (!ir.Render(i, m_Pixels.data(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Float}))
+                ColorProcessor::Instance().ProcessImage(static_cast<float*>(image->Writable()), image->Width(), image->Height(), image->Channels(), m_Colorspace);
+                if (!ir.Render(i, image->Pixels(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Float}))
                 {
                     Log(QString("Unable to render current frame: %1").arg(i), TaskLog::Level::ErrorLog);
                     return false;
@@ -215,8 +204,8 @@ bool ExportMediaFramesTask::Work()
                 SharedPixels image = media->Image(i);
 
                 /// Colorspace processor
-                ProcessImage(image->Pixels(), image->Width(), image->Height(), image->Channels(), image->InputColorSpace());
-                if (!mr.AddBuffer(m_Pixels.data(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Float}))
+                ColorProcessor::Instance().ProcessImage(static_cast<float*>(image->Writable()), image->Width(), image->Height(), image->Channels(), m_Colorspace);
+                if (!mr.AddBuffer(image->Pixels(), image->FrameSize(), {image->Width(), image->Height(), image->Channels(), BufferType::Float}))
                 {
                     Log(QString("Unable to buffer current frame: %1").arg(i), TaskLog::Level::ErrorLog);
                     return false;

--- a/src/VoidUi/Exporter/Exporter.h
+++ b/src/VoidUi/Exporter/Exporter.h
@@ -47,9 +47,6 @@ private: /* Members */
     MFrameRange m_Range;
     std::string m_Colorspace;
     std::vector<float> m_Pixels;
-
-private: /* Methods */
-    void ProcessImage(const void* pixels, int width, int height, int channels, const ColorSpace& incolorspace);
 };
 
 VOID_NAMESPACE_CLOSE


### PR DESCRIPTION
## Feat: Ensure input buffer is linear
* All Media readers output floating point buffers.
* The output from the media readers are scene linear, helping reduce overhead on the GPU for math to colorspace conversion.
* Media exporter directly work on float buffer to output the selected colorspace which is only switched from Linear to required as opposed to juggling between input colorspaces.
* Effect Editor now queues the value changed signals.
* Fixed an issue where ffmpeg writer was crashing due to wrong image size being passed when copying data to uint8_t buffer.

### Details:
The biggest mistake that I did was to work with unsigned char buffers and varying input colorspaces everywhere. This not only added additional complexity to the implementation of image operators but also the image processing when rendering the media.

The changes here are a first step in ensuring we have a standard output format from the PixReaders, which could help us work with a reusable ImageBuffer for caching, thumbnail media caching.
Also if things go according to plan, we could end up removing the Frame class altogether, reusing the MEntry in place of that.