### PR TITLE
[VOID] Fix: Track Item handles not in front of other track items

### DIFF
--- a/src/VoidObjects/Sequence/TrackMap.cpp
+++ b/src/VoidObjects/Sequence/TrackMap.cpp
@@ -43,7 +43,7 @@ bool TrackMap::Add(const SharedTrackItem& item, v_frame_t frame)
     }
 
     SharedTrackItem existing = *(it - 1);
-    if (existing->InRange(frame))
+    if (existing->InTimelineRange(frame))
         return false;
 
     m_Items.insert(it, item);

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
@@ -22,8 +22,11 @@ STrackItem::STrackItem(const SharedTrackItem& item, SequencerContext* context, Q
     setFlag(QGraphicsItem::ItemIsSelectable);
     setAcceptHoverEvents(true);
 
-    m_HeadHandle = new SHandleItem(m_Item, HandleType::HEAD, context, this);
-    m_TailHandle = new SHandleItem(m_Item, HandleType::TAIL, context, this);
+    m_HeadHandle = new SHandleItem(m_Item, HandleType::HEAD, context);
+    m_TailHandle = new SHandleItem(m_Item, HandleType::TAIL, context);
+    m_Context->Controller()->AddToScene(m_HeadHandle);
+    m_Context->Controller()->AddToScene(m_TailHandle);
+
     ToggleHandles(false);
 
     CalculateBoundingRect();
@@ -132,6 +135,9 @@ void STrackItem::mousePressEvent(QGraphicsSceneMouseEvent* event)
             m_Drag.clickpos = event->scenePos();
             m_Drag.scenepos = scenePos();
             m_Drag.offset = event->pos();
+
+            // Hide handles before we drag
+            ToggleHandles(false);
         }
         else if (m_Context->Action() == SequencerAction::SLIP_CLIP)
         {
@@ -155,7 +161,7 @@ void STrackItem::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
     if (m_Drag.pressed)
     {
         QPointF delta = event->scenePos() - m_Drag.clickpos;
-        if (delta.manhattanLength() > 10)
+        if (delta.manhattanLength() > Sequencer::DragTravelDistance)
         {
             m_Drag.pressed = false;
             m_Drag.active = true;
@@ -165,7 +171,7 @@ void STrackItem::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
     if (m_SlipContext.pressed)
     {
         QPointF delta = event->scenePos() - m_SlipContext.sourcepos;
-        if (delta.manhattanLength() > 10)
+        if (delta.manhattanLength() > Sequencer::SlipTravelDistance)
         {
             m_SlipContext.pressed = false;
             m_SlipContext.active = true;
@@ -301,8 +307,9 @@ void STrackItem::ToggleHandles(bool visible)
     m_TailHandle->setVisible(visible);
     if (visible)
     {
-        m_HeadHandle->setPos(0, 2);
-        m_TailHandle->setPos(boundingRect().width(), 2);
+        // This results in a matrix mult -- need to see if there is a better way to do this
+        m_HeadHandle->setPos(mapToScene(0, 2));
+        m_TailHandle->setPos(mapToScene(boundingRect().width(), 2));
         m_HeadHandle->Update();
         m_TailHandle->Update();
     }

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -9,6 +9,7 @@
 
 /* Qt */
 #include <QObject>
+#include <QGraphicsItem>
 #include <QGraphicsScene>
 
 /* Internal */
@@ -26,6 +27,8 @@ class SequencerController : public QObject
     Q_OBJECT
 public:
     void SetScene(QGraphicsScene* scene);
+    QGraphicsScene* Scene() const { return m_Scene; }
+    void AddToScene(QGraphicsItem* item) { m_Scene->addItem(item); }
     void MoveItem(const SharedTrackItem& item, v_frame_t frame);
     void MoveItem(const SharedPlaybackTrack& track, const SharedTrackItem& item, int trackIndex, v_frame_t frame);
     void CreateVideoTrack(const SharedPlaybackSequence& sequence);

--- a/src/VoidUi/Sequencer/SDescriptors.h
+++ b/src/VoidUi/Sequencer/SDescriptors.h
@@ -36,6 +36,9 @@ inline constexpr int ZMarker = 400;
 inline constexpr int ZSelectionBox = 500;
 inline constexpr int ZPlayheadItem = 10000;
 
+inline constexpr int DragTravelDistance = 10;
+inline constexpr int SlipTravelDistance = 4;
+
 }; // namespace Sequencer
 
 VOID_NAMESPACE_CLOSE


### PR DESCRIPTION
### Fix
* Visual appearance of the TrackItem handles such that these are not obstructed by other trackItems.
* Fix for a case when a track item is split (cut) and moved to another track, is then not able to be added back to the original track at the same position.
* Slipping a clip needs lesser travel than starting to drag an item from the track.