### PR TITLE
[VOID] Media Drag Import

### DIFF
--- a/src/VoidCore/Readers/FFmpegReader.cpp
+++ b/src/VoidCore/Readers/FFmpegReader.cpp
@@ -378,8 +378,7 @@ void FFmpegPixReader::ProcessInformation()
             const AVStream* stream = formatContext->streams[i];
             if (stream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
             {
-                /* This always has been 2 less than the total number of frames, need a bit more information here... */
-                m_Duration = stream->nb_frames - 2;
+                m_Duration = stream->nb_frames;
                 m_Startframe = av_rescale_q(stream->start_time, stream->time_base, av_inv_q(stream->r_frame_rate));
                 m_Framerate = av_q2d(stream->r_frame_rate);
                 m_Endframe = m_Duration - 1;
@@ -463,8 +462,7 @@ const std::map<std::string, std::string> FFmpegPixReader::Metadata() const
 
         vidStream = formatContext->streams[streamId];
 
-        /* This always has been 2 less than the total number of frames, need a bit more information here... */
-        int endframe = vidStream->nb_frames - 2;
+        int endframe = vidStream->nb_frames;
         double framerate = av_q2d(vidStream->r_frame_rate);
         m["end_frame"] = std::to_string(endframe);
         m["duration"] = std::to_string(endframe - m_Startframe + 1);

--- a/src/VoidUi/Media/MediaBridge.h
+++ b/src/VoidUi/Media/MediaBridge.h
@@ -72,6 +72,7 @@ public:
     void RemoveFromPlaylist(const QModelIndex& index, Playlist* playlist);
     void RemoveFromPlaylist(const std::vector<QModelIndex>& indexes, Playlist* playlist);
     void ImportDirectory(const std::string& directory, bool progressive = true) { m_Project->ImportDirectory(directory, progressive); }
+    void ImportDirectory(const std::vector<std::string>& directories, bool progressive = true) { m_Project->ImportDirectory(directories, progressive); }
 
     /**
      * Projects

--- a/src/VoidUi/Media/MediaLister.cpp
+++ b/src/VoidUi/Media/MediaLister.cpp
@@ -95,20 +95,18 @@ void VoidMediaLister::dropEvent(QDropEvent* event)
 {
     /* Fetch all the urls which have been dropped */
     QList<QUrl> urls = event->mimeData()->urls();
+    std::vector<std::string> directories;
+    directories.reserve(urls.size());
 
     for (const QUrl& url : urls)
     {
         std::string path = url.toLocalFile().toStdString();
-
-        /* Check if the path is a directory and emit the signal with the path if it is */
         if (std::filesystem::is_directory(path))
-        {
-            VOID_LOG_INFO("Dropped Media Directory: {0}", path);
-
-            /* Emit the media dropped signal */
-            _MediaBridge.ImportDirectory(path, true);
-        }
+            directories.push_back(path);
     }
+
+    if (!directories.empty())
+        _MediaBridge.ImportDirectory(directories, true);
 }
 
 void VoidMediaLister::Build()

--- a/src/VoidUi/Project/Importer.cpp
+++ b/src/VoidUi/Project/Importer.cpp
@@ -17,10 +17,11 @@ DirectoryImporter::DirectoryImporter(QObject* parent)
 
 DirectoryImporter::DirectoryImporter(const std::string& directory, int maxLevel, QObject* parent)
     : QObject(parent)
-    , m_Directory(directory)
     , m_MaxLevel(maxLevel)
     , m_Cancelled(false)
 {
+    if (!directory.empty())
+        m_Directories.push_back(directory);
 }
 
 DirectoryImporter::~DirectoryImporter()
@@ -32,16 +33,27 @@ DirectoryImporter::~DirectoryImporter()
 
 void DirectoryImporter::Import(const std::string& directory, int maxlevel)
 {
-    m_Directory = directory;
     m_MaxLevel = maxlevel;
     m_Cancelled.store(false);
+    m_Directories.push_back(directory);
+
+    m_Worker = std::async(std::launch::async, &DirectoryImporter::Process, this);
+}
+
+void DirectoryImporter::Import(const std::vector<std::string>& directories, int maxlevel)
+{
+    m_MaxLevel = maxlevel;
+    m_Cancelled.store(false);
+    m_Directories = directories;
 
     m_Worker = std::async(std::launch::async, &DirectoryImporter::Process, this);
 }
 
 void DirectoryImporter::Process()
 {
-    const std::vector<MediaStruct> media = std::move(GetMedia(m_Directory));
+    std::vector<MediaStruct> media;
+    for (auto& directory : m_Directories)
+        GetMedia(directory, media);
 
     if (media.empty() || m_Cancelled.load())
     {
@@ -70,27 +82,20 @@ void DirectoryImporter::Process()
     emit finished();
 }
 
-std::vector<MediaStruct> DirectoryImporter::GetMedia(const std::string& directory, int level) const
+void DirectoryImporter::GetMedia(const std::string& directory, std::vector<MediaStruct>& media, int level) const
 {
-    std::vector<MediaStruct> vec;
-
     try
     {
         for (std::filesystem::directory_entry entry : std::filesystem::directory_iterator(directory))
         {
 
             if (m_Cancelled.load())
-                return vec;
+                return;
 
             /* Recurse through the directory if the level allows */
             if (entry.is_directory() && level <= m_MaxLevel)
             {
-                /* Get all media inside the directory */
-                std::vector<MediaStruct> out = std::move(GetMedia(entry.path().string(), level + 1));
-
-                vec.reserve(vec.size() + out.size());
-                vec.insert(vec.end(), std::make_move_iterator(out.begin()), std::make_move_iterator(out.end()));
-
+                GetMedia(entry.path().string(), media, level + 1);
                 continue;
             }
 
@@ -108,7 +113,7 @@ std::vector<MediaStruct> DirectoryImporter::GetMedia(const std::string& director
              * i.e. the media structs to see if this entry belongs to any one of them
              * if so, this gets added there, else we create a new media struct from it
              */
-            for (MediaStruct& m : vec)
+            for (MediaStruct& m : media)
             {
                 /**
                  * The entry belongs to this Media Struct don't have to add it again
@@ -125,7 +130,7 @@ std::vector<MediaStruct> DirectoryImporter::GetMedia(const std::string& director
             /* Check if no entry in the MediaStruct adopted our newly created Media entry */
             if (new_entry)
             {
-                vec.push_back(MediaStruct(e, type));
+                media.push_back(MediaStruct(e, type));
             }
         }
     }
@@ -133,8 +138,6 @@ std::vector<MediaStruct> DirectoryImporter::GetMedia(const std::string& director
     {
         VOID_LOG_ERROR(e.what());
     }
-
-    return vec;
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Project/Importer.h
+++ b/src/VoidUi/Project/Importer.h
@@ -27,6 +27,7 @@ public:
     DirectoryImporter(const std::string& directory, int maxLevel = 5, QObject* parent = nullptr);
     ~DirectoryImporter();
     void Import(const std::string& directory, int maxlevel = 5);
+    void Import(const std::vector<std::string>& directories, int maxlevel = 5);
     inline void Cancel() { m_Cancelled.store(true); }
 
 signals:
@@ -40,14 +41,14 @@ signals:
     void finished();
 
 private: /* Members */
-    std::string m_Directory;
+    std::vector<std::string> m_Directories;
     int m_MaxLevel;
     std::atomic<bool> m_Cancelled;
     std::future<void> m_Worker;
 
 private: /* Methods */
     void Process();
-    std::vector<MediaStruct> GetMedia(const std::string& directory, int level = 0) const;
+    void GetMedia(const std::string& directory, std::vector<MediaStruct>& media, int level = 0) const;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Project/Project.cpp
+++ b/src/VoidUi/Project/Project.cpp
@@ -40,6 +40,19 @@ void Project::ImportDirectory(const std::string& directory, bool progressive)
     progressive ? ImportDirectoryP(directory) : ImportDirectory_(directory);
 }
 
+void Project::ImportDirectory(const std::vector<std::string>& directories, bool progressive)
+{
+    if (progressive)
+    {
+        SetupProgressTask();
+        m_DirectoryImporter->Import(directories, 5);
+        return;
+    }
+
+    for (auto& directory : directories)
+        ImportDirectory_(directory);
+}
+
 void Project::ImportDirectoryP(const std::string& directory)
 {
     SetupProgressTask();

--- a/src/VoidUi/Project/Project.h
+++ b/src/VoidUi/Project/Project.h
@@ -34,6 +34,7 @@ public:
     inline QUndoStack* UndoStack() const { return m_UndoStack; }
 
     void ImportDirectory(const std::string& directory, bool progressive = true);
+    void ImportDirectory(const std::vector<std::string>& directories, bool progressive = true);
 
     /**
      * The serialized string for the project can be used to construct the project from it


### PR DESCRIPTION
## Details
- The changes allow importing more than one directory the media player at once through a single process running in a separate thread.
- Fixed the issue with movie media only having a single frame, though this has caused some other behavioural issues which needs adjustments.