### PR TITLE
[VOID] Central Playback Controller

### DIFF
--- a/src/Bindings/UiModule.cpp
+++ b/src/Bindings/UiModule.cpp
@@ -83,22 +83,8 @@ void BindUi(py::module_& m)
             py::overload_cast<const std::vector<SharedMediaClip>&, const PlayerViewBuffer&>(&PlayerBridge::SetMedia),
             py::arg("media_list"), py::arg("buffer"))
         .def("set_grid_rows", &PlayerBridge::SetGridRows, py::arg("rows"))
-        .def("set_grid_columns", &PlayerBridge::SetGridColumns, py::arg("columns"));
-
-    /* Player */
-    py::class_<Player>(m, "Player")
-        .def("play_forwards", &Player::PlayForwards)
-        .def("play_backwards", &Player::PlayBackwards)
-        .def("play", &Player::PlayForwards)
-        .def("stop", &Player::Stop)
-        .def("next_frame", &Player::NextFrame)
-        .def("previous_frame", &Player::PreviousFrame)
-        .def("move_to_start", &Player::MoveToStart)
-        .def("move_to_end", &Player::MoveToEnd)
-        .def("set_frame", &Player::SetFrame, py::arg("frame"))
-        .def("refresh", &Player::Refresh)
-        .def("set_media", py::overload_cast<const SharedMediaClip&>(&Player::SetMedia), py::arg("media_clip"))
-        .def("active_viewer", &Player::ActiveViewer, py::return_value_policy::reference);
+        .def("set_grid_columns", &PlayerBridge::SetGridColumns, py::arg("columns"))
+        .def("active_viewer", &PlayerBridge::ActiveViewer, py::return_value_policy::reference);
 
     /* Viewer Buffer */
     py::class_<ViewerBuffer>(m, "Viewer")

--- a/src/VoidApplication/Engine/Engine.cpp
+++ b/src/VoidApplication/Engine/Engine.cpp
@@ -19,10 +19,10 @@
 
 #include "VoidCore/Profiler.h"
 #include "VoidObjects/Core/Threads.h"
+#include "VoidUi/BaseWindow/StartupWindow.h"
 #include "VoidUi/Engine/Bridge.h"
 #include "VoidUi/Engine/Globals.h"
 #include "VoidUi/Preferences/Preferences.h"
-#include "VoidUi/BaseWindow/StartupWindow.h"
 
 VOID_NAMESPACE_OPEN
 

--- a/src/VoidUi/BaseWindow/WorkspaceManager.cpp
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.cpp
@@ -61,7 +61,7 @@ void WorkspaceManager::Init()
     m_TaskQueue = new TaskView;
 
     // Sequencer
-    m_Sequencer = new SequencerTimeline;
+    m_Sequencer = new SequencerTimeline(_PlayerBridge.TimeController());
 
     manager.RegisterDock(m_MediaLister, "Media View");
     manager.RegisterDock(_PlayerBridge.ActivePlayer(), "Viewer");
@@ -87,11 +87,6 @@ void WorkspaceManager::Connect()
     connect(m_MediaLister, &VoidMediaLister::metadataInspected, this, &WorkspaceManager::InspectMetadata);
     connect(_PlayerBridge.ActivePlayer(), &Player::metadataInspected, this, &WorkspaceManager::InspectMetadata);
     connect(_PlayerBridge.ActivePlayer(), &Player::playlistUpdated, this, &WorkspaceManager::UpdateMediaQueue);
-    connect(_PlayerBridge.ActivePlayer(), &Player::frameChanged, m_Sequencer, &SequencerTimeline::SetFrame, Qt::DirectConnection);
-    connect(m_Sequencer, &SequencerTimeline::frameChangeRequested, this, [this](v_frame_t frame) -> void
-    {
-        _PlayerBridge.SetTimelineFrame(frame);
-    });
 }
 
 void WorkspaceManager::InitMenu(MenuSystem* menuSystem)

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -118,6 +118,7 @@ set(SOURCES
 
     # Timeline
     Timeline/Timeline.cpp
+    Timeline/TimelineController.cpp
     Timeline/TimelineElements.cpp
     Timeline/Timeslider.cpp
 

--- a/src/VoidUi/Player/Player.cpp
+++ b/src/VoidUi/Player/Player.cpp
@@ -19,11 +19,9 @@
 
 VOID_NAMESPACE_OPEN
 
-Player::Player(QWidget* parent)
-    : PlayerWidget(parent)
+Player::Player(TimelineController* timelineController, QWidget* parent)
+    : PlayerWidget(timelineController, parent)
 {
-    m_ViewBufferA.SetActivePlayer(this);
-    m_ViewBufferB.SetActivePlayer(this);
     Connect();
 }
 
@@ -33,17 +31,17 @@ Player::~Player()
 
 void Player::SetMedia(const SharedMediaClip& media)
 {
-    /* Reset timeline | Renderer */
-    m_Timeline->Clear();
+    // Reset timeline | Renderer
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 
-    /* Update what's currently being played on the viewer buffer */
+    // Update what's currently being played on the viewer buffer
     m_ActiveViewBuffer->Set(media);
 
-    m_Timeline->SetRange(media->FirstFrame(), media->LastFrame());
-    m_Timeline->SetAnnotatedFrames(std::move(media->AnnotatedFrames()));
+    m_TimelineController->SetRange(media->FirstFrame(), media->LastFrame());
+    m_TimelineController->MarkAnnotated(media->AnnotatedFrames());
 
-    Render(m_Timeline->Frame());
+    Render(m_TimelineController->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -58,12 +56,12 @@ void Player::SetMedia(const SharedMediaClip& media)
 void Player::SetMedia(const std::vector<SharedMediaClip>& media)
 {
     /* Reset timeline | Renderer */
-    m_Timeline->Clear();
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 
     m_ActiveViewBuffer->Set(media);
-    m_Timeline->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
-    Render(m_Timeline->Frame());
+    m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+    Render(m_TimelineController->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -74,40 +72,40 @@ void Player::SetMedia(const std::vector<SharedMediaClip>& media, const PlayerVie
     switch (buffer)
     {
         case PlayerViewBuffer::B:
-            m_ViewBufferB.Set(media);
-            SetTrack(m_ViewBufferB.ActiveTrack(), buffer);
+            m_ViewBufferB->Set(media);
+            SetTrack(m_ViewBufferB->ActiveTrack(), buffer);
             break;
         case PlayerViewBuffer::A:
         default:
-            m_ViewBufferA.Set(media);
-            SetTrack(m_ViewBufferA.ActiveTrack(), buffer);
+            m_ViewBufferA->Set(media);
+            SetTrack(m_ViewBufferA->ActiveTrack(), buffer);
     }
 }
 
 void Player::SetMedia(const SharedMediaClip& media, const PlayerViewBuffer& buffer)
 {
     /* Reset timeline | Renderer */
-    m_Timeline->Clear();
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 
-    buffer == PlayerViewBuffer::A ? m_ViewBufferA.Set(media) : m_ViewBufferB.Set(media);
+    buffer == PlayerViewBuffer::A ? m_ViewBufferA->Set(media) : m_ViewBufferB->Set(media);
 
     if (Comparing())
-        return CompareMediaFrame(m_Timeline->Frame());
+        return CompareMediaFrame(m_TimelineController->Frame());
 
     ViewerBuffer *active, *inactive;
 
     buffer == PlayerViewBuffer::A
-        ? (active = &m_ViewBufferA, inactive = &m_ViewBufferB)
-        : (active = &m_ViewBufferB, inactive = &m_ViewBufferA);
+        ? (active = m_ViewBufferA, inactive = m_ViewBufferB)
+        : (active = m_ViewBufferB, inactive = m_ViewBufferA);
 
     m_ActiveViewBuffer = active;
     /* Update active states for the buffers */
     active->SetActive(true);
     inactive->SetActive(false);
 
-    SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
-    Render(m_Timeline->Frame());
+    m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+    Render(m_TimelineController->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -116,14 +114,14 @@ void Player::SetMedia(const SharedMediaClip& media, const PlayerViewBuffer& buff
 void Player::SetTrack(const SharedPlaybackTrack& track)
 {
     /* Reset timeline | Renderer */
-    m_Timeline->Clear();
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 
     /* Update what's currently being played on the viewer buffer */
     m_ActiveViewBuffer->Set(track);
 
-    m_Timeline->SetRange(track->StartFrame(), track->EndFrame());
-    Render(m_Timeline->Frame());
+    m_TimelineController->SetRange(track->StartFrame(), track->EndFrame());
+    Render(m_TimelineController->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -132,27 +130,27 @@ void Player::SetTrack(const SharedPlaybackTrack& track)
 void Player::SetTrack(const SharedPlaybackTrack& track, const PlayerViewBuffer& buffer)
 {
     /* Reset timeline | Renderer */
-    m_Timeline->Clear();
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 
-    buffer == PlayerViewBuffer::A ? m_ViewBufferA.Set(track) : m_ViewBufferB.Set(track);
+    buffer == PlayerViewBuffer::A ? m_ViewBufferA->Set(track) : m_ViewBufferB->Set(track);
 
     if (Comparing())
-        return CompareMediaFrame(m_Timeline->Frame());
+        return CompareMediaFrame(m_TimelineController->Frame());
 
     ViewerBuffer *active, *inactive;
 
     buffer == PlayerViewBuffer::A
-        ? (active = &m_ViewBufferA, inactive = &m_ViewBufferB)
-        : (active = &m_ViewBufferB, inactive = &m_ViewBufferA);
+        ? (active = m_ViewBufferA, inactive = m_ViewBufferB)
+        : (active = m_ViewBufferB, inactive = m_ViewBufferA);
 
     m_ActiveViewBuffer = active;
     /* Update active states for the buffers */
     active->SetActive(true);
     inactive->SetActive(false);
 
-    SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
-    Render(m_Timeline->Frame());
+    m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+    Render(m_TimelineController->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -161,14 +159,14 @@ void Player::SetTrack(const SharedPlaybackTrack& track, const PlayerViewBuffer& 
 void Player::SetSequence(const SharedPlaybackSequence& sequence)
 {
     /* Reset timeline | Renderer */
-    m_Timeline->Clear();
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 
     /* Update what is being played on the Active Viewer Buffer */
     m_ActiveViewBuffer->Set(sequence);
 
-    m_Timeline->SetRange(sequence->StartFrame(), sequence->EndFrame());
-    Render(m_Timeline->Frame());
+    m_TimelineController->SetRange(sequence->StartFrame(), sequence->EndFrame());
+    Render(m_TimelineController->Frame());
 
     m_ControlBar->SetZoomLimits(m_Renderer->MinZoom(), m_Renderer->MaxZoom());
     m_ControlBar->SetZoom(m_Renderer->Zoom());
@@ -176,23 +174,23 @@ void Player::SetSequence(const SharedPlaybackSequence& sequence)
 
 void Player::SetPlaylist(Playlist* playlist)
 {
-    m_Timeline->Clear();
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 
     /* Update what is being played on the Active Viewer Buffer */
     m_ActiveViewBuffer->SetPlaylist(playlist);
-    SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
-    Render(m_Timeline->Frame());
+    m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+    Render(m_TimelineController->Frame());
 }
 
 void Player::SetGrid(Playlist* playlist)
 {
-    m_Timeline->Clear();
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 
     // Update what is being played on the Active Viewer Buffer
     m_ActiveViewBuffer->SetGrid(playlist);
-    SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+    m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
 
     // This internally calls refresh which renders the grid
     SetComparisonMode(5); // ComparisonMode::GRID;
@@ -201,8 +199,6 @@ void Player::SetGrid(Playlist* playlist)
 
 void Player::SetFrame(int frame)
 {
-    emit frameChanged(frame);
-
     if (ActiveGrid())
         return RenderGrid(frame);
 
@@ -221,7 +217,7 @@ void Player::NextMedia()
     if (m_ActiveViewBuffer->NextMedia())
     {
         m_Renderer->Clear();
-        SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+        m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
     }
 }
 
@@ -230,7 +226,7 @@ void Player::PreviousMedia()
     if (m_ActiveViewBuffer->PreviousMedia())
     {
         m_Renderer->Clear();
-        SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+        m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
     }
 }
 
@@ -239,16 +235,16 @@ void Player::ResetPlaylistMedia()
     if (m_ActiveViewBuffer->ResetPlaylistMedia())
     {
         m_Renderer->Clear();
-        SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
-        Render(m_Timeline->Frame());
+        m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+        Render(m_TimelineController->Frame());
     }
 }
 
 void Player::Connect()
 {
-    /* Timeline */
-    connect(m_Timeline, &Timeline::TimeChanged, this, &Player::SetFrame, Qt::DirectConnection);
-    connect(m_Timeline, &Timeline::playbackStateChanged, this, [this](const Timeline::PlayState& state) -> void
+    // Timeline
+    connect(m_TimelineController, &TimelineController::timeChanged, this, &Player::SetFrame, Qt::DirectConnection);
+    connect(m_TimelineController, &TimelineController::playbackStateChanged, this, [this](const Timeline::PlayState& state) -> void
     {
         if (state == Timeline::PlayState::STOPPED)
         {
@@ -263,44 +259,44 @@ void Player::Connect()
                 m_AudioDecoder.Start();
         }
     });
-    connect(m_Timeline, &Timeline::mediaFinished, this, [this](const Timeline::PlayState& state) -> void
+    connect(m_TimelineController, &TimelineController::mediaFinished, this, [this](const Timeline::PlayState& state) -> void
     {
         m_AudioDecoder.Restart();
         state == Timeline::PlayState::FORWARDS ? NextMedia() : PreviousMedia();
     });
-    connect(m_Timeline, &Timeline::seeked, this, [this](v_frame_t frame)
+    connect(m_TimelineController, &TimelineController::seeked, this, [this](v_frame_t frame)
     {
-        m_AudioDecoder.SeekTo((double)frame / m_Timeline->Framerate());
+        m_AudioDecoder.SeekTo((double)frame / m_TimelineController->Framerate());
     });
 
-    /* ControlBar */
+    // ControlBar
     connect(m_ControlBar, &ControlBar::viewerBufferSwitched, this, &Player::ResetViewBuffer);
     connect(m_ControlBar, &ControlBar::comparisonModeChanged, this, &Player::SetComparisonMode);
     connect(m_ControlBar, &ControlBar::blendModeChanged, this, &Player::SetBlendMode);
 
     // ViewerBuffer
-    connect(&m_ViewBufferA, &ViewerBuffer::playlistUpdated, this, &Player::playlistUpdated);
-    connect(&m_ViewBufferB, &ViewerBuffer::playlistUpdated, this, &Player::playlistUpdated);
-    connect(&m_ViewBufferA, &ViewerBuffer::updated, this, &Player::Refresh);
-    connect(&m_ViewBufferB, &ViewerBuffer::updated, this, &Player::Refresh);
+    connect(m_ViewBufferA, &ViewerBuffer::playlistUpdated, this, &Player::playlistUpdated);
+    connect(m_ViewBufferB, &ViewerBuffer::playlistUpdated, this, &Player::playlistUpdated);
+    connect(m_ViewBufferA, &ViewerBuffer::updated, this, &Player::Refresh);
+    connect(m_ViewBufferB, &ViewerBuffer::updated, this, &Player::Refresh);
 }
 
 void Player::PauseCache()
 {
-    m_ViewBufferA.PauseCaching();
-    m_ViewBufferB.PauseCaching();
+    m_ViewBufferA->PauseCaching();
+    m_ViewBufferB->PauseCaching();
 }
 
 void Player::DisableCache()
 {
-    m_ViewBufferA.DisableCaching();
-    m_ViewBufferB.DisableCaching();
+    m_ViewBufferA->DisableCaching();
+    m_ViewBufferB->DisableCaching();
 }
 
 void Player::StopCache()
 {
-    m_ViewBufferA.StopCaching();
-    m_ViewBufferB.StopCaching();
+    m_ViewBufferA->StopCaching();
+    m_ViewBufferB->StopCaching();
 }
 
 void Player::Recache()
@@ -315,8 +311,8 @@ void Player::ResumeCache()
 
 void Player::ClearCache()
 {
-    m_ViewBufferA.ClearCache();
-    m_ViewBufferB.ClearCache();
+    m_ViewBufferA->ClearCache();
+    m_ViewBufferB->ClearCache();
 }
 
 void Player::Render(int frame)
@@ -455,11 +451,11 @@ void Player::Render(int frame)
 void Player::Compare(const SharedMediaClip& first, const SharedMediaClip& second)
 {
     /* Update the Viewer Buffer with the Media Clips --> And then ask for them to be compared in the viewer */
-    m_ViewBufferA.Set(first);
-    m_ViewBufferB.Set(second);
+    m_ViewBufferA->Set(first);
+    m_ViewBufferB->Set(second);
 
     /* Compare frames */
-    CompareMediaFrame(m_Timeline->Frame());
+    CompareMediaFrame(m_TimelineController->Frame());
 }
 
 void Player::InspectCurrentMetadata()
@@ -479,7 +475,7 @@ void Player::InspectCurrentMetadata()
     }
     else
     {
-        const SharedTrackItem& item = m_ActiveViewBuffer->TrackItem(Frame());
+        const SharedTrackItem& item = m_ActiveViewBuffer->TrackItem(m_TimelineController->Frame());
         if (item)
             emit metadataInspected(item->GetMedia());
     }
@@ -487,8 +483,7 @@ void Player::InspectCurrentMetadata()
 
 void Player::CompareMediaFrame(v_frame_t frame)
 {
-    /* Compare on the Viewer */
-    m_Renderer->Compare(m_ViewBufferA.Image(frame), m_ViewBufferB.Image(frame), m_ComparisonMode, m_BlendMode);
+    m_Renderer->Compare(m_ViewBufferA->Image(frame), m_ViewBufferB->Image(frame), m_ComparisonMode, m_BlendMode);
 }
 
 void Player::RenderGrid(v_frame_t frame)
@@ -502,15 +497,15 @@ void Player::SetComparisonMode(int mode)
 
     if (m_ComparisonMode != Renderer::ComparisonMode::NONE)
     {
-        m_ViewBufferA.SetActive(true);
-        m_ViewBufferB.SetActive(true);
+        m_ViewBufferA->SetActive(true);
+        m_ViewBufferB->SetActive(true);
     }
     else
     {
-        bool activeA = m_ActiveViewBuffer == &m_ViewBufferA;
+        bool activeA = m_ActiveViewBuffer == m_ViewBufferA;
 
-        m_ViewBufferA.SetActive(activeA);
-        m_ViewBufferB.SetActive(!activeA);
+        m_ViewBufferA->SetActive(activeA);
+        m_ViewBufferB->SetActive(!activeA);
 
         m_ControlBar->SetViewerControl(ViewerControl::None);
     }
@@ -653,8 +648,8 @@ void Player::ResetViewBuffer(const PlayerViewBuffer& buffer)
     ViewerBuffer *active, *inactive;
 
     buffer == PlayerViewBuffer::A
-        ? (active = &m_ViewBufferA, inactive = &m_ViewBufferB)
-        : (active = &m_ViewBufferB, inactive = &m_ViewBufferA);
+        ? (active = m_ViewBufferA, inactive = m_ViewBufferB)
+        : (active = m_ViewBufferB, inactive = m_ViewBufferA);
 
     m_ActiveViewBuffer = active;
     /* Update active states for the buffers */
@@ -664,7 +659,7 @@ void Player::ResetViewBuffer(const PlayerViewBuffer& buffer)
     /* Clear the viewport */
     m_Renderer->Clear();
     Refresh();
-    SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
+    m_TimelineController->SetRange(m_ActiveViewBuffer->StartFrame(), m_ActiveViewBuffer->EndFrame());
 }
 
 void Player::dragEnterEvent(QDragEnterEvent* event)

--- a/src/VoidUi/Player/Player.h
+++ b/src/VoidUi/Player/Player.h
@@ -18,7 +18,7 @@ class VOID_API Player : public PlayerWidget
     Q_OBJECT
 
 public:
-    Player(QWidget* parent = nullptr);
+    Player(TimelineController* controller, QWidget* parent = nullptr);
     ~Player();
     
     virtual inline QSize sizeHint() const override { return QSize(640, 480); }
@@ -29,9 +29,7 @@ public:
      * @param frame Framenumber to be set on the Timeline.
      */
     void SetFrame(int frame);
-    void SetTimelineFrame(v_frame_t frame) { m_Timeline->SetFrame(frame); }
-
-    inline void Refresh() { SetFrame(m_Timeline->Frame()); }
+    inline void Refresh() { SetFrame(m_TimelineController->Frame()); }
     inline ViewerBuffer* ActiveViewer() const { return m_ActiveViewBuffer; }
 
     void SetMedia(const SharedMediaClip& media);
@@ -79,7 +77,6 @@ signals:
      */
     void metadataInspected(const SharedMediaClip&);
     void playlistUpdated(Playlist*);
-    void frameChanged(v_frame_t);
 
 protected:
     void dragEnterEvent(QDragEnterEvent* event) override;

--- a/src/VoidUi/Player/PlayerBridge.cpp
+++ b/src/VoidUi/Player/PlayerBridge.cpp
@@ -8,7 +8,8 @@ VOID_NAMESPACE_OPEN
 
 PlayerBridge::PlayerBridge()
 {
-    m_Player = new Player();
+    m_TimelineController = new TimelineController(this);
+    m_Player = new Player(m_TimelineController);
     m_Playlist = new Playlist();
 }
 
@@ -22,6 +23,10 @@ PlayerBridge::~PlayerBridge()
     // m_Player->deleteLater();
     // delete m_Player;
     // m_Player = nullptr;
+
+    m_TimelineController->deleteLater();
+    delete m_TimelineController;
+    m_TimelineController = nullptr;
 
     m_Playlist->deleteLater();
     delete m_Playlist;

--- a/src/VoidUi/Player/PlayerBridge.h
+++ b/src/VoidUi/Player/PlayerBridge.h
@@ -11,6 +11,7 @@
 #include "Definition.h"
 #include "Player.h"
 #include "VoidUi/BaseWindow/MenuSystem.h"
+#include "VoidUi/Timeline/TimelineController.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -28,9 +29,11 @@ public:
 
     static PlayerBridge& Instance();
     inline Player* ActivePlayer() const { return m_Player; }
+    inline ViewerBuffer* ActiveViewer() const { return m_Player->ActiveViewer(); }
+    TimelineController* TimeController() { return m_TimelineController; }
+
     void InitMenu(MenuSystem* menuSystem);
     inline void Clear() { m_Player->Clear(); }
-
     inline void Refresh() { m_Player->Refresh(); }
 
     inline void SetMedia(const SharedMediaClip& media) { m_Player->SetMedia(media); }
@@ -67,19 +70,18 @@ public:
     inline void Recache() { m_Player->Recache(); }
     inline void ClearCache() { m_Player->ClearCache(); }
 
-    inline void PlayForwards() { m_Player->PlayForwards(); }
-    inline void PlayBackwards() { m_Player->PlayBackwards(); }
-    inline void Stop() { m_Player->Stop(); }
+    inline void PlayForwards() { m_TimelineController->PlayForwards(); }
+    inline void PlayBackwards() { m_TimelineController->PlayBackwards(); }
+    inline void Stop() { m_TimelineController->Stop(); }
 
-    inline void NextFrame() { m_Player->NextFrame(); }
-    inline void PreviousFrame() { m_Player->PreviousFrame(); }
-    inline void MoveToStart() { m_Player->MoveToStart(); }
-    inline void MoveToEnd() { m_Player->MoveToEnd(); }
-    inline void ResetInFrame() { m_Player->ResetInFrame(); }
-    inline void ResetOutFrame() { m_Player->ResetOutFrame(); }
-    inline void ResetRange() { m_Player->ResetRange(); }
-    inline void EditFramerate() { m_Player->EditFramerate(); }
-    inline void SetTimelineFrame(v_frame_t frame) { m_Player->SetTimelineFrame(frame); }
+    inline void NextFrame() { m_TimelineController->NextFrame(); }
+    inline void PreviousFrame() { m_TimelineController->PreviousFrame(); }
+    inline void MoveToStart() { m_TimelineController->MoveToStart(); }
+    inline void MoveToEnd() { m_TimelineController->MoveToEnd(); }
+    inline void ResetInFrame() { m_TimelineController->ResetInFrame(); }
+    inline void ResetOutFrame() { m_TimelineController->ResetOutFrame(); }
+    inline void ResetRange() { m_TimelineController->ResetRange(); }
+    inline void EditFramerate() { m_TimelineController->EditFramerate(); }
 
     inline void InspectCurrentMetadata() { m_Player->InspectCurrentMetadata(); }
     inline void ToggleChannels(int channel) { m_Player->ToggleChannels(channel); }
@@ -97,6 +99,7 @@ public:
 private: /* Members */
     Player* m_Player;
     Playlist* m_Playlist;
+    TimelineController* m_TimelineController;
 };
 
 #define _PlayerBridge PlayerBridge::Instance()

--- a/src/VoidUi/Player/PlayerWidget.cpp
+++ b/src/VoidUi/Player/PlayerWidget.cpp
@@ -13,32 +13,30 @@
 
 VOID_NAMESPACE_OPEN
 
-PlayerWidget::PlayerWidget(QWidget* parent)
+PlayerWidget::PlayerWidget(TimelineController* timelineController, QWidget* parent)
     : QWidget(parent)
+    , m_TimelineController(timelineController)
     , m_ComparisonMode(Renderer::ComparisonMode::NONE)
     , m_BlendMode(Renderer::BlendMode::UNDER)
     , m_MFrameHandler(static_cast<MissingFrameHandler>(VoidPreferences::Instance().GetMissingFrameHandler()))
 {
-    m_ViewBufferA.SetName("A");
-    m_ViewBufferB.SetName("B");
+    m_ViewBufferA = new ViewerBuffer(timelineController);
+    m_ViewBufferB = new ViewerBuffer(timelineController);
 
-    /* Set the Associated Color for Viewer Buffer B */
-    m_ViewBufferB.SetColor(QColor(70, 180, 220));      // Blue
+    m_ViewBufferA->SetName("A");
+    m_ViewBufferB->SetName("B");
 
-    /* The default buffer is Viewer Buffer A */
-    m_ActiveViewBuffer = &m_ViewBufferA;
-    m_ViewBufferA.SetActive(true);
+    m_ViewBufferB->SetColor(QColor(70, 180, 220));      // Blue
 
-    /* Setup the OpenGL Profile before the OpenGL Context is initialised */
+    // The default buffer is Viewer Buffer A
+    m_ActiveViewBuffer = m_ViewBufferA;
+    m_ViewBufferA->SetActive(true);
+
+    // Needs to be always before we initialize Renderer
     VoidRenderer::SetProfile();
 
-    /* Build the layout */
     Build();
-
-    /* Connect Signals */
     Connect();
-
-    /* Accept drops */
     setAcceptDrops(true);
 }
 
@@ -46,63 +44,50 @@ PlayerWidget::~PlayerWidget()
 {
     m_ActiveViewBuffer = nullptr;
 
-    // Timeline was getting deleted earlier than the player, causing seg faults when closing the player
-    // in case there's playback happening, this should get deleted automatically as it's a part of the player
-    // when Qt calls deleteLater(), but in case this is flagged by any sanitizer for mem leaks, we could try and move
-    // the deletion to a different place or check for states in the player
-    // m_Timeline->deleteLater();
-    // delete m_Timeline;
-    // m_Timeline = nullptr;
+    m_ViewBufferA->deleteLater();
+    delete m_ViewBufferA;
+    m_ViewBufferA = nullptr;
+
+    m_ViewBufferB->deleteLater();
+    delete m_ViewBufferB;
+    m_ViewBufferB = nullptr;
 }
 
 void PlayerWidget::Connect()
 {
-    /* Timeline - fullscreenRequested -> Player - SetRendererFullscreen */
-    connect(m_Timeline, &Timeline::fullscreenRequested, this, &PlayerWidget::SetRendererFullscreen);
+    // TimelineController
+    connect(m_TimelineController, &TimelineController::fullscreenRequested, this, &PlayerWidget::SetRendererFullscreen);
 
-    /* ControlBar - ZoomChange -> Renderer - SetZoom */
+    // ControlBar
     connect(m_ControlBar, &ControlBar::zoomChanged, m_Renderer, &VoidRenderer::SetZoom);
-    /* ControlBar - ExposureChange -> Renderer - SetExposure */
     connect(m_ControlBar, &ControlBar::exposureChanged, m_Renderer, &VoidRenderer::SetExposure);
-    /* ControlBar - GammaChange -> Renderer - SetGamma */
     connect(m_ControlBar, &ControlBar::gammaChanged, m_Renderer, &VoidRenderer::SetGamma);
-    /* ControlBar - GainChange -> Renderer - SetGain */
     connect(m_ControlBar, &ControlBar::gainChanged, m_Renderer, &VoidRenderer::SetGain);
-    /* ControlBar - ChannelModeChanged -> Renderer - SetChannelMode */
     connect(m_ControlBar, &ControlBar::channelModeChanged, m_Renderer, &VoidRenderer::SetChannelMode);
-    /* ControlBar - Annotations Toggled -> AnnotationsController - Set Visible */
     connect(m_ControlBar, &ControlBar::annotationsToggled, this, &PlayerWidget::ToggleAnnotations);
-    /* ControlBar - Color Display Changed -> Renderer - Set Color Display */
     connect(m_ControlBar, &ControlBar::colorDisplayChanged, m_Renderer, &VoidRenderer::SetColorDisplay);
 
-    /* Annotations Controller - Cleared -> Renderer - Clear Annotations */
+    // AnnotationsController
     connect(m_AnnotationsController, &AnnotationsController::cleared, m_Renderer, &VoidRenderer::ClearAnnotations);
-    /* Annotations Controller - Color Changed -> Renderer - Set Annotation Color */
-    connect(m_AnnotationsController, &AnnotationsController::colorChanged, m_Renderer, static_cast<void(VoidRenderer::*)(const QColor&)>(&VoidRenderer::SetAnnotationColor));
-    /* Annotations Controller - Brush Size Changed -> Renderer - Set Annotation Size */
+    connect(m_AnnotationsController, &AnnotationsController::colorChanged, m_Renderer, static_cast<void (VoidRenderer::*)(const QColor&)>(&VoidRenderer::SetAnnotationColor));
     connect(m_AnnotationsController, &AnnotationsController::brushSizeChanged, m_Renderer, &VoidRenderer::SetAnnotationSize);
-    /* Annotations Controller - Control Changed -> Renderer - Set Annotation DrawType */
     connect(m_AnnotationsController, &AnnotationsController::controlChanged, m_Renderer, &VoidRenderer::SetAnnotationDrawType);
 
-    /* Preference - updated -> Player - SetFromPreferences */
+    // VoidPreferences
     connect(&VoidPreferences::Instance(), &VoidPreferences::updated, this, &PlayerWidget::SetFromPreferences);
 
-    /* Renderer - exitFullscreen -> Player - Exitfullscreen */
+    // Renderer
     connect(m_Renderer, &VoidRenderer::exitFullscreen, this, &PlayerWidget::ExitFullscreenRenderer);
-    /* Connect Play Controls from Renderer */
-    connect(m_Renderer, &VoidRenderer::playForwards, this, &PlayerWidget::PlayForwards);
-    connect(m_Renderer, &VoidRenderer::playBackwards, this, &PlayerWidget::PlayBackwards);
-    connect(m_Renderer, &VoidRenderer::stop, this, &PlayerWidget::Stop);
-    connect(m_Renderer, &VoidRenderer::moveForward, this, &PlayerWidget::NextFrame);
-    connect(m_Renderer, &VoidRenderer::moveBackward, this, &PlayerWidget::PreviousFrame);
-
-    /* Renderer - Annotation Created -> ViewerBuffer - SetAnnotation */
+    connect(m_Renderer, &VoidRenderer::playForwards, m_TimelineController, &TimelineController::PlayForwards);
+    connect(m_Renderer, &VoidRenderer::playBackwards, m_TimelineController, &TimelineController::PlayBackwards);
+    connect(m_Renderer, &VoidRenderer::stop, m_TimelineController, &TimelineController::Stop);
+    connect(m_Renderer, &VoidRenderer::moveForward, m_TimelineController, &TimelineController::NextFrame);
+    connect(m_Renderer, &VoidRenderer::moveBackward, m_TimelineController, &TimelineController::PreviousFrame);
     connect(m_Renderer, &VoidRenderer::annotationCreated, this, &PlayerWidget::AddAnnotation);
-    /* Renderer - Annotation Deleted -> ViewerBuffer - RemoveAnnotation */
     connect(m_Renderer, &VoidRenderer::annotationDeleted, this, &PlayerWidget::RemoveAnnotation);
     connect(m_Renderer, &VoidRenderer::zoomChanged, m_ControlBar, &ControlBar::SetZoom);
 
-    /* When a MediaClip is about to be removed from the MediaBride */
+    // Bridge
     connect(&_MediaBridge, &MBridge::mediaAboutToBeRemoved, this, &PlayerWidget::RemoveMedia, Qt::DirectConnection);
 }
 
@@ -140,13 +125,12 @@ void PlayerWidget::Build()
     m_RendererLayout->setContentsMargins(0, 0, 0, 0);
 
     /* Instantiate widgets */
-    m_ControlBar = new ControlBar(&m_ViewBufferA, &m_ViewBufferB, this);
+    m_ControlBar = new ControlBar(m_ViewBufferA, m_ViewBufferB, this);
     m_Renderer = new VoidRenderer(this);
     /* The placeholder renderer for when the actual renderer is fullscreen */
     m_PlaceholderRenderer = new VoidPlaceholderRenderer(this);
     /* Is hidden by default */
     m_PlaceholderRenderer->setVisible(false);
-    m_Timeline = new Timeline(this);
 
     m_Overlay = new PlayerOverlay(m_Renderer);
     m_Overlay->setVisible(false);
@@ -166,8 +150,7 @@ void PlayerWidget::Build()
     horizontalInternal->addWidget(m_AnnotationsController);
 
     layout->addLayout(horizontalInternal);
-
-    layout->addWidget(m_Timeline);
+    layout->addWidget(m_TimelineController->TimelineWidget());
 
     /* Spacing */
     layout->setSpacing(0);
@@ -180,8 +163,7 @@ void PlayerWidget::Clear()
      * Update the time range to be 0-1 ??
      * Clear the data from the player
      */
-    m_Timeline->SetRange(0, 1);
-    m_Timeline->Clear();
+    m_TimelineController->Clear();
     m_Renderer->Clear();
 }
 
@@ -202,14 +184,8 @@ void PlayerWidget::ExitFullscreenRenderer()
 
     /* Reset the parent of the Renderer back to this widget */
     m_Renderer->setParent(this);
-
-    /* Add the renderer back */
     m_RendererLayout->addWidget(m_Renderer);
-
-    /* Hide the Placeholder Renderer */
     m_PlaceholderRenderer->setVisible(false);
-
-    /* We're back normal screened */
     m_Renderer->ExitFullscreen();
 }
 
@@ -235,18 +211,14 @@ void PlayerWidget::ToggleAnnotations(const bool state)
 
 void PlayerWidget::AddAnnotation(const Renderer::SharedAnnotation& annotation)
 {
-    /* Save the Annotation */
-    m_ActiveViewBuffer->SetAnnotation(m_Timeline->Frame(), annotation);
-    /* Also Mark that the frame has been annotated */
-    m_Timeline->AddAnnotatedFrame(m_Timeline->Frame());
+    m_ActiveViewBuffer->SetAnnotation(m_TimelineController->Frame(), annotation);
+    m_TimelineController->MarkAnnotated(m_TimelineController->Frame());
 }
 
 void PlayerWidget::RemoveAnnotation()
 {
-    /* Remove Annotation from the underlying Media */
-    m_ActiveViewBuffer->RemoveAnnotation(m_Timeline->Frame());
-    /* Remove the annotated frame from the Timeline */
-    m_Timeline->RemoveAnnotatedFrame(m_Timeline->Frame());
+    m_ActiveViewBuffer->RemoveAnnotation(m_TimelineController->Frame());
+    m_TimelineController->RemoveAnnotated(m_TimelineController->Frame());
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Player/PlayerWidget.h
+++ b/src/VoidUi/Player/PlayerWidget.h
@@ -16,7 +16,7 @@
 #include "VoidObjects/Sequence/Sequence.h"
 #include "VoidRenderer/Core/RenderTypes.h"
 #include "VoidRenderer/VoidRenderer.h"
-#include "VoidUi/Timeline/Timeline.h"
+#include "VoidUi/Timeline/TimelineController.h"
 #include "VoidUi/Toolkit/AnnotationController.h"
 #include "VoidUi/Toolkit/ControlBar.h"
 
@@ -39,7 +39,7 @@ public:
     };
 
 public:
-    PlayerWidget(QWidget* parent = nullptr);
+    PlayerWidget(TimelineController* timelineController, QWidget* parent = nullptr);
     virtual ~PlayerWidget();
 
     /* Getters */
@@ -87,54 +87,10 @@ public:
     inline void ZoomOut() { m_ControlBar->ZoomOut(); }
     inline void ZoomToFit() { m_Renderer->ZoomToFit(); }
 
-    /* Mark a frame on the timeline as cached */
-    inline void AddCacheFrame(int frame) { m_Timeline->AddCacheFrame(frame); }
-    inline void RemoveCachedFrame(int frame) { m_Timeline->RemoveCachedFrame(frame); }
-    inline void ClearCachedFrames() { m_Timeline->ClearCachedFrames(); }
-
-    /* Set Range on the timeline */
-    inline void SetRange(int start, int end) { m_Timeline->SetRange(start, end); }
-
     /**
      * Removes the MediaClip from the player buffer, if found
      */
     void RemoveMedia(const SharedMediaClip& media);
-
-    /**
-     * Timeline Controls:
-     * Below methods expose the functionality from the timeline
-     * These are required to be able to govern the play state or set any frame according
-     * to the current timeline state
-     * These would get invoked from the Menu or via shortcuts
-     * Eventually making their way onto the CPython exposed API for void python API
-     */
-    inline void PlayForwards() { m_Timeline->PlayForwards(); }
-    inline void PlayBackwards() { m_Timeline->PlayBackwards(); }
-
-    inline void Stop() { m_Timeline->Stop(); }
-
-    inline v_frame_t Startframe() const { return m_Timeline->Minimum(); }
-    inline v_frame_t Endframe() const { return m_Timeline->Maximum(); }
-    inline v_frame_t Frame() const { return m_Timeline->Frame(); }
-    inline void NextFrame() { m_Timeline->NextFrame(); }
-    inline void PreviousFrame() { m_Timeline->PreviousFrame(); }
-
-    inline void MoveToStart() { m_Timeline->MoveToStart(); }
-    inline void MoveToEnd() { m_Timeline->MoveToEnd(); }
-
-    inline void SetUserFirstframe(int frame) { m_Timeline->SetUserFirstframe(frame); }
-    inline void SetUserEndframe(int frame) { m_Timeline->SetUserEndframe(frame); }
-
-    inline void EditFramerate() { m_Timeline->EditFramerate(); }
-
-    /**
-     * (Re)sets the In and out framing of the Timeslider
-     * Calling it once sets the frame as in/out frame (User-In/User-Out)
-     * Calling it the next time on the same frame Resets the in/out frame (User-In/User-Out)
-     */
-    inline void ResetInFrame() { m_Timeline->ResetInFrame(); }
-    inline void ResetOutFrame() { m_Timeline->ResetOutFrame(); }
-    inline void ResetRange() { m_Timeline->ResetRange(); }
 
     void Clear();
 
@@ -154,7 +110,7 @@ protected:  /* Members */
     PlayerOverlay* m_Overlay;
     VoidRenderer* m_Renderer;
     VoidPlaceholderRenderer* m_PlaceholderRenderer;
-    Timeline* m_Timeline;
+    TimelineController* m_TimelineController;
 
     ControlBar* m_ControlBar;
     AnnotationsController* m_AnnotationsController;
@@ -162,8 +118,8 @@ protected:  /* Members */
     Renderer::ComparisonMode m_ComparisonMode;
     Renderer::BlendMode m_BlendMode;
 
-    ViewerBuffer m_ViewBufferA;
-    ViewerBuffer m_ViewBufferB;
+    ViewerBuffer* m_ViewBufferA;
+    ViewerBuffer* m_ViewBufferB;
     ViewerBuffer* m_ActiveViewBuffer;
 
     MissingFrameHandler m_MFrameHandler;

--- a/src/VoidUi/Player/ViewerBuffer.cpp
+++ b/src/VoidUi/Player/ViewerBuffer.cpp
@@ -46,11 +46,11 @@ private:
 
 /// ViewerBuffer
 
-ViewerBuffer::ViewerBuffer(QObject* parent)
+ViewerBuffer::ViewerBuffer(TimelineController* controller, QObject* parent)
     : PlayerBuffer(parent)
     , m_Name("Viewer")
     , m_Color(130, 110, 190)    // Purple
-    , m_Player(nullptr)
+    , m_TimelineController(controller)
     , m_MaxMemory(VoidPreferences::Instance().GetCacheMemory() * 1024 * 1024 * 1024) // 1 GB by default
     , m_Framesize(1)
     , m_Capacity(10)
@@ -68,7 +68,7 @@ ViewerBuffer::ViewerBuffer(QObject* parent)
     {
         m_BackBuffer = std::min(10, std::max(3, static_cast<int>(((m_Endframe - m_Startframe) + 1) * 0.02)));
     }, Qt::DirectConnection);
-    connect(m_Sequence.get(), &PlaybackSequence::updated, this, &ViewerBuffer::Recache);
+    // connect(m_Sequence.get(), &PlaybackSequence::updated, this, &ViewerBuffer::Recache);
 }
 
 ViewerBuffer::~ViewerBuffer()
@@ -152,8 +152,8 @@ void ViewerBuffer::StopCaching()
     m_ThreadPool.clear();
     m_ThreadPool.waitForDone();
 
-    m_Player->ClearCachedFrames();
-    m_LastCached = m_Player->Frame();
+    m_TimelineController->ClearCached();
+    m_LastCached = m_TimelineController->Frame();
 }
 
 void ViewerBuffer::ResumeCaching()
@@ -348,7 +348,7 @@ void ViewerBuffer::EvictFront()
 
     m_Numbers.pop_front();
     m_Buffered.erase(frame);
-    m_Player->RemoveCachedFrame(frame);
+    m_TimelineController->RemoveCached(frame);
 }
 
 void ViewerBuffer::EvictBack()
@@ -372,7 +372,7 @@ void ViewerBuffer::EvictBack()
 
     m_Numbers.pop_back();
     m_Buffered.erase(frame);
-    m_Player->RemoveCachedFrame(frame);
+    m_TimelineController->RemoveCached(frame);
 }
 
 void ViewerBuffer::Store(v_frame_t frame)
@@ -380,7 +380,7 @@ void ViewerBuffer::Store(v_frame_t frame)
     std::lock_guard<std::mutex> lock(m_Mutex);
 
     m_Buffered.insert(frame);
-    m_Player->AddCacheFrame(frame);
+    m_TimelineController->MarkCached(frame);
 }
 
 void ViewerBuffer::Recache()
@@ -474,6 +474,7 @@ void ViewerBuffer::CacheNext()
     v_frame_t frame = m_LastCached;
     // int count = 0;
 
+    v_frame_t current = m_TimelineController->Frame();
     // Remove and Request for new frames
     while (!m_Numbers.empty())
     {
@@ -482,7 +483,7 @@ void ViewerBuffer::CacheNext()
         //     break;
 
         // Ensure the cached frame is just between the current frame and the back buffer
-        if (m_Player->Frame() - m_BackBuffer <= m_Numbers.front() && m_Numbers.front() <= m_Player->Frame())
+        if (current - m_BackBuffer <= m_Numbers.front() && m_Numbers.front() <= current)
             break;
 
         frame++;
@@ -501,12 +502,13 @@ void ViewerBuffer::CacheNext()
 void ViewerBuffer::CachePrevious()
 {
     v_frame_t frame = m_LastCached;
+    v_frame_t current = m_TimelineController->Frame();
 
     // Remove and Request for new frames
     while (!m_Numbers.empty())
     {
         // Ensure the cached frame is just between the current frame and the back buffer
-        if (m_Player->Frame() + m_BackBuffer >= m_Numbers.back() && m_Numbers.back() >= m_Player->Frame())
+        if (current + m_BackBuffer >= m_Numbers.back() && m_Numbers.back() >= current)
             break;
 
         frame--;

--- a/src/VoidUi/Player/ViewerBuffer.h
+++ b/src/VoidUi/Player/ViewerBuffer.h
@@ -21,11 +21,10 @@
 #include "Definition.h"
 #include "Components.h"
 #include "PlayerBuffer.h"
+#include "VoidUi/Timeline/TimelineController.h"
 
 VOID_NAMESPACE_OPEN
 
-/* Forward decl for Player as this needs to know the current playback type and frame */
-class Player;
 class CacheNextFrameTask;
 class CachePreviousFrameTask;
 
@@ -44,7 +43,7 @@ public: /* Enums */
     };
 
 public:
-    explicit ViewerBuffer(QObject* parent = nullptr);
+    explicit ViewerBuffer(TimelineController* controller, QObject* parent = nullptr);
     ~ViewerBuffer();
 
     /// ImageData
@@ -67,10 +66,6 @@ public:
     inline void SetActive(const bool active) { m_Active = active; emit updated(); }
     inline void SetName(const std::string& name) { m_Name = name; }
     void SetColor(const QColor& color);
-
-    /// Set Components
-
-    inline void SetActivePlayer(Player* player) { m_Player = player; }
 
     // Cache/Buffer
 
@@ -98,7 +93,7 @@ private: /* Members */
     std::string m_Name;
     QTimer m_CacheTimer;
     QColor m_Color;
-    Player* m_Player;
+    TimelineController* m_TimelineController;
 
     std::size_t m_MaxMemory;
     std::atomic<std::size_t> m_Framesize;

--- a/src/VoidUi/Sequencer/SContext.h
+++ b/src/VoidUi/Sequencer/SContext.h
@@ -30,6 +30,7 @@ public:
     SHoverModel* HoverModel() { return &m_Hover; }
     STimelineGeometry* Geometry() { return &m_Geometry; }
     SequencerController* Controller() { return &m_Controller; }
+    TimelineController* TimeController() { return m_Controller.TimeController(); }
 
     void SetAction(const SequencerAction& action) { m_Action = action; }
     void ResetAction() { m_Action = SequencerAction::NONE; }

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -17,6 +17,12 @@ void SequencerController::SetScene(QGraphicsScene* scene)
     m_Scene = scene;
 }
 
+void SequencerController::SetTimeController(TimelineController* controller)
+{
+    m_TimelineController = controller;
+    connect(m_TimelineController, &TimelineController::timeChanged, this, &SequencerController::SetCurrentFrame, Qt::DirectConnection);
+}
+
 void SequencerController::MoveItem(const SharedTrackItem& item, v_frame_t frame)
 {
     // Item was dragged and returned back to the same position
@@ -108,7 +114,7 @@ void SequencerController::SetCurrentFrame(v_frame_t frame)
 
 void SequencerController::RequestFrameChange(v_frame_t frame)
 {
-    emit frameChangeRequested(frame);
+    m_TimelineController->SetFrame(frame);
     SetCurrentFrame(frame);
 }
 

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -17,6 +17,7 @@
 #include "VoidObjects/Sequence/Sequence.h"
 #include "VoidObjects/Sequence/Track.h"
 #include "VoidObjects/Sequence/TrackItem.h"
+#include "VoidUi/Timeline/TimelineController.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -28,6 +29,10 @@ class SequencerController : public QObject
 public:
     void SetScene(QGraphicsScene* scene);
     QGraphicsScene* Scene() const { return m_Scene; }
+    
+    void SetTimeController(TimelineController* controller);
+    TimelineController* TimeController() { return m_TimelineController; }
+
     void AddToScene(QGraphicsItem* item) { m_Scene->addItem(item); }
     void MoveItem(const SharedTrackItem& item, v_frame_t frame);
     void MoveItem(const SharedPlaybackTrack& track, const SharedTrackItem& item, int trackIndex, v_frame_t frame);
@@ -55,10 +60,10 @@ public:
 
 signals:
     void frameChanged(v_frame_t);
-    void frameChangeRequested(v_frame_t);
 
 private:
     QGraphicsScene* m_Scene = { nullptr };
+    TimelineController* m_TimelineController = { nullptr };
     v_frame_t m_Frame;
 };
 

--- a/src/VoidUi/Sequencer/Sequencer.cpp
+++ b/src/VoidUi/Sequencer/Sequencer.cpp
@@ -12,10 +12,11 @@
 
 VOID_NAMESPACE_OPEN
 
-SequencerTimeline::SequencerTimeline(QWidget* parent)
+SequencerTimeline::SequencerTimeline(TimelineController* controller, QWidget* parent)
     : QWidget(parent)
     , m_Sequence(nullptr)
 {
+    m_Context.Controller()->SetTimeController(controller);
     setContextMenuPolicy(Qt::CustomContextMenu);
 
     Build();
@@ -34,8 +35,6 @@ void SequencerTimeline::SetSequence(const SharedPlaybackSequence& sequence)
     connect(m_Sequence.get(), &PlaybackSequence::trackAdded, this, &SequencerTimeline::AddTrack);
     connect(m_Sequence.get(), &PlaybackSequence::trackAboutToBeRemoved, this, &SequencerTimeline::RemoveTrack);
 
-    // m_View->SetSequence(sequence);
-    // m_TrackHeader->SetSequence(sequence);
     Refresh();
 }
 
@@ -69,11 +68,6 @@ void SequencerTimeline::RazorAt(const SharedPlaybackTrack& track, v_frame_t fram
 void SequencerTimeline::MergeCut(const SharedPlaybackTrack& track, v_frame_t frame)
 {
     m_Context.Controller()->MergeCut(track, frame);
-}
-
-void SequencerTimeline::SetFrame(v_frame_t frame)
-{
-    m_Context.Controller()->SetCurrentFrame(frame);
 }
 
 void SequencerTimeline::Refresh()
@@ -117,7 +111,6 @@ void SequencerTimeline::Build()
     m_HZoomSlider->setValue(m_Context.Geometry()->PixelsPerFrame() * 10);
 
     m_View = new STimelineView(&m_Context);
-
     m_Ruler = new STimelineRuler(m_View, &m_Context);
 
     grid->addWidget(m_Ruler, 0, 1);
@@ -152,7 +145,6 @@ void SequencerTimeline::Connect()
         SetHorizontalScale((float)value / 10);
     });
 
-    connect(m_Context.Controller(), &SequencerController::frameChangeRequested, this, &SequencerTimeline::frameChangeRequested);
     connect(this, &QWidget::customContextMenuRequested, this, [this](const QPoint& position) -> void 
     {
         m_Menu->Show(mapToGlobal(position));

--- a/src/VoidUi/Sequencer/Sequencer.h
+++ b/src/VoidUi/Sequencer/Sequencer.h
@@ -28,7 +28,7 @@ class VOID_API SequencerTimeline : public QWidget
 {
     Q_OBJECT
 public:
-    explicit SequencerTimeline(QWidget* parent = nullptr);
+    explicit SequencerTimeline(TimelineController* controller, QWidget* parent = nullptr);
     virtual inline QSize sizeHint() const override { return QSize(640, 300); }
 
     void SetSequence(const SharedPlaybackSequence& sequence);
@@ -41,13 +41,9 @@ public:
     void RazorAt(const SharedPlaybackTrack& track, v_frame_t frame);
     void MergeCut(const SharedPlaybackTrack& track, v_frame_t frame);
 
-    void SetFrame(v_frame_t frame);
     void Refresh();
 
     void SetHorizontalScale(float factor);
-
-signals:
-    void frameChangeRequested(v_frame_t);
 
 private:
     QHBoxLayout* m_Layout;

--- a/src/VoidUi/Timeline/Timeline.cpp
+++ b/src/VoidUi/Timeline/Timeline.cpp
@@ -25,8 +25,8 @@ VOID_NAMESPACE_OPEN
 
 Timeline::Timeline(QWidget* parent)
 	: QWidget(parent)
-	, m_LoopType(LoopType::LoopInfinitely)
 	, m_Playing(false)
+	, m_LoopType(LoopType::LoopInfinitely)
 	, m_Playstate(PlayState::STOPPED)
 {
 	Build();
@@ -239,7 +239,7 @@ void Timeline::PlaybackLoop()
 			timer.restart();
 		}
 
-		/* Sleep to yield cpu */
+		// yield cpu
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 	}
 }
@@ -259,8 +259,8 @@ void Timeline::SetFrame(const int frame)
 
 void Timeline::TimeUpdated(const int time)
 {
+	emit timeChanged(time);
 	m_TimeDisplay->setText(std::to_string(time).c_str());
-	emit TimeChanged(time);
 }
 
 void Timeline::SetRange(const int min, const int max)
@@ -271,14 +271,11 @@ void Timeline::SetRange(const int min, const int max)
 	/* Update timeslider range */
 	m_Timeslider->setRange(min, max);
 	m_Timeslider->m_CachedFrames.reserve(max - min + 1);
-
-	/* Update internal range */
 	Timekeeper::Instance().SetRange(min, max);
 }
 
 void Timeline::ResetRange()
 {
-	/* Reset the range for the timeslider */
 	m_Timeslider->ResetRange();
 
 	/**
@@ -334,10 +331,7 @@ void Timeline::SetUserEndframe(int frame)
 
 void Timeline::ResetInFrame()
 {
-	/* Fetch the current frame */
 	int frame = Frame();
-
-	/* Check if it's already our start frame */
 	if (frame == Timekeeper::Instance().StartFrame())
 	{
 		m_Timeslider->ResetStartFrame();
@@ -345,20 +339,15 @@ void Timeline::ResetInFrame()
 	}
 	else
 	{
-		/* Update the Start frame with the current frame */
 		SetUserFirstframe(frame);
 	}
 
-	/* If the User start frame has been set -> Reflect the same on the Toggle Push button */
 	m_InFrameButton->Toggle(static_cast<bool>(m_Timeslider->m_UserStartframe));
 }
 
 void Timeline::ResetOutFrame()
 {
-	/* Fetch the current frame */
 	int frame = Frame();
-
-	/* Check if it's already our end frame */
 	if (frame == Timekeeper::Instance().EndFrame())
 	{
 		m_Timeslider->ResetEndFrame();
@@ -370,7 +359,6 @@ void Timeline::ResetOutFrame()
 		SetUserEndframe(frame);
 	}
 
-	/* If the User end frame has been set -> Reflect the same on the Toggle Push button */
 	m_OutFrameButton->Toggle(static_cast<bool>(m_Timeslider->m_UserEndframe));
 }
 
@@ -478,8 +466,6 @@ void Timeline::Play(const Timeline::PlayState& state)
 		 */
 		m_Timeslider->setValue(Timekeeper::Instance().StartFrame());
 	}
-
-	/* once the playhead is placed correctly -> We can begin playing */
 	state == Timeline::PlayState::FORWARDS ? PlayForwards() : PlayBackwards();
 }
 

--- a/src/VoidUi/Timeline/Timeline.h
+++ b/src/VoidUi/Timeline/Timeline.h
@@ -61,7 +61,14 @@ public:
 	inline void SetFramerate(const double rate) { m_FramerateBox->SetFramerate(rate); }
 	inline void SetFramerate(const std::string& rate) { m_FramerateBox->SetFramerate(rate); }
 
+	void Play(const PlayState& state = PlayState::FORWARDS);
+	void Stop();
+
 	void SetFrame(const int frame);
+	void NextFrame();
+	void PreviousFrame();
+	inline void MoveToStart() { m_Timeslider->setValue(m_Timeslider->Minimum()); }
+	inline void MoveToEnd() { m_Timeslider->setValue(m_Timeslider->Maximum()); }
 
 	inline void SetMaximum(const int frame) { m_Timeslider->setMaximum(frame); }
 	inline void SetMinimum(const int frame) { m_Timeslider->setMinimum(frame); }
@@ -70,6 +77,13 @@ public:
 	void SetUserEndframe(int frame);
 
 	void SetRange(const int min, const int max);
+	/**
+	 * (Re)sets the In and out framing of the Timeslider
+	 * Calling it once sets the frame as in/out frame (User-In/User-Out)
+	 * Calling it the next time on the same frame Resets the in/out frame (User-In/User-Out)
+	 */
+	void ResetInFrame();
+	void ResetOutFrame();
 	void ResetRange();
 
 	/**
@@ -159,32 +173,16 @@ protected: /* Methods */
 	void PlayForwards();
 	void PlayBackwards();
 
-	void Play(const PlayState& state = PlayState::FORWARDS);
-	void Stop();
 	void Replay();
 
 	void StartPlayback();
 	void PlaybackLoop();
 	void TimerPlaybackLoop();
 
-	void NextFrame();
-	void PreviousFrame();
-
 	void PlayNextFrame();
 	void PlayPreviousFrame();
 
 	int ElapsedFrames();
-
-	inline void MoveToStart() { m_Timeslider->setValue(m_Timeslider->Minimum()); }
-	inline void MoveToEnd() { m_Timeslider->setValue(m_Timeslider->Maximum()); }
-
-	/**
-	 * (Re)sets the In and out framing of the Timeslider
-	 * Calling it once sets the frame as in/out frame (User-In/User-Out)
-	 * Calling it the next time on the same frame Resets the in/out frame (User-In/User-Out)
-	 */
-	void ResetInFrame();
-	void ResetOutFrame();
 
 	/* Friendly classes */
 	friend class PlayerWidget;

--- a/src/VoidUi/Timeline/Timeline.h
+++ b/src/VoidUi/Timeline/Timeline.h
@@ -25,13 +25,9 @@
 
 VOID_NAMESPACE_OPEN
 
-/* Forward Declaration for PlayerWidget class */
-class PlayerWidget;
-
 class Timeline : public QWidget
 {
 	Q_OBJECT
-
 public:
 	enum class PlayState : short
 	{
@@ -105,49 +101,31 @@ public:
 	void Clear();
 
 signals:
-	void Played(const PlayState& type = PlayState::FORWARDS);
-	void PlayedForwards();
-	void PlayedBackwards();
-	void TimeChanged(int);
+	void timeChanged(int);
 	void fullscreenRequested();
 	void playbackStateChanged(const PlayState&);
 	void mediaFinished(const PlayState & type = PlayState::FORWARDS);
 	void seeked(v_frame_t);
 
 private: /* Members */
-	/* Main Layout */
 	QVBoxLayout* m_Layout;
-
-	/**
-	 * To Keep the Time Display at the center
-	 * We keep Left layout Holding Left side elements
-	 * Right Layout holding right side elements
-	 */
 	QHBoxLayout* m_LeftLayout;
 	QHBoxLayout* m_RightLayout;
 
 	QPushButton* m_ForwardButton;
 	QPushButton* m_NextFrameButton;
 	QPushButton* m_EndFrameButton;
-
 	QPushButton* m_BackwardButton;
 	QPushButton* m_PrevFrameButton;
 	QPushButton* m_StartFrameButton;
 
-	/* Sets the user defined in and out */
 	ToggleStatePushButton* m_InFrameButton;
 	ToggleStatePushButton* m_OutFrameButton;
-
-	/* Loop State Button - Indicates the current playback loop type */
 	LoopTypeButton* m_LoopTypeButton;
-
 	QPushButton* m_FullscreenButton;
-
 	QPushButton* m_StopButton;
 
-	/* Internal timeslider */
 	Timeslider* m_Timeslider;
-
 	TimeDisplay* m_TimeDisplay;
 	FramerateBox* m_FramerateBox;
 
@@ -155,37 +133,27 @@ private: /* Members */
 	QTimer m_PlayTimer;
 	QElapsedTimer m_ElapsedTimer;
 
-	/* Loop mode for playback */
-	LoopType m_LoopType;
-
 	std::future<void> m_Worker;
 	std::atomic<bool> m_Playing;
 	int m_FrameInterval;
 
+	LoopType m_LoopType;
 	PlayState m_Playstate;
 
 protected: /* Methods */
 	void Build();
 	void Connect();
 	void Setup();
-
 	void TimeUpdated(const int time);
 	void PlayForwards();
 	void PlayBackwards();
-
 	void Replay();
-
 	void StartPlayback();
 	void PlaybackLoop();
 	void TimerPlaybackLoop();
-
 	void PlayNextFrame();
 	void PlayPreviousFrame();
-
 	int ElapsedFrames();
-
-	/* Friendly classes */
-	friend class PlayerWidget;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Timeline/TimelineController.cpp
+++ b/src/VoidUi/Timeline/TimelineController.cpp
@@ -11,7 +11,7 @@ TimelineController::TimelineController(QObject* parent)
 {
     m_Timeline = new Timeline();
 
-    connect(m_Timeline, &Timeline::TimeChanged, this, &TimelineController::timeChanged, Qt::DirectConnection);
+    connect(m_Timeline, &Timeline::timeChanged, this, &TimelineController::timeChanged, Qt::DirectConnection);
     connect(m_Timeline, &Timeline::fullscreenRequested, this, &TimelineController::fullscreenRequested, Qt::DirectConnection);
     connect(m_Timeline, &Timeline::playbackStateChanged, this, &TimelineController::playbackStateChanged, Qt::DirectConnection);
     connect(m_Timeline, &Timeline::mediaFinished, this, &TimelineController::mediaFinished, Qt::DirectConnection);

--- a/src/VoidUi/Timeline/TimelineController.cpp
+++ b/src/VoidUi/Timeline/TimelineController.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Internal */
+#include "TimelineController.h"
+
+VOID_NAMESPACE_OPEN
+
+TimelineController::TimelineController(QObject* parent)
+    : QObject(parent)
+{
+    m_Timeline = new Timeline();
+
+    connect(m_Timeline, &Timeline::TimeChanged, this, &TimelineController::timeChanged, Qt::DirectConnection);
+    connect(m_Timeline, &Timeline::fullscreenRequested, this, &TimelineController::fullscreenRequested, Qt::DirectConnection);
+    connect(m_Timeline, &Timeline::playbackStateChanged, this, &TimelineController::playbackStateChanged, Qt::DirectConnection);
+    connect(m_Timeline, &Timeline::mediaFinished, this, &TimelineController::mediaFinished, Qt::DirectConnection);
+    connect(m_Timeline, &Timeline::seeked, this, &TimelineController::seeked);
+}
+
+TimelineController::~TimelineController()
+{
+    // Timeline was getting deleted earlier than the player, causing seg faults when closing the player
+    // in case there's playback happening, this should get deleted automatically as it's a part of the player
+    // when Qt calls deleteLater(), but in case this is flagged by any sanitizer for mem leaks, we could try and move
+    // the deletion to a different place or check for states in the player
+    // m_Timeline->deleteLater();
+    // delete m_Timeline;
+    // m_Timeline = nullptr;
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Timeline/TimelineController.h
+++ b/src/VoidUi/Timeline/TimelineController.h
@@ -20,35 +20,36 @@ public:
     explicit TimelineController(QObject* parent = nullptr);
     ~TimelineController();
 
+    // Returns the Timeline widget for display and interaction on the player
     Timeline* TimelineWidget() { return m_Timeline; }
 
-    /**
-     * Timeline Controls:
-     * Below methods expose the functionality from the timeline
-     * These are required to be able to govern the play state or set any frame according
-     * to the current timeline state
-     * These would get invoked from the Menu or via shortcuts
-     * Eventually making their way onto the CPython exposed API for void python API
-     */
+    inline int Frame() const { return m_Timeline->Frame(); }
+
+    // Play Controls
+
     inline void PlayForwards() { m_Timeline->Play(Timeline::PlayState::FORWARDS); }
     inline void PlayBackwards() { m_Timeline->Play(Timeline::PlayState::BACKWARDS); }
-
     inline void Stop() { m_Timeline->Stop(); }
 
-    inline void Clear() { m_Timeline->Clear(); }
-
-    inline v_frame_t Startframe() const { return m_Timeline->Minimum(); }
-    inline v_frame_t Endframe() const { return m_Timeline->Maximum(); }
-    inline v_frame_t Frame() const { return m_Timeline->Frame(); }
+    // Move to Frame
 
     inline void NextFrame() { m_Timeline->NextFrame(); }
     inline void PreviousFrame() { m_Timeline->PreviousFrame(); }
-
     inline void MoveToStart() { m_Timeline->MoveToStart(); }
     inline void MoveToEnd() { m_Timeline->MoveToEnd(); }
 
+    // Clear any markings on the timeline and reset the range 0 - 1
+
+    inline void Clear() { m_Timeline->Clear(); }
+
+    // Setters
+
+    inline void SetFrame(v_frame_t frame) { m_Timeline->SetFrame(frame); }
     inline void SetUserFirstframe(int frame) { m_Timeline->SetUserFirstframe(frame); }
     inline void SetUserEndframe(int frame) { m_Timeline->SetUserEndframe(frame); }
+    inline void SetRange(int start, int end) { m_Timeline->SetRange(start, end); }
+
+    // Framerate
 
     inline double Framerate() const { return m_Timeline->Framerate(); }
     inline void EditFramerate() { m_Timeline->EditFramerate(); }
@@ -62,10 +63,7 @@ public:
     inline void ResetOutFrame() { m_Timeline->ResetOutFrame(); }
     inline void ResetRange() { m_Timeline->ResetRange(); }
 
-    void SetFrame(v_frame_t frame) { m_Timeline->SetFrame(frame); }
-
-    /* Set Range on the timeline */
-    inline void SetRange(int start, int end) { m_Timeline->SetRange(start, end); }
+    // Markings
 
     void MarkAnnotated(int frame) { m_Timeline->AddAnnotatedFrame(frame); }
     void MarkAnnotated(const std::vector<int>& frames) { m_Timeline->SetAnnotatedFrames(frames); }

--- a/src/VoidUi/Timeline/TimelineController.h
+++ b/src/VoidUi/Timeline/TimelineController.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _TIMELINE_CONTROLLER_H
+#define _TIMELINE_CONTROLLER_H
+
+/* Qt */
+#include <QObject>
+
+/* Internal */
+#include "Definition.h"
+#include "Timeline.h"
+
+VOID_NAMESPACE_OPEN
+
+class VOID_API TimelineController : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TimelineController(QObject* parent = nullptr);
+    ~TimelineController();
+
+    Timeline* TimelineWidget() { return m_Timeline; }
+
+    /**
+     * Timeline Controls:
+     * Below methods expose the functionality from the timeline
+     * These are required to be able to govern the play state or set any frame according
+     * to the current timeline state
+     * These would get invoked from the Menu or via shortcuts
+     * Eventually making their way onto the CPython exposed API for void python API
+     */
+    inline void PlayForwards() { m_Timeline->Play(Timeline::PlayState::FORWARDS); }
+    inline void PlayBackwards() { m_Timeline->Play(Timeline::PlayState::BACKWARDS); }
+
+    inline void Stop() { m_Timeline->Stop(); }
+
+    inline void Clear() { m_Timeline->Clear(); }
+
+    inline v_frame_t Startframe() const { return m_Timeline->Minimum(); }
+    inline v_frame_t Endframe() const { return m_Timeline->Maximum(); }
+    inline v_frame_t Frame() const { return m_Timeline->Frame(); }
+
+    inline void NextFrame() { m_Timeline->NextFrame(); }
+    inline void PreviousFrame() { m_Timeline->PreviousFrame(); }
+
+    inline void MoveToStart() { m_Timeline->MoveToStart(); }
+    inline void MoveToEnd() { m_Timeline->MoveToEnd(); }
+
+    inline void SetUserFirstframe(int frame) { m_Timeline->SetUserFirstframe(frame); }
+    inline void SetUserEndframe(int frame) { m_Timeline->SetUserEndframe(frame); }
+
+    inline double Framerate() const { return m_Timeline->Framerate(); }
+    inline void EditFramerate() { m_Timeline->EditFramerate(); }
+
+    // /**
+    //  * (Re)sets the In and out framing of the Timeslider
+    //  * Calling it once sets the frame as in/out frame (User-In/User-Out)
+    //  * Calling it the next time on the same frame Resets the in/out frame (User-In/User-Out)
+    //  */
+    inline void ResetInFrame() { m_Timeline->ResetInFrame(); }
+    inline void ResetOutFrame() { m_Timeline->ResetOutFrame(); }
+    inline void ResetRange() { m_Timeline->ResetRange(); }
+
+    void SetFrame(v_frame_t frame) { m_Timeline->SetFrame(frame); }
+
+    /* Set Range on the timeline */
+    inline void SetRange(int start, int end) { m_Timeline->SetRange(start, end); }
+
+    void MarkAnnotated(int frame) { m_Timeline->AddAnnotatedFrame(frame); }
+    void MarkAnnotated(const std::vector<int>& frames) { m_Timeline->SetAnnotatedFrames(frames); }
+	void MarkAnnotated(std::vector<int>&& frames) { m_Timeline->SetAnnotatedFrames(frames); }
+    void RemoveAnnotated(int frame) { m_Timeline->RemoveAnnotatedFrame(frame); }
+
+    void MarkCached(int frame) { m_Timeline->AddCacheFrame(frame); }
+    void RemoveCached(int frame) { m_Timeline->RemoveCachedFrame(frame); }
+    void ClearCached() { m_Timeline->ClearCachedFrames(); }
+
+signals:
+    void timeChanged(int);
+	void fullscreenRequested();
+	void playbackStateChanged(const Timeline::PlayState&);
+	void mediaFinished(const Timeline::PlayState& type);
+	void seeked(v_frame_t);
+
+private:
+    Timeline* m_Timeline;
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _TIMELINE_CONTROLLER_H


### PR DESCRIPTION
## Feat: Create and use a central Playback/Timeline Controller
### Details
Connecting player components to Sequencer components for setting and getting current time and signals connecting is complicated and adds unnecessary workarounds.
The change here creates a central place for holding and parenting the timeline.
### Changes
-  Timeline Controller owns and is responsible for the timeline and it's lifetime.
- All signals are connected directly and is the component to connect to if timeline tracking is needed.
- Player uses Timeline controller directly.
- ViewerBuffer now relies directly on TimelineController instead of circling back to Player.
- Sequencer components rely upon TimelineController for frame setting and timeChanged signals.
