### PR TITLE
[VOID] Timeline Effects in Sequence View

### DIFF
--- a/src/Bindings/CoreModule.cpp
+++ b/src/Bindings/CoreModule.cpp
@@ -167,6 +167,8 @@ void BindCore(py::module_& m)
         .def("set_name", &Effect::SetName, py::arg("name"))
         .def("enabled", &Effect::Enabled)
         .def("set_enabled", &Effect::SetEnabled, py::arg("enable"))
+        .def("timeline_in", &Effect::TimelineIn)
+        .def("timeline_out", &Effect::TimelineOut)
         .def("get_value", &Effect::Value, py::return_value_policy::reference)
         .def("set_value", &Effect::SetValue, py::arg("param"), py::arg("value"));
 
@@ -208,7 +210,8 @@ void BindCore(py::module_& m)
         .def("merge_cut", &PlaybackTrack::MergeCut, py::arg("frame"))
         .def("move_item", &PlaybackTrack::MoveItem, py::arg("track_item"), py::arg("frame"))
         .def("item_at", &PlaybackTrack::ItemAt, py::arg("index"), py::return_value_policy::reference)
-        .def("items", &PlaybackTrack::Items, py::return_value_policy::reference);
+        .def("items", &PlaybackTrack::Items, py::return_value_policy::reference)
+        .def("create_effect", &PlaybackTrack::CreateEffect, py::arg("track_item"), py::arg("effect"), py::return_value_policy::reference);
 
     py::class_<TrackItem, SharedTrackItem>(m, "TrackItem")
         .def("__repr__", [](py::handle h) -> std::string

--- a/src/VoidCore/Media/Filesystem.cpp
+++ b/src/VoidCore/Media/Filesystem.cpp
@@ -466,7 +466,7 @@ MediaStruct MediaStruct::FromFile(const std::string& filepath)
     /**
      * If the type of the media is Movie or any other then we can just return the current MediaStruct from here
      * considering a movie or audio is a container on it's own and does not depend on other containers
-     * Also consider if the entry does not have a frame seqeunce number like #### or %03d or %04d something similar
+     * Also consider if the entry does not have a frame sequence number like #### or %03d or %04d something similar
      */
     if (m.Type() != MediaType::Image || m.SingleFile())
         return m;

--- a/src/VoidCore/Operators/Flipper.h
+++ b/src/VoidCore/Operators/Flipper.h
@@ -14,6 +14,7 @@ class VOID_API FlipOp : public ImageOp
 {
 public:
     bool Evaluate(ImageRow& row) override;
+    std::string Type() const { return "Flip"; }
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Operators/Grader.h
+++ b/src/VoidCore/Operators/Grader.h
@@ -15,7 +15,7 @@ class VOID_API GradeOp : public ImageOp
 public:
     GradeOp();
     bool Evaluate(ImageRow& row) override;
-    std::string Type() const { return "ColorGrade"; }
+    std::string Type() const override { return "ColorGrade"; }
 
 private:
     Param* m_RedGain;
@@ -28,7 +28,7 @@ class VOID_API Grade2 : public ImageOp
 public:
     Grade2();
     bool Evaluate(ImageRow& row) override;
-    std::string Type() const { return "Grade2"; }
+    std::string Type() const override { return "Grade2"; }
 
 private:
     Param* m_ChannelRed;

--- a/src/VoidCore/Operators/Grader.h
+++ b/src/VoidCore/Operators/Grader.h
@@ -15,6 +15,7 @@ class VOID_API GradeOp : public ImageOp
 public:
     GradeOp();
     bool Evaluate(ImageRow& row) override;
+    std::string Type() const { return "ColorGrade"; }
 
 private:
     Param* m_RedGain;
@@ -27,6 +28,7 @@ class VOID_API Grade2 : public ImageOp
 public:
     Grade2();
     bool Evaluate(ImageRow& row) override;
+    std::string Type() const { return "Grade2"; }
 
 private:
     Param* m_ChannelRed;

--- a/src/VoidCore/Operators/Inverter.h
+++ b/src/VoidCore/Operators/Inverter.h
@@ -14,7 +14,7 @@ class VOID_API InvertOp : public ImageOp
 {
 public:
     bool Evaluate(ImageRow& row) override;
-    std::string Type() const { return "Invert"; }
+    std::string Type() const override { return "Invert"; }
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidCore/Operators/Inverter.h
+++ b/src/VoidCore/Operators/Inverter.h
@@ -14,6 +14,7 @@ class VOID_API InvertOp : public ImageOp
 {
 public:
     bool Evaluate(ImageRow& row) override;
+    std::string Type() const { return "Invert"; }
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Effects/Bridge.cpp
+++ b/src/VoidObjects/Effects/Bridge.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* STD */
+#include <sstream>
+
 /* Internal */
 #include "Bridge.h"
 #include "FormatForge.h"
@@ -37,6 +40,21 @@ Effect* EffectsBridge::CreateEffect(const std::string& type, v_frame_t in, v_fra
         return new Effect(creator.release(), EffectName(type), in, out);
     }
     return nullptr;
+}
+
+Effect* EffectsBridge::Copy(const Effect* effect)
+{
+    Effect* copied = new Effect(Forge::Instance().GetImageOp(effect->Type()).release(), "copy");
+
+    // Copy internals and values
+    std::ostringstream out(std::ios::binary);
+    effect->Serialize(out);
+    std::istringstream in(out.str(), std::ios::binary);
+    copied->Deserialize(in);
+
+    // Finally set the next available name
+    copied->SetName(EffectName(effect->Type()));
+    return copied;
 }
 
 std::string EffectsBridge::EffectName(const std::string& type)

--- a/src/VoidObjects/Effects/Bridge.cpp
+++ b/src/VoidObjects/Effects/Bridge.cpp
@@ -26,6 +26,19 @@ Effect* EffectsBridge::CreateEffect(const std::string& type)
     return nullptr;
 }
 
+Effect* EffectsBridge::CreateEffect(const std::string& type, v_frame_t in, v_frame_t out)
+{
+    if (std::unique_ptr<ImageOp> creator = Forge::Instance().GetImageOp(type))
+    {
+        /**
+         * We want to transfer the ownership of the created operator to the effect
+         * such that it will be it's new parent and will decide when the creator needs to be deleted
+         */
+        return new Effect(creator.release(), EffectName(type), in, out);
+    }
+    return nullptr;
+}
+
 std::string EffectsBridge::EffectName(const std::string& type)
 {
     std::string name = type;

--- a/src/VoidObjects/Effects/Bridge.h
+++ b/src/VoidObjects/Effects/Bridge.h
@@ -22,6 +22,7 @@ public:
 
     Effect* CreateEffect(const std::string& type);
     Effect* CreateEffect(const std::string& type, v_frame_t in, v_frame_t out);
+    Effect* Copy(const Effect* effect);
 
 private: /* Members */
     std::unordered_map<std::string, std::size_t> m_EffectCount;

--- a/src/VoidObjects/Effects/Bridge.h
+++ b/src/VoidObjects/Effects/Bridge.h
@@ -21,6 +21,7 @@ public:
     static EffectsBridge& Instance();
 
     Effect* CreateEffect(const std::string& type);
+    Effect* CreateEffect(const std::string& type, v_frame_t in, v_frame_t out);
 
 private: /* Members */
     std::unordered_map<std::string, std::size_t> m_EffectCount;

--- a/src/VoidObjects/Effects/Effects.cpp
+++ b/src/VoidObjects/Effects/Effects.cpp
@@ -108,4 +108,132 @@ void Effect::SetTimelineRange(v_frame_t start, v_frame_t end)
     emit rangeChanged(m_TimelineIn, m_TimelineOut);
 }
 
+void Effect::Serialize(rapidjson::Value& out, rapidjson::Document::AllocatorType& allocator) const
+{
+    out.SetObject();
+    out.AddMember("name_", rapidjson::Value(m_Name.c_str(), allocator), allocator);
+    out.AddMember("enabled_", static_cast<int>(m_Enabled), allocator);
+    out.AddMember("timeline_in_", static_cast<int64_t>(m_TimelineIn), allocator);
+    out.AddMember("timeline_out_", static_cast<int64_t>(m_TimelineOut), allocator);
+    out.AddMember("color_r_", m_Color.red(), allocator);
+    out.AddMember("color_g_", m_Color.green(), allocator);
+    out.AddMember("color_b_", m_Color.blue(), allocator);
+
+    for (const auto& p : m_Operator->Params())
+    {
+        switch (p->type)
+        {
+            case Param::TypeDesc::Boolean:
+                out.AddMember(rapidjson::StringRef(p->name.c_str()), static_cast<int>(p->value.GetBool()), allocator);
+                break;
+            case Param::TypeDesc::Int:
+                out.AddMember(rapidjson::StringRef(p->name.c_str()), p->value.GetInt(), allocator);
+                break;
+            case Param::TypeDesc::Float:
+                out.AddMember(rapidjson::StringRef(p->name.c_str()), p->value.GetFloat(), allocator);
+                break;
+            case Param::TypeDesc::String:
+                out.AddMember(rapidjson::StringRef(p->name.c_str()), rapidjson::Value(p->value.GetString().c_str(), allocator), allocator);
+                break;
+        }
+    }
+}
+
+void Effect::Serialize(std::ostream& out) const
+{
+    // Internal members
+    WriteString(out, m_Name);
+    
+    out.write(reinterpret_cast<const char*>(&m_Enabled), sizeof(m_Enabled));
+    out.write(reinterpret_cast<const char*>(&m_TimelineIn), sizeof(m_TimelineIn));
+    out.write(reinterpret_cast<const char*>(&m_TimelineOut), sizeof(m_TimelineOut));
+
+    int r = m_Color.red();
+    int g = m_Color.green();
+    int b = m_Color.blue();
+
+    out.write(reinterpret_cast<const char*>(&r), sizeof(r));
+    out.write(reinterpret_cast<const char*>(&g), sizeof(g));
+    out.write(reinterpret_cast<const char*>(&b), sizeof(b));
+
+    // Dynamic params
+    for (const auto& p : m_Operator->Params())
+    {
+        // switch (p->type)
+        // {
+        //     case Param::TypeDesc::Boolean:
+        //         out.write(reinterpret_cast<const char*>(p->value), sizeof(p->value));
+        //         break;
+        //     case Param::TypeDesc::Int:
+        //         out.write(reinterpret_cast<const char*>(p->value), sizeof(p->value));
+        //         break;
+        //     case Param::TypeDesc::Float:
+        //         out.write(reinterpret_cast<const char*>(p->value), sizeof(p->value));
+        //         break;
+        //     case Param::TypeDesc::String:
+        //         out.write(reinterpret_cast<const char*>(p->value), sizeof(p->value));
+        //         break;
+        // }
+        out.write(reinterpret_cast<const char*>(&p->value), sizeof(p->value));
+    }
+}
+
+void Effect::Deserialize(const rapidjson::Value& in)
+{
+    m_Name = in["name_"].GetString();
+    m_Enabled = in["enabled_"].GetInt();
+    m_TimelineIn = in["timeline_in_"].GetInt64();
+    m_TimelineOut = in["timeline_out_"].GetInt64();
+
+    m_Color.setRed(in["color_r_"].GetInt());
+    m_Color.setGreen(in["color_g_"].GetInt());
+    m_Color.setBlue(in["color_b_"].GetInt());
+
+    // Dynamic Params
+    for (auto& p : m_Operator->Params())
+    {
+        switch (p->type)
+        {
+            case Param::TypeDesc::Boolean:
+                p->SetValue(static_cast<bool>(in[p->name.c_str()].GetInt()));
+                break;
+            case Param::TypeDesc::Int:
+                p->SetValue(in[p->name.c_str()].GetInt());
+                break;
+            case Param::TypeDesc::Float:
+                p->SetValue(in[p->name.c_str()].GetFloat());
+                break;
+            case Param::TypeDesc::String:
+                p->SetValue(in[p->name.c_str()].GetString());
+                break;
+        }
+    }
+}
+
+void Effect::Deserialize(std::istream& in)
+{
+    m_Name = ReadString(in);
+
+    in.read(reinterpret_cast<char*>(m_Enabled), sizeof(m_Enabled));
+    in.read(reinterpret_cast<char*>(&m_TimelineIn), sizeof(m_TimelineIn));
+    in.read(reinterpret_cast<char*>(&m_TimelineOut), sizeof(m_TimelineOut));
+
+    int r, g, b;
+    in.read(reinterpret_cast<char*>(&r), sizeof(r));
+    in.read(reinterpret_cast<char*>(&g), sizeof(g));
+    in.read(reinterpret_cast<char*>(&b), sizeof(b));
+
+    m_Color.setRed(r);
+    m_Color.setGreen(g);
+    m_Color.setBlue(b);
+
+    // Dynamic Params
+    ValueType v;
+    for (auto& p : m_Operator->Params())
+    {
+        in.read(reinterpret_cast<char*>(&v), sizeof(v));
+        p->SetValue(v);
+    }
+}
+
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Effects/Effects.cpp
+++ b/src/VoidObjects/Effects/Effects.cpp
@@ -7,9 +7,17 @@
 VOID_NAMESPACE_OPEN
 
 Effect::Effect(ImageOp* iop, const std::string& name, QObject* parent)
+    : Effect(iop, name, 0, 0, parent)
+{
+}
+
+Effect::Effect(ImageOp* iop, const std::string& name, v_frame_t in, v_frame_t out, QObject* parent)
     : VoidObject(parent)
     , m_Operator(iop)
     , m_Name(name)
+    , m_Color(225, 220, 225)
+    , m_TimelineIn(in)
+    , m_TimelineOut(out)
     , m_Enabled(true)
 {
 }
@@ -21,6 +29,24 @@ Effect::~Effect()
         delete m_Operator;
         m_Operator = nullptr;
     }
+}
+
+void Effect::SetTimelineItem(TrackItem* item)
+{
+    m_TrackItem = item;
+    emit updated();
+}
+
+void Effect::SetName(const std::string& name)
+{
+    m_Name = name;
+    emit updated();
+}
+
+void Effect::SetColor(const QColor& color)
+{
+    m_Color = color;
+    emit updated();
 }
 
 bool Effect::SetValue(const std::string& param, ValueType value)
@@ -61,6 +87,25 @@ void Effect::SetEnabled(bool enable)
 {
     m_Enabled = enable;
     emit updated();
+}
+
+void Effect::SetTimelineIn(v_frame_t frame)
+{
+    m_TimelineIn = frame;
+    emit rangeChanged(m_TimelineIn, m_TimelineOut);
+}
+
+void Effect::SetTimelineOut(v_frame_t frame)
+{
+    m_TimelineOut = frame;
+    emit rangeChanged(m_TimelineIn, m_TimelineOut);
+}
+
+void Effect::SetTimelineRange(v_frame_t start, v_frame_t end)
+{
+    m_TimelineIn = start;
+    m_TimelineOut = end;
+    emit rangeChanged(m_TimelineIn, m_TimelineOut);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Effects/Effects.cpp
+++ b/src/VoidObjects/Effects/Effects.cpp
@@ -158,24 +158,7 @@ void Effect::Serialize(std::ostream& out) const
 
     // Dynamic params
     for (const auto& p : m_Operator->Params())
-    {
-        // switch (p->type)
-        // {
-        //     case Param::TypeDesc::Boolean:
-        //         out.write(reinterpret_cast<const char*>(p->value), sizeof(p->value));
-        //         break;
-        //     case Param::TypeDesc::Int:
-        //         out.write(reinterpret_cast<const char*>(p->value), sizeof(p->value));
-        //         break;
-        //     case Param::TypeDesc::Float:
-        //         out.write(reinterpret_cast<const char*>(p->value), sizeof(p->value));
-        //         break;
-        //     case Param::TypeDesc::String:
-        //         out.write(reinterpret_cast<const char*>(p->value), sizeof(p->value));
-        //         break;
-        // }
         out.write(reinterpret_cast<const char*>(&p->value), sizeof(p->value));
-    }
 }
 
 void Effect::Deserialize(const rapidjson::Value& in)
@@ -214,7 +197,7 @@ void Effect::Deserialize(std::istream& in)
 {
     m_Name = ReadString(in);
 
-    in.read(reinterpret_cast<char*>(m_Enabled), sizeof(m_Enabled));
+    in.read(reinterpret_cast<char*>(&m_Enabled), sizeof(m_Enabled));
     in.read(reinterpret_cast<char*>(&m_TimelineIn), sizeof(m_TimelineIn));
     in.read(reinterpret_cast<char*>(&m_TimelineOut), sizeof(m_TimelineOut));
 

--- a/src/VoidObjects/Effects/Effects.h
+++ b/src/VoidObjects/Effects/Effects.h
@@ -73,6 +73,12 @@ public:
     v_frame_t TimelineIn() const { return m_TimelineIn; }
     v_frame_t TimelineOut() const { return m_TimelineOut; }
 
+    void Serialize(rapidjson::Value& out, rapidjson::Document::AllocatorType& allocator) const;
+    void Serialize(std::ostream& out) const;
+    void Deserialize(const rapidjson::Value& in);
+    void Deserialize(std::istream& in);
+    const char* TypeName() const { return m_Operator->Type().c_str(); }
+
 signals:
     void updated();
     void valueChanged(const Param*);

--- a/src/VoidObjects/Effects/Effects.h
+++ b/src/VoidObjects/Effects/Effects.h
@@ -4,6 +4,9 @@
 #ifndef _IMAGE_EFFECTS_H
 #define _IMAGE_EFFECTS_H
 
+/* Qt */
+#include <QColor>
+
 /* Internal */
 #include "Definition.h"
 #include "Operator.h"
@@ -11,16 +14,25 @@
 
 VOID_NAMESPACE_OPEN
 
+class TrackItem;
+
 class VOID_API Effect : public VoidObject
 {
     Q_OBJECT
 
 public:
     Effect(ImageOp* iop, const std::string& name, QObject* parent = nullptr);
+    Effect(ImageOp* iop, const std::string& name, v_frame_t in, v_frame_t out, QObject* parent = nullptr);
     ~Effect();
 
+    TrackItem* TimelineItem() const { return m_TrackItem; }
+    void SetTimelineItem(TrackItem* item);
+
     const std::string& Name() const { return m_Name; }
-    void SetName(const std::string& name) { m_Name = name; }
+    void SetName(const std::string& name);
+
+    void SetColor(const QColor& color);
+    QColor Color() const { return m_Color; }
 
     /**
      * @brief Set the Value on the param.
@@ -55,13 +67,23 @@ public:
 
     const std::vector<Param*>& Params() const { return m_Operator->Params(); }
 
+    void SetTimelineIn(v_frame_t frame);
+    void SetTimelineOut(v_frame_t frame);
+    void SetTimelineRange(v_frame_t start, v_frame_t end);
+    v_frame_t TimelineIn() const { return m_TimelineIn; }
+    v_frame_t TimelineOut() const { return m_TimelineOut; }
+
 signals:
     void updated();
     void valueChanged(const Param*);
+    void rangeChanged(v_frame_t, v_frame_t);
 
 private:
     ImageOp* m_Operator;
+    TrackItem* m_TrackItem;
     std::string m_Name;
+    QColor m_Color;
+    v_frame_t m_TimelineIn, m_TimelineOut;
     bool m_Enabled;
 };
 

--- a/src/VoidObjects/Effects/Effects.h
+++ b/src/VoidObjects/Effects/Effects.h
@@ -77,7 +77,8 @@ public:
     void Serialize(std::ostream& out) const;
     void Deserialize(const rapidjson::Value& in);
     void Deserialize(std::istream& in);
-    const char* TypeName() const { return m_Operator->Type().c_str(); }
+    std::string Type() const { return m_Operator->Type(); }
+    const char* TypeName() const { return "Effect"; }
 
 signals:
     void updated();

--- a/src/VoidObjects/Sequence/Sequence.cpp
+++ b/src/VoidObjects/Sequence/Sequence.cpp
@@ -83,6 +83,7 @@ void PlaybackSequence::AddVideoTrack(const SharedPlaybackTrack& track)
     m_VideoTracks.push_back(track);
     connect(track.get(), &PlaybackTrack::rangeChanged, this, &PlaybackSequence::UpdateRange);
     connect(track.get(), &PlaybackTrack::updated, this, &PlaybackSequence::updated);
+    connect(track.get(), &PlaybackTrack::maxEffectsChanged, this, [=]() -> void { emit maxTrackEffectsChanged(track); });
 
     if (track->Name().empty())
     {
@@ -251,7 +252,7 @@ bool PlaybackSequence::HasMedia() const
 {
     /**
      * A sequence can be said empty if there are no tracks on it
-     * But the same seqeunce can have track(s) but no media in them
+     * But the same sequence can have track(s) but no media in them
      * This means that the sequence is not empty but has no media on it to be played
      */
     if (IsEmpty())    /* Already has no tracks on it */

--- a/src/VoidObjects/Sequence/Sequence.cpp
+++ b/src/VoidObjects/Sequence/Sequence.cpp
@@ -109,6 +109,9 @@ void PlaybackSequence::AddVideoTrack(const SharedPlaybackTrack& track)
 void PlaybackSequence::AddAudioTrack(const SharedPlaybackTrack& track)
 {
     m_AudioTracks.push_back(track);
+    connect(track.get(), &PlaybackTrack::rangeChanged, this, &PlaybackSequence::UpdateRange);
+    connect(track.get(), &PlaybackTrack::updated, this, &PlaybackSequence::updated);
+
     if (track->Name().empty())
     {
         std::string name;
@@ -135,6 +138,7 @@ void PlaybackSequence::AddVideoTrack(const SharedPlaybackTrack& track, int index
     m_VideoTracks.insert(m_VideoTracks.begin() + index, track);
     connect(track.get(), &PlaybackTrack::rangeChanged, this, &PlaybackSequence::UpdateRange);
     connect(track.get(), &PlaybackTrack::updated, this, &PlaybackSequence::updated);
+    connect(track.get(), &PlaybackTrack::maxEffectsChanged, this, [=]() -> void { emit maxTrackEffectsChanged(track); });
 
     if (track->Name().empty())
     {
@@ -160,6 +164,9 @@ void PlaybackSequence::AddVideoTrack(const SharedPlaybackTrack& track, int index
 void PlaybackSequence::AddAudioTrack(const SharedPlaybackTrack& track, int index)
 {
     m_AudioTracks.insert(m_AudioTracks.begin() + index, track);
+    connect(track.get(), &PlaybackTrack::rangeChanged, this, &PlaybackSequence::UpdateRange);
+    connect(track.get(), &PlaybackTrack::updated, this, &PlaybackSequence::updated);
+
     if (track->Name().empty())
     {
         std::string name;

--- a/src/VoidObjects/Sequence/Sequence.h
+++ b/src/VoidObjects/Sequence/Sequence.h
@@ -91,6 +91,7 @@ signals: /* Signals denoting actions in the seqeuence */
     void cleared();
     void updated();
     void rangeChanged(int start, int end);
+    void maxTrackEffectsChanged(const SharedPlaybackTrack&);
 
 protected: /* Members */
     std::vector<SharedPlaybackTrack> m_VideoTracks;
@@ -105,7 +106,7 @@ private: /* Methods */
      * This method is responsible for updating the range of the sequence based on
      * any changes that have been made to underlying tracks of whose range has been updated
      * This method checks the current start and end frame and then evaluates the min and max of
-     * start and end frames respectively to ensure the range of the seqeunce is not messed up
+     * start and end frames respectively to ensure the range of the sequence is not messed up
      */
     void UpdateRange(int start, int end);
 };

--- a/src/VoidObjects/Sequence/Track.cpp
+++ b/src/VoidObjects/Sequence/Track.cpp
@@ -8,6 +8,7 @@
 #include "Track.h"
 #include "Sequence.h"
 #include "VoidCore/Logging.h"
+#include "VoidObjects/Effects/Bridge.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -42,6 +43,18 @@ Effect* PlaybackTrack::CreateEffect(const SharedTrackItem& item, const std::stri
         CalculateMaxEffects(item);
     }
     return created;
+}
+
+void PlaybackTrack::CopyEffect(Effect* effect, const SharedTrackItem& item)
+{
+    Effect* copied = _EffectsBridge.Copy(effect);
+    copied->SetTimelineItem(item.get());
+    copied->SetTimelineRange(item->TimelineIn(), item->TimelineOut());
+
+    item->AddEffect(copied);
+
+    // Recalc now that a new effect was added
+    CalculateMaxEffects();
 }
 
 void PlaybackTrack::SetMedia(const SharedMediaClip& media)
@@ -229,6 +242,10 @@ bool PlaybackTrack::RazorAt(v_frame_t frame)
         // The requested and the frame where the other item starts
         m_Razored.insert(frame);
         m_Razored.insert(frame + 1);
+
+        // Copy all effects as well
+        for (const auto& effect : item->Effects())
+            CopyEffect(effect, nitem);
 
         m_Items.Add(nitem);
         emit itemAdded(nitem);

--- a/src/VoidObjects/Sequence/Track.cpp
+++ b/src/VoidObjects/Sequence/Track.cpp
@@ -18,6 +18,7 @@ PlaybackTrack::PlaybackTrack(const Sequence::TrackType& type, QObject* parent)
     , m_StartFrame(0)
     , m_EndFrame(0)
     , m_Duration(0)
+    , m_MaxEffects(0)
     , m_Visible(true)
     , m_Enabled(true)
     , m_Locked(false)
@@ -30,6 +31,17 @@ PlaybackTrack::PlaybackTrack(const Sequence::TrackType& type, QObject* parent)
 
 PlaybackTrack::~PlaybackTrack()
 {
+}
+
+Effect* PlaybackTrack::CreateEffect(const SharedTrackItem& item, const std::string& effect)
+{
+    Effect* created = item->CreateEffect(effect);
+    if (created)
+    {
+        emit effectAdded(created);
+        CalculateMaxEffects(item);
+    }
+    return created;
 }
 
 void PlaybackTrack::SetMedia(const SharedMediaClip& media)
@@ -262,6 +274,8 @@ bool PlaybackTrack::AddItem(const SharedTrackItem& item)
 {
     if (m_Items.Add(item, item->TimelineIn()))
     {
+        CalculateMaxEffects(item);
+        item->SetTrack(this);
         emit itemAdded(item);
         return true;
     }
@@ -272,6 +286,7 @@ bool PlaybackTrack::AddItem(const SharedTrackItem& item, v_frame_t frame)
 {
     if (m_Items.Add(item, frame))
     {
+        CalculateMaxEffects(item);
         item->SetTrack(this);
         // Set the timeline range based on the provided frame
         item->Move(frame);
@@ -291,8 +306,13 @@ void PlaybackTrack::RemoveItem(v_frame_t frame)
 
 void PlaybackTrack::RemoveItem(const SharedTrackItem& item)
 {
+    int effects = item->NumEffects();
     emit itemAboutToBeRemoved(item);
     m_Items.Remove(item);
+
+    if (effects == m_MaxEffects)
+        CalculateMaxEffects();
+
     emit itemRemoved();
     emit updated();
 }
@@ -344,12 +364,26 @@ void PlaybackTrack::Deserialize(const rapidjson::Value& in)
     {
         SharedTrackItem item = std::make_shared<TrackItem>(this);
         item->Deserialize(trackitems[i]);
-
-        // m_Items.Add(item);
-        // emit itemAdded(item);
         AddItem(item);
-        VOID_LOG_INFO("Added item -- {0} -- TimelineIn: {1}", item->Name(), item->TimelineIn());
     }
+}
+
+void PlaybackTrack::CalculateMaxEffects(const SharedTrackItem& item)
+{
+    int previous = m_MaxEffects;
+    m_MaxEffects = std::max(m_MaxEffects, item->NumEffects());
+
+    if (previous != m_MaxEffects);
+        emit maxEffectsChanged();
+}
+
+void PlaybackTrack::CalculateMaxEffects()
+{
+    m_MaxEffects = 0;
+    for (const auto& item : m_Items)
+        m_MaxEffects = std::max(m_MaxEffects, item->NumEffects());
+    
+    emit maxEffectsChanged();
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Sequence/Track.cpp
+++ b/src/VoidObjects/Sequence/Track.cpp
@@ -345,6 +345,24 @@ void PlaybackTrack::Serialize(rapidjson::Value& out, rapidjson::Document::Alloca
     out.AddMember("TrackItems", trackitems, allocator);
 }
 
+void PlaybackTrack::Serialize(std::ostream& out) const
+{
+    WriteString(out, m_Name);
+    out.write(reinterpret_cast<const char*>(&m_StartFrame), sizeof(m_StartFrame));
+    out.write(reinterpret_cast<const char*>(&m_EndFrame), sizeof(m_EndFrame));
+    out.write(reinterpret_cast<const char*>(&m_Duration), sizeof(m_Duration));
+    out.write(reinterpret_cast<const char*>(&m_Visible), sizeof(m_Visible));
+    out.write(reinterpret_cast<const char*>(&m_Enabled), sizeof(m_Enabled));
+    out.write(reinterpret_cast<const char*>(&m_Locked), sizeof(m_Locked));
+    out.write(reinterpret_cast<const char*>(&m_Type), sizeof(m_Type));
+
+    int64_t itemCount = static_cast<int64_t>(m_Items.Size());
+    out.write(reinterpret_cast<const char*>(&itemCount), sizeof(itemCount));
+
+    for (int i = 0; i < itemCount; ++i)
+        m_Items.AtIndex(i)->Serialize(out);
+}
+
 void PlaybackTrack::Deserialize(const rapidjson::Value& in)
 {
     m_Name = in["name"].GetString();
@@ -368,6 +386,28 @@ void PlaybackTrack::Deserialize(const rapidjson::Value& in)
     }
 }
 
+void PlaybackTrack::Deserialize(std::istream& in)
+{
+    m_Name = ReadString(in);
+    in.read(reinterpret_cast<char*>(&m_StartFrame), sizeof(m_StartFrame));
+    in.read(reinterpret_cast<char*>(&m_EndFrame), sizeof(m_EndFrame));
+    in.read(reinterpret_cast<char*>(&m_Duration), sizeof(m_Duration));
+    in.read(reinterpret_cast<char*>(&m_Visible), sizeof(m_Visible));
+    in.read(reinterpret_cast<char*>(&m_Enabled), sizeof(m_Enabled));
+    in.read(reinterpret_cast<char*>(&m_Locked), sizeof(m_Locked));
+    in.read(reinterpret_cast<char*>(&m_Type), sizeof(m_Type));
+
+    int64_t itemCount;
+    in.read(reinterpret_cast<char*>(&itemCount), sizeof(itemCount));
+
+    for (int i = 0; i < itemCount; ++i)
+    {
+        SharedTrackItem item = std::make_shared<TrackItem>(this);
+        item->Deserialize(in);
+        AddItem(item);
+    }
+}
+
 void PlaybackTrack::CalculateMaxEffects(const SharedTrackItem& item)
 {
     int previous = m_MaxEffects;
@@ -382,7 +422,7 @@ void PlaybackTrack::CalculateMaxEffects()
     m_MaxEffects = 0;
     for (const auto& item : m_Items)
         m_MaxEffects = std::max(m_MaxEffects, item->NumEffects());
-    
+
     emit maxEffectsChanged();
 }
 

--- a/src/VoidObjects/Sequence/Track.h
+++ b/src/VoidObjects/Sequence/Track.h
@@ -138,7 +138,9 @@ public:
     inline void SetStartFrame(int start) { SetRange(start, start + m_EndFrame); }
 
     void Serialize(rapidjson::Value& out, rapidjson::Document::AllocatorType& allocator) const override;
+    void Serialize(std::ostream& out) const override;
     void Deserialize(const rapidjson::Value& in) override;
+    void Deserialize(std::istream& in) override;
 
     const char* TypeName() const override { return "PlaybackTrack"; }
 

--- a/src/VoidObjects/Sequence/Track.h
+++ b/src/VoidObjects/Sequence/Track.h
@@ -36,11 +36,6 @@ public:
     void SetName(std::string&& name) { m_Name = std::move(name); }
     const std::string& Name() const { return m_Name; }
 
-    /*
-     * Clears anything in the track and sets the provided media as first
-     */
-    void SetMedia(const SharedMediaClip& media);
-
     // /* Set a color for the Track */
     // inline void SetColor(const QColor& color)
     // {
@@ -50,13 +45,23 @@ public:
     //     emit updated();
     // }
 
-    std::size_t ItemCount() const { return m_Items.Size(); }
+    std::size_t NumItems() const { return m_Items.Size(); }
     std::size_t ItemIndex(const SharedTrackItem& item) const { return m_Items.ItemIndex(item); }
     SharedTrackItem ItemAt(std::size_t index) const { return m_Items.AtIndex(index); }
     MFrameRange ItemRange(std::size_t index) const { return m_Items.AtIndex(index)->TimelineRange(); }
     const std::vector<SharedTrackItem>& Items() const { return m_Items.Items(); }
 
-    /*
+    Effect* CreateEffect(const SharedTrackItem& item, const std::string& effect);
+    int MaxEffects() const { return m_MaxEffects; }
+
+    /**
+     * @brief Clears anything in the track and sets the provided media as first
+     * 
+     * @param media Media to be reset on the track.
+     */
+    void SetMedia(const SharedMediaClip& media);
+
+    /**
      * Appends the Media to the already existing track of Medis files
      * Which will get played in order
      */
@@ -138,8 +143,10 @@ public:
 
 signals: /* Signals Denoting actions in the Track */
     void cleared();
-    void itemAdded(const SharedTrackItem& item);
-    void itemAboutToBeRemoved(const SharedTrackItem& item);
+    void itemAdded(const SharedTrackItem&);
+    void effectAdded(const Effect* const);
+    void itemAboutToBeRemoved(const SharedTrackItem&);
+    void maxEffectsChanged();
     void itemRemoved();
     void updated();
     void rangeChanged(int start, int end);
@@ -152,6 +159,7 @@ protected: /* Members */
     std::string m_Name;
     int m_StartFrame, m_EndFrame;
     int m_Duration;
+    int m_MaxEffects;
     bool m_Visible;
     bool m_Enabled;
     bool m_Locked;
@@ -159,6 +167,8 @@ protected: /* Members */
 
 protected: /* Methods */
     void SetRange(int start, int end, const bool inclusive = true);
+    void CalculateMaxEffects(const SharedTrackItem& item);
+    void CalculateMaxEffects();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Sequence/Track.h
+++ b/src/VoidObjects/Sequence/Track.h
@@ -47,6 +47,7 @@ public:
 
     std::size_t NumItems() const { return m_Items.Size(); }
     std::size_t ItemIndex(const SharedTrackItem& item) const { return m_Items.ItemIndex(item); }
+    std::size_t ItemIndex(const TrackItem* item) const { return m_Items.ItemIndex(item); }
     SharedTrackItem ItemAt(std::size_t index) const { return m_Items.AtIndex(index); }
     MFrameRange ItemRange(std::size_t index) const { return m_Items.AtIndex(index)->TimelineRange(); }
     const std::vector<SharedTrackItem>& Items() const { return m_Items.Items(); }

--- a/src/VoidObjects/Sequence/Track.h
+++ b/src/VoidObjects/Sequence/Track.h
@@ -53,6 +53,7 @@ public:
     const std::vector<SharedTrackItem>& Items() const { return m_Items.Items(); }
 
     Effect* CreateEffect(const SharedTrackItem& item, const std::string& effect);
+    void CopyEffect(Effect* effect, const SharedTrackItem& item);
     int MaxEffects() const { return m_MaxEffects; }
 
     /**

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -82,7 +82,7 @@ Effect* TrackItem::CreateEffect(const std::string& type)
     if (Effect* effect = _EffectsBridge.CreateEffect(type, m_TimelineIn, m_TimelineOut))
     {
         effect->SetTimelineItem(this);
-        VOID_LOG_INFO("Effect Created -> {}", effect->Name());
+        // VOID_LOG_INFO("Effect Created -> {}", effect->Name());
         m_Effects.push_back(effect);
 
         emit effectCreated(effect);
@@ -178,7 +178,6 @@ void TrackItem::Image(const v_frame_t frame, FloatImage& image)
 const FloatImage TrackItem::Image(v_frame_t frame)
 {
     v_frame_t f = frame + m_Offset;
-    // VOID_LOG_INFO("Timeline frame: {0} -- Media Frame: {1} -- Offset: {2}", frame, f, m_Offset);
     if (m_Media && m_Media->Contains(f))
         return m_Media->Image(f);
 
@@ -275,7 +274,22 @@ void TrackItem::Serialize(rapidjson::Value& out, rapidjson::Document::AllocatorT
     out.AddMember("g", m_Color.green(), allocator);
     out.AddMember("b", m_Color.blue(), allocator);
 
-    // TODO: Pending work with handles (head and tail) & effects added on the track item;
+    out.AddMember("effect_count", static_cast<int>(m_Effects.size()), allocator);
+    rapidjson::Value effects(rapidjson::kArrayType);
+    for (const auto& effect : m_Effects)
+    {
+        rapidjson::Value entry(rapidjson::kObjectType);
+        std::string type(effect->TypeName());
+        entry.AddMember("typename", rapidjson::Value(type.c_str(), allocator), allocator);
+
+        rapidjson::Value effectObject;
+        effect->Serialize(effectObject, allocator);
+        entry.AddMember("effect", effectObject, allocator);
+
+        effects.PushBack(entry, allocator);
+    }
+
+    out.AddMember("timeline_effects", effects, allocator);
 }
 
 void TrackItem::Serialize(std::ostream& out) const
@@ -297,6 +311,14 @@ void TrackItem::Serialize(std::ostream& out) const
     out.write(reinterpret_cast<const char*>(&r), sizeof(r));
     out.write(reinterpret_cast<const char*>(&g), sizeof(g));
     out.write(reinterpret_cast<const char*>(&b), sizeof(b));
+
+    int effectsCount = static_cast<int>(m_Effects.size());
+    out.write(reinterpret_cast<const char*>(&effectsCount), sizeof(effectsCount));
+    for (const auto& effect : m_Effects)
+    {
+        WriteString(out, effect->TypeName());
+        effect->Serialize(out);
+    }
 }
 
 void TrackItem::Deserialize(const rapidjson::Value& in)
@@ -316,6 +338,18 @@ void TrackItem::Deserialize(const rapidjson::Value& in)
     m_Color.setRed(in["r"].GetInt());
     m_Color.setGreen(in["g"].GetInt());
     m_Color.setBlue(in["b"].GetInt());
+
+    const rapidjson::Value::ConstArray effects = in["timeline_effects"].GetArray();
+    m_Effects.reserve(effects.Size());
+    for (int i = 0; i < effects.Size(); ++i)
+    {
+        std::string type = effects[i]["typename"].GetString();
+        if (Effect* effect = _EffectsBridge.CreateEffect(type))
+        {
+            effect->Deserialize(effects[i]["effect"]);
+            m_Effects.push_back(effect);
+        }
+    }
 }
 
 void TrackItem::Deserialize(std::istream& in)
@@ -341,6 +375,20 @@ void TrackItem::Deserialize(std::istream& in)
     m_Color.setRed(r);
     m_Color.setGreen(g);
     m_Color.setBlue(b);
+
+    int effectsCount;
+    in.read(reinterpret_cast<char*>(&effectsCount), sizeof(effectsCount));
+    m_Effects.reserve(effectsCount);
+
+    for (int i = 0; i < effectsCount; ++i)
+    {
+        std::string type = ReadString(in);
+        if (Effect* effect = _EffectsBridge.CreateEffect(type))
+        {
+            effect->Deserialize(in);
+            m_Effects.push_back(effect);
+        }
+    }
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -279,7 +279,7 @@ void TrackItem::Serialize(rapidjson::Value& out, rapidjson::Document::AllocatorT
     for (const auto& effect : m_Effects)
     {
         rapidjson::Value entry(rapidjson::kObjectType);
-        std::string type(effect->TypeName());
+        std::string type(effect->Type());
         entry.AddMember("typename", rapidjson::Value(type.c_str(), allocator), allocator);
 
         rapidjson::Value effectObject;
@@ -316,7 +316,7 @@ void TrackItem::Serialize(std::ostream& out) const
     out.write(reinterpret_cast<const char*>(&effectsCount), sizeof(effectsCount));
     for (const auto& effect : m_Effects)
     {
-        WriteString(out, effect->TypeName());
+        WriteString(out, effect->Type());
         effect->Serialize(out);
     }
 }

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -69,6 +69,12 @@ void TrackItem::Unlink()
     emit updated();
 }
 
+void TrackItem::SetEnabled(bool enable)
+{
+    m_Enabled = enable;
+    emit updated();
+}
+
 Effect* TrackItem::CreateEffect(const std::string& type)
 {
     if (Effect* effect = _EffectsBridge.CreateEffect(type, m_TimelineIn, m_TimelineOut))
@@ -122,7 +128,7 @@ void TrackItem::ClearEffects()
     m_Effects.clear();
 }
 
-int TrackItem::EffectIndex(const Effect* const effect)
+int TrackItem::EffectIndex(const Effect* const effect) const
 {
     auto it = std::find(m_Effects.begin(), m_Effects.end(), effect);
     return it == m_Effects.end() ? -1 : it - m_Effects.begin();
@@ -234,6 +240,7 @@ void TrackItem::Serialize(rapidjson::Value& out, rapidjson::Document::AllocatorT
     out.AddMember("source_in", static_cast<int64_t>(m_SourceIn), allocator);
     out.AddMember("source_out", static_cast<int64_t>(m_SourceOut), allocator);
     out.AddMember("offset", static_cast<int64_t>(m_Offset), allocator);
+    out.AddMember("enabled", static_cast<int>(m_Enabled), allocator);
     out.AddMember("r", m_Color.red(), allocator);
     out.AddMember("g", m_Color.green(), allocator);
     out.AddMember("b", m_Color.blue(), allocator);
@@ -252,6 +259,7 @@ void TrackItem::Serialize(std::ostream& out) const
     out.write(reinterpret_cast<const char*>(&m_SourceIn), sizeof(m_SourceIn));
     out.write(reinterpret_cast<const char*>(&m_SourceOut), sizeof(m_SourceOut));
     out.write(reinterpret_cast<const char*>(&m_Offset), sizeof(m_Offset));
+    out.write(reinterpret_cast<const char*>(&m_Enabled), sizeof(m_Enabled));
 
     int r = m_Color.red();
     int g = m_Color.green();
@@ -273,6 +281,7 @@ void TrackItem::Deserialize(const rapidjson::Value& in)
     m_SourceIn = in["source_in"].GetInt64();
     m_SourceOut = in["source_out"].GetInt64();
     m_Offset = in["offset"].GetInt64();
+    m_Enabled = in["enabled"].GetInt();
 
     m_Color.setRed(in["r"].GetInt());
     m_Color.setGreen(in["g"].GetInt());
@@ -292,6 +301,7 @@ void TrackItem::Deserialize(std::istream& in)
     in.read(reinterpret_cast<char*>(&m_SourceIn), sizeof(m_SourceIn));
     in.read(reinterpret_cast<char*>(&m_SourceOut), sizeof(m_SourceOut));
     in.read(reinterpret_cast<char*>(&m_Offset), sizeof(m_Offset));
+    in.read(reinterpret_cast<char*>(&m_Enabled), sizeof(m_Enabled));
 
     int r, g, b;
     in.read(reinterpret_cast<char*>(&r), sizeof(r));

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -23,6 +23,7 @@ TrackItem::TrackItem(QObject* parent)
     , m_Enabled(true)
 {
     VOID_LOG_INFO("TrackItem Created: {0}", Vuid());
+    connect(this, &TrackItem::rangeChanged, this, &TrackItem::ResetEffectsRange);
 }
 
 TrackItem::TrackItem(const SharedMediaClip& media, v_frame_t start, v_frame_t end, v_frame_t offset, QObject* parent)
@@ -39,6 +40,7 @@ TrackItem::TrackItem(const SharedMediaClip& media, v_frame_t start, v_frame_t en
     , m_Enabled(true)
 {
     VOID_LOG_INFO("TrackItem Created: {0}", Vuid());
+    connect(this, &TrackItem::rangeChanged, this, &TrackItem::ResetEffectsRange);
 }
 
 TrackItem::~TrackItem()
@@ -389,6 +391,12 @@ void TrackItem::Deserialize(std::istream& in)
             m_Effects.push_back(effect);
         }
     }
+}
+
+void TrackItem::ResetEffectsRange(v_frame_t start, v_frame_t end)
+{
+    for (auto& effect : m_Effects)
+        effect->SetTimelineRange(start, end);
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -5,6 +5,7 @@
 #include "TrackItem.h"
 #include "VoidCore/Logging.h"
 #include "VoidObjects/VoidContext.h"
+#include "VoidObjects/Effects/Bridge.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -66,6 +67,65 @@ void TrackItem::Unlink()
 {
     m_Media.reset();
     emit updated();
+}
+
+Effect* TrackItem::CreateEffect(const std::string& type)
+{
+    if (Effect* effect = _EffectsBridge.CreateEffect(type, m_TimelineIn, m_TimelineOut))
+    {
+        effect->SetTimelineItem(this);
+        VOID_LOG_INFO("Effect Created -> {}", effect->Name());
+        m_Effects.push_back(effect);
+
+        emit effectCreated(effect);
+
+        // For every effect that gets updated, the media will be set dirty
+        // connect(effect, &Effect::updated, this, [this]() -> void { SetDirty(true); });
+        // SetDirty(true);
+        return effect;
+    }
+
+    return nullptr;
+}
+
+bool TrackItem::RemoveEffect(const std::string& name)
+{
+    for (int i = static_cast<int>(m_Effects.size()) - 1; i >= 0; --i)
+    {
+        Effect* effect = m_Effects[i];
+        if (effect->Name() == name)
+        {
+            emit effectAboutToBeRemoved(effect);
+
+            effect->deleteLater();
+            delete effect;
+            effect = nullptr;
+
+            m_Effects.erase(m_Effects.begin() + i);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void TrackItem::ClearEffects()
+{
+    for (auto& effect : m_Effects)
+    {
+        emit effectAboutToBeRemoved(effect);
+        effect->deleteLater();
+        delete effect;
+        effect = nullptr;
+    }
+
+    m_Effects.clear();
+}
+
+int TrackItem::EffectIndex(const Effect* const effect)
+{
+    auto it = std::find(m_Effects.begin(), m_Effects.end(), effect);
+    return it == m_Effects.end() ? -1 : it - m_Effects.begin();
 }
 
 void TrackItem::Image(const v_frame_t frame, FloatImage& image)

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -20,6 +20,7 @@ TrackItem::TrackItem(QObject* parent)
     , m_TimelineOut(0)
     , m_SourceIn(0)
     , m_SourceOut(0)
+    , m_Enabled(true)
 {
     VOID_LOG_INFO("TrackItem Created: {0}", Vuid());
 }
@@ -35,6 +36,7 @@ TrackItem::TrackItem(const SharedMediaClip& media, v_frame_t start, v_frame_t en
     , m_TimelineOut(end)
     , m_SourceIn(media->FirstFrame())
     , m_SourceOut(media->LastFrame())
+    , m_Enabled(true)
 {
     VOID_LOG_INFO("TrackItem Created: {0}", Vuid());
 }
@@ -94,6 +96,20 @@ Effect* TrackItem::CreateEffect(const std::string& type)
     return nullptr;
 }
 
+void TrackItem::AddEffect(Effect* effect)
+{
+    effect->SetTimelineItem(this);
+    m_Effects.push_back(effect);
+    emit effectCreated(effect);
+}
+
+void TrackItem::InsertEffect(Effect* effect, int index)
+{
+    effect->SetTimelineItem(this);
+    m_Effects.insert(m_Effects.begin() + index, effect);
+    emit effectCreated(effect);
+}
+
 bool TrackItem::RemoveEffect(const std::string& name)
 {
     for (int i = static_cast<int>(m_Effects.size()) - 1; i >= 0; --i)
@@ -113,6 +129,20 @@ bool TrackItem::RemoveEffect(const std::string& name)
     }
 
     return false;
+}
+
+void TrackItem::RemoveEffect(int index, bool destroy)
+{
+    Effect*& effect = m_Effects[index];
+    emit effectAboutToBeRemoved(effect);
+    if (destroy)
+    {
+        effect->deleteLater();
+        delete effect;
+        effect = nullptr;
+    }
+
+    m_Effects.erase(m_Effects.begin() + index);
 }
 
 void TrackItem::ClearEffects()

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -6,6 +6,7 @@
 
 /* STD */
 #include <memory>
+#include <vector>
 
 /* Qt */
 #include <QObject>
@@ -21,6 +22,7 @@ VOID_NAMESPACE_OPEN
 /* Forward Declaration of the Track */
 class PlaybackTrack;
 class TrackItem;
+class Effect;
 
 typedef std::shared_ptr<TrackItem> SharedTrackItem;
 
@@ -55,6 +57,13 @@ public:
     inline SharedMediaClip GetMedia() const { return m_Media; }
 
     std::string Name() const { return m_Media ? m_Media->Name() : m_Name; }
+    Effect* CreateEffect(const std::string& type);
+    bool RemoveEffect(const std::string& name);
+    void ClearEffects();
+    bool HasEffects() const { return !m_Effects.empty(); }
+    int NumEffects() const { return static_cast<int>(m_Effects.size()); }
+    int EffectIndex(const Effect* const effect);
+    Effect* EffectAt(int index) const { return m_Effects.at(index); }
 
     /**
      * @brief Updates the Image pointer with the data from the underlying media in the Item.
@@ -68,15 +77,15 @@ public:
     void ClearCache(v_frame_t frame);
 
     /**
-     *      Timeline In         Timeline Out
-     *             v              v
-     *  |' ' ' ' ' """""""""""""""" ' ' ' ' ' ' ' '|
-     *  |          |              |                |
-     *  |          | <-Duration-> |                |
-     *  | <--Head->|              | <---Tail------>|
-     *  |_ _ _ _ _ |______________| _ _ _ _ _ _ _ _|
-     *  ^                                          ^
-     * Source in                              Source Out
+     *              Timeline In         Timeline Out
+     *                    v              v
+     *  |' ' ' ' ' ' ' '  """""""""""""""" ' ' ' ' ' ' ' '|
+     *  |                 |              |                |
+     *  |                 | <-Duration-> |                |
+     *  | <----Head-----> |              | <---Tail------>|
+     *  |_ _ _ _ _ _ _ _ _|______________| _ _ _ _ _ _ _ _|
+     *  ^                 ^              ^                ^ 
+     * Source start   Source In       Source Out       Source end
      */
 
     v_frame_t TimelineIn() const { return m_TimelineIn; }
@@ -147,15 +156,11 @@ signals:
     void mediaChanged();
     void updated();
     void rangeChanged(v_frame_t start, v_frame_t end);
-
-    // /**
-    //  * Emitted when a frame is cached
-    //  * The cache could happen when the media cache operation is run continuously on a thread
-    //  * Or if the frame is queried by the viewport
-    //  */
-    // void frameCached(v_frame_t frame);
+    void effectCreated(Effect*);
+    void effectAboutToBeRemoved(const Effect*);
 
 protected:
+    std::vector<Effect*> m_Effects;
     SharedMediaClip m_Media;
     PlaybackTrack* m_Track;
     std::string m_Name;

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -52,6 +52,9 @@ public:
     bool Linked() const { return (bool)m_Media; }
     void Unlink();
 
+    void SetEnabled(bool enable);
+    bool Enabled() const { return m_Enabled; }
+
     /* Getters */
     inline v_frame_t GetOffset() const { return m_Offset; }
     inline SharedMediaClip GetMedia() const { return m_Media; }
@@ -62,7 +65,7 @@ public:
     void ClearEffects();
     bool HasEffects() const { return !m_Effects.empty(); }
     int NumEffects() const { return static_cast<int>(m_Effects.size()); }
-    int EffectIndex(const Effect* const effect);
+    int EffectIndex(const Effect* const effect) const;
     Effect* EffectAt(int index) const { return m_Effects.at(index); }
 
     /**
@@ -173,6 +176,8 @@ protected:
 
     v_frame_t m_SourceIn;
     v_frame_t m_SourceOut;
+
+    bool m_Enabled;
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -61,7 +61,10 @@ public:
 
     std::string Name() const { return m_Media ? m_Media->Name() : m_Name; }
     Effect* CreateEffect(const std::string& type);
+    void AddEffect(Effect* effect);
+    void InsertEffect(Effect* effect, int index);
     bool RemoveEffect(const std::string& name);
+    void RemoveEffect(int index, bool destroy = true);
     void ClearEffects();
     bool HasEffects() const { return !m_Effects.empty(); }
     int NumEffects() const { return static_cast<int>(m_Effects.size()); }
@@ -160,7 +163,7 @@ signals:
     void updated();
     void rangeChanged(v_frame_t start, v_frame_t end);
     void effectCreated(Effect*);
-    void effectAboutToBeRemoved(const Effect*);
+    void effectAboutToBeRemoved(Effect*);
 
 protected:
     std::vector<Effect*> m_Effects;

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -181,6 +181,9 @@ protected:
     v_frame_t m_SourceOut;
 
     bool m_Enabled;
+
+private:
+    void ResetEffectsRange(v_frame_t start, v_frame_t end);
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -70,6 +70,7 @@ public:
     int NumEffects() const { return static_cast<int>(m_Effects.size()); }
     int EffectIndex(const Effect* const effect) const;
     Effect* EffectAt(int index) const { return m_Effects.at(index); }
+    const std::vector<Effect*>& Effects() const { return m_Effects; }
 
     /**
      * @brief Updates the Image pointer with the data from the underlying media in the Item.

--- a/src/VoidObjects/Sequence/TrackMap.cpp
+++ b/src/VoidObjects/Sequence/TrackMap.cpp
@@ -86,6 +86,12 @@ std::size_t TrackMap::ItemIndex(const SharedTrackItem& item) const
     return (it == m_Items.end()) ? std::string::npos : static_cast<std::size_t>(it - m_Items.begin());
 }
 
+std::size_t TrackMap::ItemIndex(const TrackItem* item) const
+{
+    auto it = std::find_if(m_Items.begin(), m_Items.end(), [item](const SharedTrackItem& _i) { return item == _i.get(); });
+    return (it == m_Items.end()) ? std::string::npos : static_cast<std::size_t>(it - m_Items.begin());
+}
+
 SharedTrackItem TrackMap::At(const int frame) const
 {
     // Returns the iter to the first item whose timeline in is higher than the requested O(log n)

--- a/src/VoidObjects/Sequence/TrackMap.h
+++ b/src/VoidObjects/Sequence/TrackMap.h
@@ -52,6 +52,7 @@ public:
     std::size_t Size() const { return m_Items.size(); }
     SharedTrackItem AtIndex(std::size_t index) const { return m_Items.at(index); }
     std::size_t ItemIndex(const SharedTrackItem& item) const;
+    std::size_t ItemIndex(const TrackItem* item) const;
 
     /**
      * Returns a Track Item present at a given frame, if it exists

--- a/src/VoidUi/BaseWindow/WorkspaceManager.cpp
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.cpp
@@ -90,10 +90,11 @@ void WorkspaceManager::Init()
 
 void WorkspaceManager::Connect()
 {
-    connect(m_MediaLister, &VoidMediaLister::effectsEdited, this, &WorkspaceManager::EditEffects);
+    connect(m_MediaLister, &VoidMediaLister::effectsEdited, this, static_cast<void (WorkspaceManager::*)(const SharedMediaClip&)>(&WorkspaceManager::EditEffects));
     connect(m_MediaLister, &VoidMediaLister::metadataInspected, this, &WorkspaceManager::InspectMetadata);
     connect(_PlayerBridge.ActivePlayer(), &Player::metadataInspected, this, &WorkspaceManager::InspectMetadata);
     connect(_PlayerBridge.ActivePlayer(), &Player::playlistUpdated, this, &WorkspaceManager::UpdateMediaQueue);
+    connect(m_Sequencer, &SequencerTimeline::editEffectRequested, this, static_cast<void (WorkspaceManager::*)(Effect*)>(&WorkspaceManager::EditEffects));
 }
 
 void WorkspaceManager::InitMenu(MenuSystem* menuSystem)
@@ -199,6 +200,12 @@ void WorkspaceManager::EditEffects(const SharedMediaClip& media)
     for (auto effect : media->Effects())
         m_PropertiesEditor->EditEffect(effect);
 
+    ShowComponent(Component::Properties);
+}
+
+void WorkspaceManager::EditEffects(Effect* effect)
+{
+    m_PropertiesEditor->EditEffect(effect);
     ShowComponent(Component::Properties);
 }
 

--- a/src/VoidUi/BaseWindow/WorkspaceManager.h
+++ b/src/VoidUi/BaseWindow/WorkspaceManager.h
@@ -90,6 +90,7 @@ private: /* Members */
     void InspectMetadata(const SharedMediaClip& media);
     void UpdateMediaQueue(Playlist* playlist);
     void EditEffects(const SharedMediaClip& media);
+    void EditEffects(Effect* effect);
     void ShowComponent(const Component& component) const;
     bool ShowIfDocked(const QString& name) const;
 };

--- a/src/VoidUi/CMakeLists.txt
+++ b/src/VoidUi/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SOURCES
     Sequencer/Graphics/SHandleItem.cpp
     Sequencer/Graphics/SPlayheadItem.cpp
     Sequencer/Graphics/SRazorItem.cpp
+    Sequencer/Graphics/STimelineEffect.cpp
     Sequencer/Graphics/STimelineItem.cpp
     Sequencer/Graphics/STrack.cpp
     Sequencer/Graphics/STrackItem.cpp

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -417,7 +417,7 @@ DeleteTimelineEffectCommand::DeleteTimelineEffectCommand(Effect* effect, QUndoCo
     m_ItemIndex = track->ItemIndex(item);
     m_EffectIndex = item->EffectIndex(effect);
 
-    m_EffectType = effect->TypeName();
+    m_EffectType = effect->Type();
 
     setText("Delete Timeline Effect");
 }

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -451,6 +451,44 @@ bool DeleteTimelineEffectCommand::Redo()
     return false;
 }
 
+/// CreateTimelineEffectCommand
+
+CreateTimelineEffectCommand::CreateTimelineEffectCommand(const SharedTrackItem& item, const std::string type, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Sequence(item->Track()->Sequence())
+    , m_EffectType(type)
+{
+    const PlaybackTrack* const track = item->Track();
+    m_TrackType = track->Type();
+    m_TrackIndex = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
+    m_ItemIndex = track->ItemIndex(item);
+    m_EffectIndex = item->NumEffects();
+
+    QString text("Create '%1' Effect");
+    setText(text.arg(type));
+}
+
+void CreateTimelineEffectCommand::undo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        item->RemoveEffect(m_EffectIndex);
+    }
+}
+
+bool CreateTimelineEffectCommand::Redo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        return (bool)track->CreateEffect(item, m_EffectType);
+    }
+    return false;
+}
+
 /// RazorTrackCommand
 
 RazorTrackCommand::RazorTrackCommand(const SharedPlaybackTrack& track, v_frame_t frame, QUndoCommand* parent)

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -465,7 +465,7 @@ CreateTimelineEffectCommand::CreateTimelineEffectCommand(const SharedTrackItem& 
     m_EffectIndex = item->NumEffects();
 
     QString text("Create '%1' Effect");
-    setText(text.arg(type));
+    setText(text.arg(type.c_str()));
 }
 
 void CreateTimelineEffectCommand::undo()

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -216,6 +216,80 @@ bool ToggleTrackStateCommand::Redo()
     return false;
 }
 
+/// ToggleTrackItemStateCommand
+
+ToggleTrackItemStateCommand::ToggleTrackItemStateCommand(const SharedTrackItem& item, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Sequence(item->Track()->Sequence())
+    , m_ItemIndex(item->Track()->ItemIndex(item))
+    , m_TrackType(item->Track()->Type())
+{
+    const PlaybackTrack* const track = item->Track();
+    m_TrackIndex = track->Type() == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
+
+    setText("Toggle TrackItem");
+}
+
+void ToggleTrackItemStateCommand::undo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        item->SetEnabled(!item->Enabled());
+    }
+}
+
+bool ToggleTrackItemStateCommand::Redo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        item->SetEnabled(!item->Enabled());
+        return true;
+    }
+    return false;
+}
+
+/// ToggleTimelineEffectCommand
+
+ToggleTimelineEffectCommand::ToggleTimelineEffectCommand(Effect* effect, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Sequence(effect->TimelineItem()->Track()->Sequence())
+{
+    const PlaybackTrack* const track = effect->TimelineItem()->Track();
+    const TrackItem* const item = effect->TimelineItem();
+    m_TrackType = track->Type();
+    m_TrackIndex = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
+    m_ItemIndex = track->ItemIndex(item);
+    m_EffectIndex = item->EffectIndex(effect);
+}
+
+void ToggleTimelineEffectCommand::undo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        Effect* effect = item->EffectAt(m_EffectIndex);
+        effect->SetEnabled(!effect->Enabled());
+    }
+}
+
+bool ToggleTimelineEffectCommand::Redo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        Effect* effect = item->EffectAt(m_EffectIndex);
+        effect->SetEnabled(!effect->Enabled());
+        return true;
+    }
+    return false;
+}
+
 /// CreateTrackCommand
 
 CreateTrackCommand::CreateTrackCommand(const SharedPlaybackSequence& sequence, const Sequence::TrackType& type, QUndoCommand* parent)

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -331,8 +331,9 @@ void DeleteTrackCommand::undo()
 {
     if (SharedPlaybackSequence sequence = m_Sequence.lock())
     {
+        std::istringstream is(m_TrackData, std::ios::binary);
         SharedPlaybackTrack track = sequence->CreateTrack(m_Type, m_TrackIndex);
-        track->Deserialize(m_TrackData);
+        track->Deserialize(is);
     }
 }
 
@@ -340,13 +341,12 @@ bool DeleteTrackCommand::Redo()
 {
     if (SharedPlaybackSequence sequence = m_Sequence.lock())
     {
-        rapidjson::Document doc;
-        doc.SetObject();
-
-        rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>& allocator = doc.GetAllocator();
         if (const SharedPlaybackTrack track = sequence->VideoTrackAt(m_TrackIndex))
         {
-            track->Serialize(m_TrackData, allocator);
+            std::ostringstream os(std::ios::binary);
+            track->Serialize(os);
+            m_TrackData = os.str();
+
             track->Clear();
             sequence->RemoveTrack(track);
             return true;

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -404,6 +404,53 @@ bool DeleteTrackItemCommand::Redo()
     return false;
 }
 
+/// DeleteTimelineEffectCommand
+
+DeleteTimelineEffectCommand::DeleteTimelineEffectCommand(Effect* effect, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Sequence(effect->TimelineItem()->Track()->Sequence())
+{
+    const PlaybackTrack* const track = effect->TimelineItem()->Track();
+    const TrackItem* const item = effect->TimelineItem();
+    m_TrackType = track->Type();
+    m_TrackIndex = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
+    m_ItemIndex = track->ItemIndex(item);
+    m_EffectIndex = item->EffectIndex(effect);
+
+    m_EffectType = effect->TypeName();
+
+    setText("Delete Timeline Effect");
+}
+
+void DeleteTimelineEffectCommand::undo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        std::istringstream is(m_EffectData, std::ios::binary);
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        Effect* effect = EffectsBridge::Instance().CreateEffect(m_EffectType);
+        effect->Deserialize(is);
+        item->InsertEffect(effect, m_EffectIndex);
+    }
+}
+
+bool DeleteTimelineEffectCommand::Redo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        std::ostringstream os(std::ios::binary);
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        Effect* effect = item->EffectAt(m_EffectIndex);
+        effect->Serialize(os);
+        m_EffectData = os.str();
+        item->RemoveEffect(m_EffectIndex);
+        return true;
+    }
+    return false;
+}
+
 /// RazorTrackCommand
 
 RazorTrackCommand::RazorTrackCommand(const SharedPlaybackTrack& track, v_frame_t frame, QUndoCommand* parent)

--- a/src/VoidUi/Commands/SequenceCommands.h
+++ b/src/VoidUi/Commands/SequenceCommands.h
@@ -143,10 +143,10 @@ public:
     bool Redo() override;
 
 private:
+    std::string m_TrackData;
     std::weak_ptr<PlaybackSequence> m_Sequence;
     Sequence::TrackType m_Type;
     int m_TrackIndex;
-    rapidjson::Value m_TrackData;
 };
 
 class DeleteTrackItemCommand : public VoidUndoCommand

--- a/src/VoidUi/Commands/SequenceCommands.h
+++ b/src/VoidUi/Commands/SequenceCommands.h
@@ -177,7 +177,23 @@ private:
     int m_TrackIndex;
     int m_ItemIndex;
     int m_EffectIndex;
-    Sequence::TrackType m_TrackType;  
+    Sequence::TrackType m_TrackType;
+};
+
+class CreateTimelineEffectCommand : public VoidUndoCommand
+{
+public:
+    CreateTimelineEffectCommand(const SharedTrackItem& item, const std::string type, QUndoCommand* parent = nullptr);
+    void undo() override;
+    bool Redo() override;
+
+private:
+    std::string m_EffectType;
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
+    int m_ItemIndex;
+    int m_EffectIndex;
+    Sequence::TrackType m_TrackType;
 };
 
 class RazorTrackCommand : public VoidUndoCommand

--- a/src/VoidUi/Commands/SequenceCommands.h
+++ b/src/VoidUi/Commands/SequenceCommands.h
@@ -8,6 +8,7 @@
 #include "Definition.h"
 #include "VoidCommand.h"
 #include "VoidObjects/Sequence/TrackItem.h"
+#include "VoidObjects/Effects/Effects.h"
 #include "VoidUi/Sequencer/SController.h"
 
 VOID_NAMESPACE_OPEN
@@ -90,6 +91,35 @@ public:
 private:
     std::weak_ptr<PlaybackTrack> m_Track;
     bool m_Previous;
+};
+
+class ToggleTrackItemStateCommand : public VoidUndoCommand
+{
+public:
+    explicit ToggleTrackItemStateCommand(const SharedTrackItem& item, QUndoCommand* parent = nullptr);
+    void undo() override;
+    bool Redo() override;
+
+private:
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
+    int m_ItemIndex;
+    Sequence::TrackType m_TrackType;
+};
+
+class ToggleTimelineEffectCommand : public VoidUndoCommand
+{
+public:
+    explicit ToggleTimelineEffectCommand(Effect* effect, QUndoCommand* parent = nullptr);
+    void undo() override;
+    bool Redo() override;
+
+private:
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
+    int m_ItemIndex;
+    int m_EffectIndex;
+    Sequence::TrackType m_TrackType;
 };
 
 class CreateTrackCommand : public VoidUndoCommand

--- a/src/VoidUi/Commands/SequenceCommands.h
+++ b/src/VoidUi/Commands/SequenceCommands.h
@@ -8,7 +8,7 @@
 #include "Definition.h"
 #include "VoidCommand.h"
 #include "VoidObjects/Sequence/TrackItem.h"
-#include "VoidObjects/Effects/Effects.h"
+#include "VoidObjects/Effects/Bridge.h"
 #include "VoidUi/Sequencer/SController.h"
 
 VOID_NAMESPACE_OPEN
@@ -162,6 +162,22 @@ private:
     int m_TrackIndex;
     int m_ItemIndex;
     std::string m_ItemData;
+};
+
+class DeleteTimelineEffectCommand : public VoidUndoCommand
+{
+public:
+    explicit DeleteTimelineEffectCommand(Effect* effect, QUndoCommand* parent = nullptr);
+    void undo() override;
+    bool Redo() override;
+
+private:
+    std::string m_EffectData, m_EffectType;
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
+    int m_ItemIndex;
+    int m_EffectIndex;
+    Sequence::TrackType m_TrackType;  
 };
 
 class RazorTrackCommand : public VoidUndoCommand

--- a/src/VoidUi/Editor/Effects.cpp
+++ b/src/VoidUi/Editor/Effects.cpp
@@ -67,10 +67,12 @@ void EffectEditor::Build()
     m_NameEdit = new QLineEdit;
     m_NameEdit->setText(m_Effect->Name().c_str());
 
+    m_ColorButton = new ColorSelectionButton;
     m_EnableButton = new QToolButton;
     m_CloseButton = new CloseButton;
 
     title->addWidget(m_NameEdit);
+    title->addWidget(m_ColorButton);
     title->addWidget(m_EnableButton);
     title->addWidget(m_CloseButton);
 
@@ -120,9 +122,11 @@ void EffectEditor::Setup()
     m_EnableButton->setAutoRaise(true);
 
     m_EnableButton->setChecked(m_Effect->Enabled());
+    m_ColorButton->SetColor(m_Effect->Color());
 
     m_EnableButton->setFixedSize(16, 16);
     m_CloseButton->setFixedSize(16, 16);
+    m_ColorButton->setFixedSize(16, 16);
 
     // Match the Effect Name, for finding the widget corresponding to the effect
     setObjectName(m_Effect->Name().c_str());
@@ -143,6 +147,7 @@ void EffectEditor::Connect()
         m_Effect->SetEnabled(checked);
         _PlayerBridge.Refresh();
     });
+    connect(m_ColorButton, &ColorSelectionButton::colorChanged, m_Effect, &Effect::SetColor);
 }
 
 void EffectEditor::SetupIntParam(QGridLayout* grid, int row, const Param* param)

--- a/src/VoidUi/Editor/Effects.h
+++ b/src/VoidUi/Editor/Effects.h
@@ -33,6 +33,7 @@ protected:
 private: /* Members */
     QVBoxLayout* m_Layout;
     QLineEdit* m_NameEdit;
+    ColorSelectionButton* m_ColorButton;
     QToolButton* m_EnableButton;
     CloseButton* m_CloseButton;
 

--- a/src/VoidUi/QExtensions/PushButton.cpp
+++ b/src/VoidUi/QExtensions/PushButton.cpp
@@ -105,33 +105,30 @@ ColorSelectionButton::ColorSelectionButton(const QColor& color, QWidget* parent)
     : QPushButton(parent)
     , m_Color(color)
 {
-    /* Connect to allow selecting Color */
     connect(this, &QPushButton::clicked, this, &ColorSelectionButton::SelectColor);
+}
+
+void ColorSelectionButton::SetColor(const QColor& color)
+{
+    m_Color = color;
+    update();
 }
 
 void ColorSelectionButton::paintEvent(QPaintEvent* event)
 {
-    /* Add the current color as what'll be displayed on the button */
     QPainter painter(this);
-
     painter.setPen(Qt::black);
     painter.setBrush(QBrush(m_Color));
-
     painter.drawRect(rect());
 }
 
 void ColorSelectionButton::SelectColor()
 {
     QColor selected = QColorDialog::getColor(m_Color, this, "Select Color");
-
-    /* If we have a valid and different color selected */
     if (selected.isValid() && selected != m_Color)
     {
-        /* Update the color */
         m_Color = selected;
-        /* Emit the updated color */
         emit colorChanged(m_Color);
-        /* And repaint */
         update();
     }
 }

--- a/src/VoidUi/QExtensions/PushButton.h
+++ b/src/VoidUi/QExtensions/PushButton.h
@@ -62,6 +62,7 @@ class ColorSelectionButton : public QPushButton
 public:
     ColorSelectionButton(QWidget* parent = nullptr);
     ColorSelectionButton(const QColor& color, QWidget* parent = nullptr);
+    void SetColor(const QColor& color);
 
 signals:
     /**

--- a/src/VoidUi/Sequencer/Graphics/SHandleItem.h
+++ b/src/VoidUi/Sequencer/Graphics/SHandleItem.h
@@ -14,7 +14,7 @@ class SHandleItem : public STimelineItem
 {
 public:
     SHandleItem(int handle, SequencerContext* context, QGraphicsItem* parent = nullptr);
-    void Update();
+    void Update() override;
     void Update(int handle);
 
 protected:

--- a/src/VoidUi/Sequencer/Graphics/SRazorItem.cpp
+++ b/src/VoidUi/Sequencer/Graphics/SRazorItem.cpp
@@ -32,6 +32,13 @@ void SRazorItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option
     painter->drawLine(QPoint(0, 0), QPoint(0, boundingRect().height()));
 }
 
+void SRazorItem::SetHeight(int height)
+{
+    prepareGeometryChange();
+    m_BoundingRect = QRectF(-1, 0, 2, height);
+    update();    
+}
+
 /// STrackRazorItem
 
 STrackRazorItem::STrackRazorItem(SequencerContext* context, QGraphicsItem* parent)

--- a/src/VoidUi/Sequencer/Graphics/SRazorItem.h
+++ b/src/VoidUi/Sequencer/Graphics/SRazorItem.h
@@ -15,6 +15,7 @@ public:
     explicit SRazorItem(SequencerContext* context, QGraphicsItem* parent = nullptr);
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
     void SetX(int x);
+    void SetHeight(int height);
 };
 
 class STrackRazorItem : public SRazorItem

--- a/src/VoidUi/Sequencer/Graphics/STimelineEffect.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STimelineEffect.cpp
@@ -20,6 +20,7 @@ STimelineEffect::STimelineEffect(Effect* effect, SequencerContext* context, QGra
     CalculateBoundingBox();
     connect(m_Context->SelectionModel(), &SSelectionModel::selectionChanged, this, [this]() { update(); });
     connect(m_Context->SelectionModel(), &SSelectionModel::effectSelectionChanged, this, [this]() { update(); });
+    connect(m_Effect, &Effect::rangeChanged, this, &STimelineEffect::Update);
     connect(m_Effect, &Effect::updated, this, [this]() { update(); });
 }
 
@@ -49,6 +50,13 @@ void STimelineEffect::paint(QPainter* painter, const QStyleOptionGraphicsItem* o
     );
     painter->setPen(Qt::black);
     painter->drawText(boundingRect().adjusted(10, 0, -2, 0), Qt::AlignLeft | Qt::AlignVCenter, m_Effect->Name().c_str());
+}
+
+void STimelineEffect::SetWidth(double width)
+{
+    prepareGeometryChange();
+    m_BoundingRect = QRectF(0, 0, width, Sequencer::TimelineEffectHeight);
+    update();
 }
 
 void STimelineEffect::Update()

--- a/src/VoidUi/Sequencer/Graphics/STimelineEffect.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STimelineEffect.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+/* Qt */
+#include <QGraphicsSceneMouseEvent>
+#include <QPainter>
+#include <QStyleOptionGraphicsItem>
+
+/* Internal */
+#include "STimelineEffect.h"
+#include "VoidObjects/Effects/Effects.h"
+#include "VoidCore/Logging.h"
+
+VOID_NAMESPACE_OPEN
+
+STimelineEffect::STimelineEffect(Effect* effect, SequencerContext* context, QGraphicsItem* parent)
+    : STimelineItem(context, parent)
+    , m_Effect(effect)
+{
+    CalculateBoundingBox();
+    connect(m_Context->SelectionModel(), &SSelectionModel::selectionChanged, this, [this]() { update(); });
+    connect(m_Context->SelectionModel(), &SSelectionModel::effectSelectionChanged, this, [this]() { update(); });
+}
+
+void STimelineEffect::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
+{
+
+    if (m_Context->SelectionModel()->IsSelected(m_Effect->TimelineItem()) || m_Context->SelectionModel()->IsSelected(m_Effect))
+    {
+        painter->setPen(QPen(option->palette.color(QPalette::Highlight)));
+        painter->setBrush(option->palette.color(QPalette::Highlight).darker(180));
+    }
+    else
+    {
+        painter->setPen(QPen(option->palette.color(QPalette::Dark)));
+        painter->setBrush(m_Effect->Color());
+    }
+
+    painter->drawRect(boundingRect());
+
+    painter->fillRect(2, 2, std::min(6, static_cast<int>(boundingRect().width()) - 2) , Sequencer::TimelineEffectHeight - 4, m_Effect->Color());
+    painter->setPen(Qt::black);
+    painter->drawText(boundingRect().adjusted(10, 0, -2, 0), Qt::AlignLeft | Qt::AlignTop, m_Effect->Name().c_str());
+}
+
+void STimelineEffect::Update()
+{
+    prepareGeometryChange();
+    CalculateBoundingBox();
+
+    update();
+}
+
+void STimelineEffect::mousePressEvent(QGraphicsSceneMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton)
+    {
+        if (m_Context->Action() == SequencerAction::NONE)
+        {
+            if (event->modifiers() & Qt::ControlModifier)
+                m_Context->SelectionModel()->Toggle(m_Effect);
+            else
+                m_Context->SelectionModel()->Select(m_Effect);
+        }
+    }
+
+    STimelineItem::mousePressEvent(event);
+}
+
+void STimelineEffect::CalculateBoundingBox()
+{
+    const double width = m_Context->Geometry()->FrameToSceneX(m_Effect->TimelineOut() + 1) - m_Context->Geometry()->FrameToSceneX(m_Effect->TimelineIn());
+    m_BoundingRect = QRectF(0, 0, width, Sequencer::TimelineEffectHeight);
+}
+
+VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequencer/Graphics/STimelineEffect.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STimelineEffect.cpp
@@ -20,6 +20,7 @@ STimelineEffect::STimelineEffect(Effect* effect, SequencerContext* context, QGra
     CalculateBoundingBox();
     connect(m_Context->SelectionModel(), &SSelectionModel::selectionChanged, this, [this]() { update(); });
     connect(m_Context->SelectionModel(), &SSelectionModel::effectSelectionChanged, this, [this]() { update(); });
+    connect(m_Effect, &Effect::updated, this, [this]() { update(); });
 }
 
 void STimelineEffect::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
@@ -33,14 +34,21 @@ void STimelineEffect::paint(QPainter* painter, const QStyleOptionGraphicsItem* o
     else
     {
         painter->setPen(QPen(option->palette.color(QPalette::Dark)));
-        painter->setBrush(m_Effect->Color());
+        painter->setBrush(
+            m_Effect->Enabled() ? m_Effect->Color() : m_Effect->Color().darker(350)
+        );
     }
 
     painter->drawRect(boundingRect());
-
-    painter->fillRect(2, 2, std::min(6, static_cast<int>(boundingRect().width()) - 2) , Sequencer::TimelineEffectHeight - 4, m_Effect->Color());
+    painter->fillRect(
+        2,
+        2,
+        std::min(6, static_cast<int>(boundingRect().width()) - 2),
+        Sequencer::TimelineEffectHeight - 4,
+        m_Effect->Enabled() ? m_Effect->Color() : m_Effect->Color().darker(350)
+    );
     painter->setPen(Qt::black);
-    painter->drawText(boundingRect().adjusted(10, 0, -2, 0), Qt::AlignLeft | Qt::AlignTop, m_Effect->Name().c_str());
+    painter->drawText(boundingRect().adjusted(10, 0, -2, 0), Qt::AlignLeft | Qt::AlignVCenter, m_Effect->Name().c_str());
 }
 
 void STimelineEffect::Update()
@@ -65,6 +73,12 @@ void STimelineEffect::mousePressEvent(QGraphicsSceneMouseEvent* event)
     }
 
     STimelineItem::mousePressEvent(event);
+}
+
+void STimelineEffect::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
+{
+    m_Context->Controller()->EditEffect(m_Effect);
+    STimelineItem::mouseDoubleClickEvent(event);
 }
 
 void STimelineEffect::CalculateBoundingBox()

--- a/src/VoidUi/Sequencer/Graphics/STimelineEffect.h
+++ b/src/VoidUi/Sequencer/Graphics/STimelineEffect.h
@@ -23,6 +23,7 @@ public:
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
 
 private:
     Effect* m_Effect;

--- a/src/VoidUi/Sequencer/Graphics/STimelineEffect.h
+++ b/src/VoidUi/Sequencer/Graphics/STimelineEffect.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 waaake
+// Licensed under the MIT License
+
+#ifndef _SEQUENCER_TIMELINE_EFFECT_H
+#define _SEQUENCER_TIMELINE_EFFECT_H
+
+/* Internal */
+#include "Definition.h"
+#include "STimelineItem.h"
+
+VOID_NAMESPACE_OPEN
+
+class Effect;
+
+class STimelineEffect : public STimelineItem
+{
+public:
+    STimelineEffect(Effect* effect, SequencerContext* context, QGraphicsItem* parent = nullptr);
+
+    Effect* TimelineEffect() const { return m_Effect; }
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
+    void Update() override;
+
+protected:
+    void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+
+private:
+    Effect* m_Effect;
+
+private: /* Methods */
+    void CalculateBoundingBox();
+};
+
+VOID_NAMESPACE_CLOSE
+
+#endif // _SEQUENCER_TIMELINE_EFFECT_H

--- a/src/VoidUi/Sequencer/Graphics/STimelineEffect.h
+++ b/src/VoidUi/Sequencer/Graphics/STimelineEffect.h
@@ -19,6 +19,7 @@ public:
 
     Effect* TimelineEffect() const { return m_Effect; }
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
+    void SetWidth(double width);
     void Update() override;
 
 protected:

--- a/src/VoidUi/Sequencer/Graphics/STrack.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrack.cpp
@@ -171,7 +171,10 @@ void STrack::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
     STimelineItem::hoverEnterEvent(event);
 
     if (m_Context->Action() == SequencerAction::RAZOR)
+    {
         m_RazorMarker->setVisible(true);
+        m_RazorMarker->SetHeight(boundingRect().height());
+    }
 }
 
 void STrack::hoverMoveEvent(QGraphicsSceneHoverEvent* event)

--- a/src/VoidUi/Sequencer/Graphics/STrack.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrack.cpp
@@ -25,9 +25,18 @@ STrack::STrack(const SharedPlaybackTrack& track, SequencerContext* context, QGra
     connect(m_Track.get(), &PlaybackTrack::itemAdded, this, &STrack::AddItem);
     connect(m_Track.get(), &PlaybackTrack::cleared, this, &STrack::Clear);
     connect(m_Track.get(), &PlaybackTrack::itemAboutToBeRemoved, this, &STrack::RemoveItem);
+    connect(m_Track.get(), &PlaybackTrack::itemRemoved, this, &STrack::Update);
 
-    m_BoundingRect = QRectF(0, 0, Sequencer::SceneWidth, Sequencer::TrackHeight);
-    setPos(0, context->Geometry()->TrackRect(track->TrackIndex()).top());
+    int index = track->TrackIndex();
+    m_BoundingRect = QRectF(
+        0,
+        0,
+        Sequencer::SceneWidth,
+        m_Track->Type() == Sequence::TrackType::VIDEO
+            ? m_Context->Geometry()->VideoTrackHeight(index)
+            : m_Context->Geometry()->AudioTrackHeight(index)
+    );
+    setPos(0, context->Geometry()->TrackRect(index).top());
     BuildItems();
 
     m_RazorMarker = new STrackRazorItem(context, this);
@@ -58,7 +67,17 @@ void STrack::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QW
 void STrack::Update()
 {
     prepareGeometryChange();
-    setPos(0, m_Context->Geometry()->TrackRect(m_Track->TrackIndex()).top());
+    int index = m_Track->TrackIndex();
+    setPos(0, m_Context->Geometry()->TrackRect(index).top());
+    
+    m_BoundingRect = QRectF(
+        0,
+        0,
+        Sequencer::SceneWidth,
+        m_Track->Type() == Sequence::TrackType::VIDEO
+            ? m_Context->Geometry()->VideoTrackHeight(index)
+            : m_Context->Geometry()->AudioTrackHeight(index)
+    );
 
     update();
 }
@@ -107,7 +126,10 @@ void STrack::UpdateItem(const SharedTrackItem& item)
 void STrack::UpdateItems()
 {
     for (auto& [_, trackitem] : m_Items)
+    {
         trackitem->Update();
+        trackitem->UpdateItems();
+    }
 }
 
 STrackItem* STrack::ItemAt(int index) const
@@ -170,8 +192,8 @@ void STrack::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 
 void STrack::BuildItems()
 {
-    m_Items.reserve(m_Track->ItemCount());
-    for (int i = 0; i < m_Track->ItemCount(); ++i)
+    m_Items.reserve(m_Track->NumItems());
+    for (int i = 0; i < m_Track->NumItems(); ++i)
         AddItem(m_Track->ItemAt(i));
 }
 

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
@@ -39,6 +39,7 @@ STrackItem::STrackItem(const SharedTrackItem& item, SequencerContext* context, Q
     connect(m_Item.get(), &TrackItem::updated, this, &STrackItem::Update);
     connect(m_Item.get(), &TrackItem::rangeChanged, this, &STrackItem::Update);
     connect(m_Item.get(), &TrackItem::effectCreated, this, static_cast<void (STrackItem::*)(Effect*)>(&STrackItem::AddEffect));
+    connect(m_Item.get(), &TrackItem::effectAboutToBeRemoved, this, &STrackItem::RemoveEffect);
 
     AddEffects();
 }
@@ -174,6 +175,23 @@ void STrackItem::AddEffects()
 {
     for (int i = 0; i < m_Item->NumEffects(); ++i)
         AddEffect(m_Item->EffectAt(i), i);
+}
+
+void STrackItem::RemoveEffect(Effect* effect)
+{
+    // auto it = m_Effects.find(effect);
+    // if (it == m_Effects.end())
+    //     return;
+    if (m_Effects.find(effect) == m_Effects.end()) return;
+
+    STimelineEffect*& teffect = m_Effects[effect];
+    teffect->setParent(nullptr);
+    teffect->setVisible(false);
+    teffect->deleteLater();
+    delete teffect;
+    teffect = nullptr;
+
+    m_Effects.erase(effect);
 }
 
 void STrackItem::mousePressEvent(QGraphicsSceneMouseEvent* event)
@@ -424,21 +442,36 @@ void STrackItem::AdjustTimelineRange(v_frame_t frame)
 
 QColor STrackItem::Background(const QStyleOptionGraphicsItem* option) const
 {
-    if (Track()->Locked()) return option->palette.color(QPalette::Base).darker(150);
+//     if (Track()->Locked()) return option->palette.color(QPalette::Base).darker(150);
 
-    if (Track()->Enabled())
+//     if (!Track()->Enabled() || !m_Item->Enabled())
+//     {
+//         return m_Context->SelectionModel()->IsSelected(m_Item)
+//             ? option->palette.color(QPalette::Highlight).darker(180)
+//             : option->palette.color(QPalette::Base).darker(180);
+//     }
+
+//     QColor color = m_Item->Color().darker(250);
+//     return m_Context->SelectionModel()->IsSelected(m_Item)
+//         ? option->palette.color(QPalette::Highlight).darker(180)
+//         : m_Context->HoverModel()->IsHovered(m_Item) ? color.darker(140) : color;
+
+    if (Track()->Locked()) return option->palette.color(QPalette::Base).darker(150);
+    if (m_Context->SelectionModel()->IsSelected(m_Item)) return option->palette.color(QPalette::Highlight).darker(180);
+
+    if (Track()->Enabled() && m_Item->Enabled())
     {
+        // if (m_Context->SelectionModel()->IsSelected(m_Item)) return option->palette.color(QPalette::Highlight).darker(180);
         QColor color = m_Item->Color().darker(250);
-        return m_Context->SelectionModel()->IsSelected(m_Item)
-            ? option->palette.color(QPalette::Highlight).darker(180)
-            : m_Context->HoverModel()->IsHovered(m_Item)
-                ? color.darker(140)
-                : color;
+        return m_Context->HoverModel()->IsHovered(m_Item) ? color.darker(140) : color;
     }
 
-    return m_Context->SelectionModel()->IsSelected(m_Item)
-            ? option->palette.color(QPalette::Highlight).darker(180)
-            : option->palette.color(QPalette::Base).darker(180);
+    // Disabled
+    return option->palette.color(QPalette::Base).darker(180);
+
+    // return  m_Context->SelectionModel()->IsSelected(m_Item)
+    //         ? option->palette.color(QPalette::Highlight).darker(180)
+    //         : option->palette.color(QPalette::Base).darker(180);
 }
 
 int STrackItem::YPos() const

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
@@ -428,11 +428,12 @@ QColor STrackItem::Background(const QStyleOptionGraphicsItem* option) const
 
     if (Track()->Enabled())
     {
+        QColor color = m_Item->Color().darker(250);
         return m_Context->SelectionModel()->IsSelected(m_Item)
             ? option->palette.color(QPalette::Highlight).darker(180)
             : m_Context->HoverModel()->IsHovered(m_Item)
-                ? option->palette.color(QPalette::Base).darker(140)
-                : option->palette.color(QPalette::Base).darker(110);
+                ? color.darker(140)
+                : color;
     }
 
     return m_Context->SelectionModel()->IsSelected(m_Item)
@@ -453,9 +454,9 @@ void STrackItem::ToggleHandles(int head, int tail, int duration, bool visible)
     if (visible)
     {
         // This results in a matrix mult -- need to see if there is a better way to do this
-        m_HeadHandle->setPos(mapToScene(0 - m_Context->Geometry()->FrameToSceneX(head), 2));
-        m_TailHandle->setPos(mapToScene(boundingRect().width(), 2));
-        m_DurationHandle->setPos(mapToScene(0, 2));
+        m_HeadHandle->setPos(mapToScene(0 - m_Context->Geometry()->FrameToSceneX(head), 22));
+        m_TailHandle->setPos(mapToScene(boundingRect().width(), 22));
+        m_DurationHandle->setPos(mapToScene(0, 22));
         m_HeadHandle->Update(head);
         m_TailHandle->Update(tail);
         m_DurationHandle->Update(duration);

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
@@ -434,10 +434,18 @@ void STrackItem::AdjustTimelineRange(v_frame_t frame)
     }
 
     m_BoundingRect = QRectF(0, 0, width, Sequencer::TrackItemHeight - 4);
+    // Need to see how expensive this becomes, we don't want slowness while dragging -- so keeping an eye on performance
+    AdjustEffectsWidth(width);
 
     // Dynamic handles shifting as we move
     ToggleHandles(head, tail, m_Item->Duration() - m_TrimContext.handle, true);
     update();
+}
+
+void STrackItem::AdjustEffectsWidth(double width)
+{
+    for (auto& [_, teffect] : m_Effects)
+        teffect->SetWidth(width);
 }
 
 QColor STrackItem::Background(const QStyleOptionGraphicsItem* option) const

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
@@ -179,9 +179,6 @@ void STrackItem::AddEffects()
 
 void STrackItem::RemoveEffect(Effect* effect)
 {
-    // auto it = m_Effects.find(effect);
-    // if (it == m_Effects.end())
-    //     return;
     if (m_Effects.find(effect) == m_Effects.end()) return;
 
     STimelineEffect*& teffect = m_Effects[effect];
@@ -450,20 +447,6 @@ void STrackItem::AdjustEffectsWidth(double width)
 
 QColor STrackItem::Background(const QStyleOptionGraphicsItem* option) const
 {
-//     if (Track()->Locked()) return option->palette.color(QPalette::Base).darker(150);
-
-//     if (!Track()->Enabled() || !m_Item->Enabled())
-//     {
-//         return m_Context->SelectionModel()->IsSelected(m_Item)
-//             ? option->palette.color(QPalette::Highlight).darker(180)
-//             : option->palette.color(QPalette::Base).darker(180);
-//     }
-
-//     QColor color = m_Item->Color().darker(250);
-//     return m_Context->SelectionModel()->IsSelected(m_Item)
-//         ? option->palette.color(QPalette::Highlight).darker(180)
-//         : m_Context->HoverModel()->IsHovered(m_Item) ? color.darker(140) : color;
-
     if (Track()->Locked()) return option->palette.color(QPalette::Base).darker(150);
     if (m_Context->SelectionModel()->IsSelected(m_Item)) return option->palette.color(QPalette::Highlight).darker(180);
 
@@ -476,10 +459,6 @@ QColor STrackItem::Background(const QStyleOptionGraphicsItem* option) const
 
     // Disabled
     return option->palette.color(QPalette::Base).darker(180);
-
-    // return  m_Context->SelectionModel()->IsSelected(m_Item)
-    //         ? option->palette.color(QPalette::Highlight).darker(180)
-    //         : option->palette.color(QPalette::Base).darker(180);
 }
 
 int STrackItem::YPos() const

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
@@ -9,6 +9,7 @@
 /* Internal */
 #include "STrackItem.h"
 #include "STrack.h"
+#include "STimelineEffect.h"
 #include "VoidUi/Sequencer/SContext.h"
 #include "VoidCore/Logging.h"
 
@@ -32,11 +33,14 @@ STrackItem::STrackItem(const SharedTrackItem& item, SequencerContext* context, Q
     ToggleHandles();
 
     CalculateBoundingRect();
-    setPos(context->Geometry()->FrameToSceneX(item->TimelineIn()), 2);
+    setPos(context->Geometry()->FrameToSceneX(item->TimelineIn()), YPos());
 
     connect(m_Context->SelectionModel(), &SSelectionModel::selectionChanged, this, [this]() { update(); });
     connect(m_Item.get(), &TrackItem::updated, this, &STrackItem::Update);
     connect(m_Item.get(), &TrackItem::rangeChanged, this, &STrackItem::Update);
+    connect(m_Item.get(), &TrackItem::effectCreated, this, static_cast<void (STrackItem::*)(Effect*)>(&STrackItem::AddEffect));
+
+    AddEffects();
 }
 
 STrackItem::~STrackItem()
@@ -142,9 +146,34 @@ void STrackItem::Update()
 {
     prepareGeometryChange();
     CalculateBoundingRect();
-    setPos(m_Context->Geometry()->FrameToSceneX(m_Item->TimelineIn()), 2);
+    setPos(m_Context->Geometry()->FrameToSceneX(m_Item->TimelineIn()), YPos());
 
     update();
+}
+
+void STrackItem::UpdateItems()
+{
+    for (auto& [_, effect] : m_Effects)
+        effect->Update();
+}
+
+void STrackItem::AddEffect(Effect* effect)
+{
+    AddEffect(effect, m_Item->EffectIndex(effect));
+}
+
+void STrackItem::AddEffect(Effect* effect, int index)
+{
+    STimelineEffect* timelineEffect = new STimelineEffect(effect, m_Context, this);
+    timelineEffect->setPos(0, -(Sequencer::TimelineEffectHeight + index * Sequencer::TimelineEffectHeight));
+
+    m_Effects[effect] = timelineEffect;
+}
+
+void STrackItem::AddEffects()
+{
+    for (int i = 0; i < m_Item->NumEffects(); ++i)
+        AddEffect(m_Item->EffectAt(i), i);
 }
 
 void STrackItem::mousePressEvent(QGraphicsSceneMouseEvent* event)
@@ -371,7 +400,7 @@ void STrackItem::AdjustTimelineRange(v_frame_t frame)
     {
         frame = std::min(std::max(frame, m_Item->TimelineIn() - m_Item->HeadHandle()), m_Item->TimelineOut());
         width = m_Context->Geometry()->FrameToSceneX(m_Item->TimelineOut() + 1) - m_Context->Geometry()->FrameToSceneX(frame);
-        setPos(m_Context->Geometry()->FrameToSceneX(frame), 2);
+        setPos(m_Context->Geometry()->FrameToSceneX(frame), YPos());
 
         m_TrimContext.handle = frame - m_Item->TimelineIn();
         head += m_TrimContext.handle;
@@ -380,7 +409,7 @@ void STrackItem::AdjustTimelineRange(v_frame_t frame)
     {
         frame = std::max(std::min(frame, m_Item->TimelineOut() + m_Item->TailHandle()), m_Item->TimelineIn());
         width = m_Context->Geometry()->FrameToSceneX(frame + 1) - m_Context->Geometry()->FrameToSceneX(m_Item->TimelineIn());
-        setPos(m_Context->Geometry()->FrameToSceneX(m_Item->TimelineIn()), 2);
+        setPos(m_Context->Geometry()->FrameToSceneX(m_Item->TimelineIn()), YPos());
 
         m_TrimContext.handle = m_Item->TimelineOut() - frame;
         tail += m_TrimContext.handle;
@@ -409,6 +438,11 @@ QColor STrackItem::Background(const QStyleOptionGraphicsItem* option) const
     return m_Context->SelectionModel()->IsSelected(m_Item)
             ? option->palette.color(QPalette::Highlight).darker(180)
             : option->palette.color(QPalette::Base).darker(180);
+}
+
+int STrackItem::YPos() const
+{
+    return Track()->boundingRect().height() - Sequencer::TrackItemHeight + 2;
 }
 
 void STrackItem::ToggleHandles(int head, int tail, int duration, bool visible)

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.h
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.h
@@ -4,6 +4,9 @@
 #ifndef _SEQUENCER_TRACK_ITEM_H
 #define _SEQUENCER_TRACK_ITEM_H
 
+/* STD */
+#include <unordered_map>
+
 // /* Qt */
 // #include <QGraphicsObject>
 
@@ -17,6 +20,7 @@ VOID_NAMESPACE_OPEN
 
 // class SequencerContext;
 class STrack;
+class STimelineEffect;
 
 class STrackItem : public STimelineItem
 {
@@ -30,6 +34,11 @@ public:
     STrack* Track() const;
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
     void Update() override;
+    void UpdateItems();
+
+    void AddEffect(Effect* effect);
+    void AddEffect(Effect* effect, int index);
+    void AddEffects();
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
@@ -40,6 +49,7 @@ protected:
     void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
 
 private:
+    std::unordered_map<Effect*, STimelineEffect*> m_Effects;
     SSlipClipContext m_SlipContext;
     SItemTrimContext m_TrimContext;
     QRectF m_HeadTrimRect, m_TailTrimRect;
@@ -49,6 +59,7 @@ private:
 private: /* Methods */
     void CalculateBoundingRect();
     void AdjustTimelineRange(v_frame_t frame);
+    int YPos() const;
     void ToggleHandles(int head = 0, int tail = 0, int duration = 0, bool visible = false);
     QColor Background(const QStyleOptionGraphicsItem* option) const;
 };

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.h
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.h
@@ -60,6 +60,7 @@ private:
 private: /* Methods */
     void CalculateBoundingRect();
     void AdjustTimelineRange(v_frame_t frame);
+    void AdjustEffectsWidth(double width);
     int YPos() const;
     void ToggleHandles(int head = 0, int tail = 0, int duration = 0, bool visible = false);
     QColor Background(const QStyleOptionGraphicsItem* option) const;

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.h
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.h
@@ -39,6 +39,7 @@ public:
     void AddEffect(Effect* effect);
     void AddEffect(Effect* effect, int index);
     void AddEffects();
+    void RemoveEffect(Effect* effect);
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent* event) override;

--- a/src/VoidUi/Sequencer/Models/SSelectionModel.cpp
+++ b/src/VoidUi/Sequencer/Models/SSelectionModel.cpp
@@ -41,13 +41,13 @@ void SSelectionModel::Select(const SharedPlaybackTrack& track)
     emit trackSelectionChanged();
 }
 
-void SSelectionModel::Select(const Effect* effect)
+void SSelectionModel::Select(Effect* effect)
 {
     m_Effects.insert(effect);
     emit effectSelectionChanged();
 }
 
-void SSelectionModel::Select(const std::vector<const Effect*>& effects)
+void SSelectionModel::Select(const std::vector<Effect*>& effects)
 {
     m_Effects.clear();
     m_Effects.reserve(effects.size());
@@ -70,7 +70,7 @@ void SSelectionModel::Deselect(const SharedPlaybackTrack& track)
     emit trackSelectionChanged();
 }
 
-void SSelectionModel::Deselect(const Effect* effect)
+void SSelectionModel::Deselect(Effect* effect)
 {
     m_Effects.erase(effect);
     emit effectSelectionChanged();
@@ -96,7 +96,7 @@ void SSelectionModel::Toggle(const SharedPlaybackTrack& track)
     emit trackSelectionChanged();
 }
 
-void SSelectionModel::Toggle(const Effect* effect)
+void SSelectionModel::Toggle(Effect* effect)
 {
     if (m_Effects.find(effect) == m_Effects.end())
         m_Effects.insert(effect);
@@ -130,7 +130,7 @@ bool SSelectionModel::IsSelected(const SharedPlaybackTrack& track)
     return m_Tracks.find(track) != m_Tracks.end();
 }
 
-bool SSelectionModel::IsSelected(const Effect* effect)
+bool SSelectionModel::IsSelected(Effect* effect)
 {
     return m_Effects.find(effect) != m_Effects.end();
 }

--- a/src/VoidUi/Sequencer/Models/SSelectionModel.cpp
+++ b/src/VoidUi/Sequencer/Models/SSelectionModel.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* STD */
+#include <algorithm> // std::find_if
+
 /* Internal */
 #include "SSelectionModel.h"
 
@@ -10,8 +13,10 @@ void SSelectionModel::Clear()
 {
     m_Items.clear();
     m_Tracks.clear();
+    m_Effects.clear();
     emit selectionChanged();
     emit trackSelectionChanged();
+    emit effectSelectionChanged();
 }
 
 void SSelectionModel::Select(const SharedTrackItem& item)
@@ -36,6 +41,23 @@ void SSelectionModel::Select(const SharedPlaybackTrack& track)
     emit trackSelectionChanged();
 }
 
+void SSelectionModel::Select(const Effect* effect)
+{
+    m_Effects.insert(effect);
+    emit effectSelectionChanged();
+}
+
+void SSelectionModel::Select(const std::vector<const Effect*>& effects)
+{
+    m_Effects.clear();
+    m_Effects.reserve(effects.size());
+
+    for (auto& effect : effects)
+        m_Effects.insert(effect);
+
+    emit effectSelectionChanged();
+}
+
 void SSelectionModel::Deselect(const SharedTrackItem& item)
 {
     m_Items.erase(item);
@@ -46,6 +68,12 @@ void SSelectionModel::Deselect(const SharedPlaybackTrack& track)
 {
     m_Tracks.erase(track);
     emit trackSelectionChanged();
+}
+
+void SSelectionModel::Deselect(const Effect* effect)
+{
+    m_Effects.erase(effect);
+    emit effectSelectionChanged();
 }
 
 void SSelectionModel::Toggle(const SharedTrackItem& item)
@@ -68,6 +96,30 @@ void SSelectionModel::Toggle(const SharedPlaybackTrack& track)
     emit trackSelectionChanged();
 }
 
+void SSelectionModel::Toggle(const Effect* effect)
+{
+    if (m_Effects.find(effect) == m_Effects.end())
+        m_Effects.insert(effect);
+    else
+        m_Effects.erase(effect);
+
+    emit effectSelectionChanged();
+}
+
+bool SSelectionModel::IsSelected(const TrackItem* item)
+{
+    auto it = std::find_if(
+        m_Items.begin(),
+        m_Items.end(),
+        [item](const SharedTrackItem& _i) -> bool
+        {
+            return _i.get() == item;
+        }
+    );
+
+    return it != m_Items.end();
+}
+
 bool SSelectionModel::IsSelected(const SharedTrackItem& item)
 {
     return m_Items.find(item) != m_Items.end();
@@ -76,6 +128,11 @@ bool SSelectionModel::IsSelected(const SharedTrackItem& item)
 bool SSelectionModel::IsSelected(const SharedPlaybackTrack& track)
 {
     return m_Tracks.find(track) != m_Tracks.end();
+}
+
+bool SSelectionModel::IsSelected(const Effect* effect)
+{
+    return m_Effects.find(effect) != m_Effects.end();
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequencer/Models/SSelectionModel.h
+++ b/src/VoidUi/Sequencer/Models/SSelectionModel.h
@@ -15,6 +15,7 @@
 #include "Definition.h"
 #include "VoidObjects/Sequence/Track.h"
 #include "VoidObjects/Sequence/TrackItem.h"
+#include "VoidObjects/Effects/Effects.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -26,13 +27,19 @@ public:
     void Select(const SharedTrackItem& item);
     void Select(const std::vector<SharedTrackItem>& items);
     void Select(const SharedPlaybackTrack& track);
+    void Select(const Effect* effect);
+    void Select(const std::vector<const Effect*>& effects);
     void Deselect(const SharedTrackItem& item);
     void Deselect(const SharedPlaybackTrack& track);
+    void Deselect(const Effect* effect);
     void Toggle(const SharedTrackItem& item);
     void Toggle(const SharedPlaybackTrack& track);
+    void Toggle(const Effect* effect);
 
+    bool IsSelected(const TrackItem* item);
     bool IsSelected(const SharedTrackItem& item);
     bool IsSelected(const SharedPlaybackTrack& track);
+    bool IsSelected(const Effect* effect);
     bool HasTrackItemSelection() const { return !m_Items.empty(); }
     bool HasTrackSelection() const { return !m_Tracks.empty(); }
     const std::unordered_set<SharedTrackItem>& SelectedItems() const { return m_Items; }
@@ -41,9 +48,11 @@ public:
 signals:
     void selectionChanged();
     void trackSelectionChanged();
+    void effectSelectionChanged();
 
 private:
     std::unordered_set<SharedTrackItem> m_Items;
+    std::unordered_set<const Effect*> m_Effects;
     std::unordered_set<SharedPlaybackTrack> m_Tracks;
 };
 

--- a/src/VoidUi/Sequencer/Models/SSelectionModel.h
+++ b/src/VoidUi/Sequencer/Models/SSelectionModel.h
@@ -43,6 +43,7 @@ public:
     bool HasTrackItemSelection() const { return !m_Items.empty(); }
     bool HasEffectSelection() const { return !m_Effects.empty(); }
     bool HasTrackSelection() const { return !m_Tracks.empty(); }
+    bool HasAnySelection() const { return !m_Items.empty() || !m_Effects.empty() || !m_Tracks.empty(); }
     const std::unordered_set<SharedTrackItem>& SelectedItems() const { return m_Items; }
     const std::unordered_set<SharedPlaybackTrack>& SelectedTracks() const { return m_Tracks; }
     const std::unordered_set<Effect*>& SelectedEffects() const { return m_Effects; }

--- a/src/VoidUi/Sequencer/Models/SSelectionModel.h
+++ b/src/VoidUi/Sequencer/Models/SSelectionModel.h
@@ -27,23 +27,25 @@ public:
     void Select(const SharedTrackItem& item);
     void Select(const std::vector<SharedTrackItem>& items);
     void Select(const SharedPlaybackTrack& track);
-    void Select(const Effect* effect);
-    void Select(const std::vector<const Effect*>& effects);
+    void Select(Effect* effect);
+    void Select(const std::vector<Effect*>& effects);
     void Deselect(const SharedTrackItem& item);
     void Deselect(const SharedPlaybackTrack& track);
-    void Deselect(const Effect* effect);
+    void Deselect(Effect* effect);
     void Toggle(const SharedTrackItem& item);
     void Toggle(const SharedPlaybackTrack& track);
-    void Toggle(const Effect* effect);
+    void Toggle(Effect* effect);
 
     bool IsSelected(const TrackItem* item);
     bool IsSelected(const SharedTrackItem& item);
     bool IsSelected(const SharedPlaybackTrack& track);
-    bool IsSelected(const Effect* effect);
+    bool IsSelected(Effect* effect);
     bool HasTrackItemSelection() const { return !m_Items.empty(); }
+    bool HasEffectSelection() const { return !m_Effects.empty(); }
     bool HasTrackSelection() const { return !m_Tracks.empty(); }
     const std::unordered_set<SharedTrackItem>& SelectedItems() const { return m_Items; }
     const std::unordered_set<SharedPlaybackTrack>& SelectedTracks() const { return m_Tracks; }
+    const std::unordered_set<Effect*>& SelectedEffects() const { return m_Effects; }
 
 signals:
     void selectionChanged();
@@ -52,7 +54,7 @@ signals:
 
 private:
     std::unordered_set<SharedTrackItem> m_Items;
-    std::unordered_set<const Effect*> m_Effects;
+    std::unordered_set<Effect*> m_Effects;
     std::unordered_set<SharedPlaybackTrack> m_Tracks;
 };
 

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -292,6 +292,28 @@ void SequencerController::ToggleTrackState(const SharedPlaybackTrack& track)
     _MediaBridge.PushCommand(new ToggleTrackStateCommand(track));
 }
 
+void SequencerController::ToggleItemState(const std::unordered_set<SharedTrackItem>& items)
+{
+    QUndoStack* stack = _MediaBridge.UndoStack();
+    stack->beginMacro("Toggle TrackItem(s)");
+
+    for (const SharedTrackItem& item : items)
+        stack->push(new ToggleTrackItemStateCommand(item));
+
+    stack->endMacro();
+}
+
+void SequencerController::ToggleItemState(const std::unordered_set<Effect*>& effects)
+{
+    QUndoStack* stack = _MediaBridge.UndoStack();
+    stack->beginMacro("Toggle Timeline Effect(s)");
+
+    for (Effect* effect : effects)
+        stack->push(new ToggleTimelineEffectCommand(effect));
+
+    stack->endMacro();
+}
+
 void SequencerController::RazorAt(const SharedPlaybackSequence& sequence, v_frame_t frame)
 {
     _MediaBridge.PushCommand(new RazorSequenceCommand(sequence, frame));

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -233,6 +233,17 @@ void SequencerController::RippleRemoveTrackItems(const SharedPlaybackSequence& s
     stack->endMacro();
 }
 
+void SequencerController::RemoveTimelineEffects(std::unordered_set<Effect*> effects)
+{
+    QUndoStack* stack = _MediaBridge.UndoStack();
+    stack->beginMacro("Delete Timeline Effect(s)");
+
+    for (auto& effect : effects)
+        stack->push(new DeleteTimelineEffectCommand(effect));
+
+    stack->endMacro();
+}
+
 STrack* SequencerController::TrackAt(int index) const
 {
     if (STimelineScene* scene = dynamic_cast<STimelineScene*>(m_Scene))

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -248,10 +248,34 @@ void SequencerController::CreateEffect(const std::unordered_set<SharedTrackItem>
 
 void SequencerController::RemoveTimelineEffects(const std::unordered_set<Effect*>& effects)
 {
+    std::vector<Effect*> sorted;
+    sorted.reserve(effects.size());
+
+    for (const auto& effect : effects)
+        sorted.push_back(effect);
+
+    std::sort(sorted.begin(), sorted.end(), [&](const Effect* _a, const Effect* _b) -> bool
+    {
+        TrackItem* _aitem = _a->TimelineItem();
+        TrackItem* _bitem = _b->TimelineItem();
+
+        int _aitemidx = _aitem ? _aitem->Track()->ItemIndex(_aitem) : -1;
+        int _bitemidx = _bitem ? _bitem->Track()->ItemIndex(_bitem) : -2;
+
+        // Sort ascending based on the track item index -- effect _b belongs to a different track item than _a
+        if (_aitemidx != _bitemidx)
+            return _aitemidx < _bitemidx;
+
+        // Sort descending based on the effect index
+        // we need the items to be reversed such that when deleting them, the index of other items don't change
+        // and running undo works as expected
+        return _aitem->EffectIndex(_a) > _bitem->EffectIndex(_b);
+    });
+
     QUndoStack* stack = _MediaBridge.UndoStack();
     stack->beginMacro("Delete Timeline Effect(s)");
 
-    for (auto& effect : effects)
+    for (auto& effect : sorted)
         stack->push(new DeleteTimelineEffectCommand(effect));
 
     stack->endMacro();

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -238,7 +238,7 @@ void SequencerController::CreateEffect(const std::unordered_set<SharedTrackItem>
     QUndoStack* stack = _MediaBridge.UndoStack();
 
     QString text("Create '%1' Effect");
-    stack->beginMacro(text.arg(type));
+    stack->beginMacro(text.arg(type.c_str()));
 
     for (const SharedTrackItem& item : items)
         stack->push(new CreateTimelineEffectCommand(item, type));

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -233,7 +233,20 @@ void SequencerController::RippleRemoveTrackItems(const SharedPlaybackSequence& s
     stack->endMacro();
 }
 
-void SequencerController::RemoveTimelineEffects(std::unordered_set<Effect*> effects)
+void SequencerController::CreateEffect(const std::unordered_set<SharedTrackItem>& items, const std::string& type)
+{
+    QUndoStack* stack = _MediaBridge.UndoStack();
+
+    QString text("Create '%1' Effect");
+    stack->beginMacro(text.arg(type));
+
+    for (const SharedTrackItem& item : items)
+        stack->push(new CreateTimelineEffectCommand(item, type));
+
+    stack->endMacro();
+}
+
+void SequencerController::RemoveTimelineEffects(const std::unordered_set<Effect*>& effects)
 {
     QUndoStack* stack = _MediaBridge.UndoStack();
     stack->beginMacro("Delete Timeline Effect(s)");

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -49,7 +49,7 @@ void SequencerController::RippleMoveItem(const SharedTrackItem& item, v_frame_t 
     // We're moving forwards (towards right, so start with the right most item here)
     if (offset > 0)
     {
-        for (int i = static_cast<int>(track->ItemCount()) - 1; i > index; --i)
+        for (int i = static_cast<int>(track->NumItems()) - 1; i > index; --i)
         {
             const SharedTrackItem& trackitem = track->ItemAt(i);
             stack->push(new OffsetItemCommand(trackitem, offset));
@@ -57,7 +57,7 @@ void SequencerController::RippleMoveItem(const SharedTrackItem& item, v_frame_t 
     }
     else
     {
-        for (int i = index; i < static_cast<int>(track->ItemCount()); ++i)
+        for (int i = index; i < static_cast<int>(track->NumItems()); ++i)
         {
             const SharedTrackItem& trackitem = track->ItemAt(i);
             stack->push(new OffsetItemCommand(trackitem, offset));
@@ -85,7 +85,7 @@ void SequencerController::RippleMoveItem(const SharedPlaybackTrack& track, const
     int index = track->ItemIndex(item);
     stack->push(new MoveItemToTrackCommand(track, item, trackIndex, frame));
 
-    std::size_t max = track->ItemCount();
+    std::size_t max = track->NumItems();
     // Last Item --- Nothing else to offset/move
     if (index >= max)
         return stack->endMacro();
@@ -215,7 +215,7 @@ void SequencerController::RippleRemoveTrackItems(const SharedPlaybackSequence& s
 
         stack->push(new DeleteTrackItemCommand(sequence, track->Type(), track->TrackIndex(), track->ItemIndex(item)));
 
-        std::size_t max = track->ItemCount();
+        std::size_t max = track->NumItems();
         // Last Item --- Nothing else to offset/move
         if (index >= max)
             continue;
@@ -333,7 +333,7 @@ void SequencerController::RippleTrimItemTail(const SharedTrackItem& item, int ha
     PlaybackTrack* track = item->Track();
     int index = track->ItemIndex(item);
 
-    std::size_t max = track->ItemCount();
+    std::size_t max = track->NumItems();
     // Last Item --- Nothing else to offset/move
     if (index + 1 >= max)
         return stack->endMacro();

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -64,6 +64,8 @@ public:
     void SetTrackItemsColor(const std::unordered_set<SharedTrackItem>& items);
     void ToggleTrackLock(const SharedPlaybackTrack& track);
     void ToggleTrackState(const SharedPlaybackTrack& track);
+    void ToggleItemState(const std::unordered_set<SharedTrackItem>& items);
+    void ToggleItemState(const std::unordered_set<Effect*>& effects);
 
     void RazorAt(const SharedPlaybackSequence& sequence, v_frame_t frame);
     void RazorAt(const SharedPlaybackTrack& track, v_frame_t frame);

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -48,7 +48,7 @@ public:
     void MoveItem(const SharedPlaybackTrack& track, const SharedTrackItem& item, int trackIndex, v_frame_t frame);
     void RippleMoveItem(const SharedPlaybackTrack& track, const SharedTrackItem& item, int trackIndex, v_frame_t frame);
     void CreateVideoTrack(const SharedPlaybackSequence& sequence);
-    void CreateAudioTrack(const SharedPlaybackSequence& seqeunce);
+    void CreateAudioTrack(const SharedPlaybackSequence& sequence);
     void RemoveTracks(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedPlaybackTrack>& tracks);
     void RemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items);
     void RippleRemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items);

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -52,7 +52,8 @@ public:
     void RemoveTracks(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedPlaybackTrack>& tracks);
     void RemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items);
     void RippleRemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items);
-    void RemoveTimelineEffects(const std::unordered_set<Effect*> effects);
+    void CreateEffect(const std::unordered_set<SharedTrackItem>& items, const std::string& type);
+    void RemoveTimelineEffects(const std::unordered_set<Effect*>& effects);
 
     STrack* TrackAt(const QPointF& position) const;
     STrack* TrackAt(int index) const;

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -77,8 +77,11 @@ public:
     void SetEditMode(const EditMode& mode) { m_EditMode = mode; }
     const EditMode& GetEditMode() const { return m_EditMode; }
 
+    void EditEffect(Effect* effect) { emit editEffectRequested(effect); }
+
 signals:
     void frameChanged(v_frame_t);
+    void editEffectRequested(Effect*);
 
 private:
     QGraphicsScene* m_Scene = { nullptr };

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -52,6 +52,7 @@ public:
     void RemoveTracks(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedPlaybackTrack>& tracks);
     void RemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items);
     void RippleRemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items);
+    void RemoveTimelineEffects(const std::unordered_set<Effect*> effects);
 
     STrack* TrackAt(const QPointF& position) const;
     STrack* TrackAt(int index) const;

--- a/src/VoidUi/Sequencer/SDescriptors.h
+++ b/src/VoidUi/Sequencer/SDescriptors.h
@@ -15,6 +15,7 @@ inline constexpr int RulerHeight = 30;
 inline constexpr int ToolbarWidth = 40;
 inline constexpr int TrackHeight = 60;
 inline constexpr int TrackItemHeight = 60;
+inline constexpr int TimelineEffectHeight = 18;
 inline constexpr int TrackSpacing = 2;
 inline constexpr int TrackHeaderWidth = 180;
 inline constexpr int SceneWidth = 20000;

--- a/src/VoidUi/Sequencer/SMenu.cpp
+++ b/src/VoidUi/Sequencer/SMenu.cpp
@@ -3,6 +3,8 @@
 
 /* Internal */
 #include "SMenu.h"
+#include "FormatForge.h"
+#include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -22,6 +24,7 @@ SequencerContextMenu::SequencerContextMenu(SequencerContext* context, QWidget* p
 
 void SequencerContextMenu::Show(const QPoint& position)
 {
+    BuildEffectsMenu();
     Validate();
     exec(position);
 }
@@ -29,8 +32,7 @@ void SequencerContextMenu::Show(const QPoint& position)
 void SequencerContextMenu::Build()
 {
     m_AddVideoTrackAction = new QAction("Add Video Track", this);
-    m_RemoveTrackAction = new QAction("Remove Selected Track(s)", this);
-    m_RemoveTrackItemsAction = new QAction("Remove Selected TrackItems(s)", this);
+    m_RemoveSelectedAction = new QAction("Delete Selected", this);
 
     m_ColorMenu = new QMenu("Color", this);
 
@@ -61,9 +63,10 @@ void SequencerContextMenu::Build()
     m_EditModeMenu->addAction(m_OverwriteAction);
     m_EditModeMenu->addAction(m_RippleAction);
 
+    m_EffectsMenu = new QMenu("Timeline Effects", this);
+
     addAction(m_AddVideoTrackAction);
-    addAction(m_RemoveTrackAction);
-    addAction(m_RemoveTrackItemsAction);
+    addAction(m_RemoveSelectedAction);
 
     addSeparator();
 
@@ -72,13 +75,16 @@ void SequencerContextMenu::Build()
     addSeparator();
     
     addMenu(m_EditModeMenu);
+
+    addSeparator();
+
+    addMenu(m_EffectsMenu);
 }
 
 void SequencerContextMenu::Connect()
 {
     connect(m_AddVideoTrackAction, &QAction::triggered, this, &SequencerContextMenu::createTrackRequested);
-    connect(m_RemoveTrackAction, &QAction::triggered, this, &SequencerContextMenu::removeTracksRequested);
-    connect(m_RemoveTrackItemsAction, &QAction::triggered, this, &SequencerContextMenu::removeTrackItemsRequested);
+    connect(m_RemoveSelectedAction, &QAction::triggered, this, &SequencerContextMenu::deleteSelectionRequested);
     connect(m_ColorItemAction, &QAction::triggered, this, [this]() -> void { emit colorChangeRequested(false); });
     connect(m_ResetItemColorAction, &QAction::triggered, this, [this]() -> void { emit colorChangeRequested(true); });
     connect(m_EditModeGroup, &QActionGroup::triggered, this, [this](QAction* action) -> void
@@ -89,14 +95,29 @@ void SequencerContextMenu::Connect()
 
 void SequencerContextMenu::Validate()
 {
-    m_RemoveTrackAction->setEnabled(m_Context->SelectionModel()->HasTrackSelection());
-    m_RemoveTrackItemsAction->setEnabled(m_Context->SelectionModel()->HasTrackItemSelection());
+    m_RemoveSelectedAction->setEnabled(m_Context->SelectionModel()->HasAnySelection());
     m_ColorItemAction->setEnabled(m_Context->SelectionModel()->HasTrackItemSelection());
     m_ResetItemColorAction->setEnabled(m_Context->SelectionModel()->HasTrackItemSelection());
 
     m_NoOverwriteAction->setChecked(m_Context->Controller()->GetEditMode() == SequencerController::EditMode::NO_OVERWRITE);
     m_OverwriteAction->setChecked(m_Context->Controller()->GetEditMode() == SequencerController::EditMode::OVERWRITE);
     m_RippleAction->setChecked(m_Context->Controller()->GetEditMode() == SequencerController::EditMode::RIPPLE);
+
+    m_EffectsMenu->setEnabled(m_Context->SelectionModel()->HasTrackItemSelection());
+}
+
+void SequencerContextMenu::BuildEffectsMenu()
+{
+    if (m_EffectsMenu->actions().empty())
+    {
+        for (const auto& [name, _] : Forge::Instance().Operators())
+        {
+            VOID_LOG_INFO("Effect: {0}", name);
+            QAction* effaction = new QAction(name.c_str(), m_EffectsMenu);
+            connect(effaction, &QAction::triggered, this, [=]() -> void { emit addEffectRequested(name); });
+            m_EffectsMenu->addAction(effaction);
+        }
+    }
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequencer/SMenu.h
+++ b/src/VoidUi/Sequencer/SMenu.h
@@ -25,16 +25,15 @@ public:
 
 signals:
     void createTrackRequested();
-    void removeTracksRequested();
-    void removeTrackItemsRequested();
+    void deleteSelectionRequested();
     void colorChangeRequested(bool reset = false);
     void editModeChangeRequested(const SequencerController::EditMode&);
+    void addEffectRequested(const std::string&);
 
 private:
     SequencerContext* m_Context;
     QAction* m_AddVideoTrackAction;
-    QAction* m_RemoveTrackAction;
-    QAction* m_RemoveTrackItemsAction;
+    QAction* m_RemoveSelectedAction;
 
     QMenu* m_ColorMenu;
     QAction* m_ColorItemAction;
@@ -46,8 +45,11 @@ private:
     QAction* m_RippleAction;
     QActionGroup* m_EditModeGroup;
 
+    QMenu* m_EffectsMenu;
+
 private: /* Methods */
     void Build();
+    void BuildEffectsMenu();
     void Connect();
     void Validate();
 };

--- a/src/VoidUi/Sequencer/STimelineGeometry.cpp
+++ b/src/VoidUi/Sequencer/STimelineGeometry.cpp
@@ -18,14 +18,31 @@ QRectF STimelineGeometry::HeaderRect() const
 
 QRectF STimelineGeometry::TrackRect(int index) const
 {
-    const int y = TimelineTop() + index * (Sequencer::TrackHeight + Sequencer::TrackSpacing);
-    return QRectF(ContentLeft(), y, Sequencer::SceneWidth, Sequencer::TrackHeight);
+    int y = TimelineTop();
+    for (int i = 0; i < index; ++i)
+        y += (VideoTrackHeight(i) + Sequencer::TrackSpacing);
+
+    return QRect(0, y, Sequencer::SceneWidth, VideoTrackHeight(index));
 }
 
 QRectF STimelineGeometry::TrackHeaderRect(int index) const
 {
-    const int y = TimelineTop() + index * (Sequencer::TrackHeight + Sequencer::TrackSpacing);
-    return QRectF(0, y, Sequencer::TrackHeaderWidth, Sequencer::TrackHeight);
+    int y = TimelineTop();
+    for (int i = 0; i < index; ++i)
+        y += (VideoTrackHeight(i) + Sequencer::TrackSpacing);
+
+    return QRect(0, y, Sequencer::TrackHeaderWidth, VideoTrackHeight(index));
+}
+
+int STimelineGeometry::VideoTrackHeight(int index) const
+{
+    SharedPlaybackTrack track = m_Sequence->VideoTrackAt(index);
+    return Sequencer::TrackHeight + track->MaxEffects() * Sequencer::TimelineEffectHeight;
+}
+
+int STimelineGeometry::AudioTrackHeight(int index) const
+{
+    return Sequencer::TrackHeight;
 }
 
 double STimelineGeometry::FrameToSceneX(v_frame_t frame) const

--- a/src/VoidUi/Sequencer/STimelineGeometry.h
+++ b/src/VoidUi/Sequencer/STimelineGeometry.h
@@ -10,6 +10,7 @@
 /* Internal */
 #include "Definition.h"
 #include "SDescriptors.h"
+#include "VoidObjects/Sequence/Sequence.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -24,6 +25,9 @@ public:
     int TimelineTop() const { return Sequencer::RulerHeight; }
     // int ContentLeft() const { return Sequencer::TrackHeaderWidth; }
     int ContentLeft() const { return 0; }
+    
+    int VideoTrackHeight(int index) const;
+    int AudioTrackHeight(int index) const;
 
     double FrameToX(v_frame_t frame) const { return frame * m_PixelsPerFrame; }
     v_frame_t XToFrame(double x) const { return static_cast<v_frame_t>(x / m_PixelsPerFrame); }
@@ -35,8 +39,12 @@ public:
     void SetPixelsPerFrame(double p) { if (p > 0) m_PixelsPerFrame = p; }
     void ResetPixelsPerFrame() { m_PixelsPerFrame = 2.0; }
 
+    void SetSequence(const SharedPlaybackSequence& sequence) { m_Sequence = sequence; }
+    void ResetSequence() { m_Sequence = nullptr; }
+
 private:
     double m_PixelsPerFrame = 2.0;
+    SharedPlaybackSequence m_Sequence;
 };
 
 

--- a/src/VoidUi/Sequencer/STimelineScene.cpp
+++ b/src/VoidUi/Sequencer/STimelineScene.cpp
@@ -15,6 +15,7 @@
 #include "Graphics/SRazorItem.h"
 #include "Graphics/STrack.h"
 #include "Graphics/STrackItem.h"
+#include "Graphics/STimelineEffect.h"
 #include "VoidCore/Logging.h"
 
 VOID_NAMESPACE_OPEN
@@ -151,18 +152,23 @@ STrack*& STimelineScene::TrackAt(int index)
     return m_Tracks.at(index);
 }
 
-void STimelineScene::SelectTrackItems(const QRectF& rect)
+void STimelineScene::SelectItems(const QRectF& rect)
 {
     const QList<QGraphicsItem*> hits = items(rect, Qt::IntersectsItemShape);
     std::vector<SharedTrackItem> trackitems;
+    std::vector<Effect*> effects;
     trackitems.reserve(hits.size());
+    effects.reserve(hits.size());
     for (auto& item : hits)
     {
         if (const auto& trackitem = dynamic_cast<STrackItem*>(item))
             trackitems.emplace_back(trackitem->TrackItem());
+        else if (const auto& effect = dynamic_cast<STimelineEffect*>(item))
+            effects.push_back(effect->TimelineEffect());
     }
 
     m_Context->SelectionModel()->Select(trackitems);
+    m_Context->SelectionModel()->Select(effects);
 }
 
 void STimelineScene::drawBackground(QPainter* painter, const QRectF& rect)

--- a/src/VoidUi/Sequencer/STimelineScene.h
+++ b/src/VoidUi/Sequencer/STimelineScene.h
@@ -42,7 +42,7 @@ public:
     STrack* TrackAt(int index) const;
     STrack*& TrackAt(int index);
 
-    void SelectTrackItems(const QRectF& rect);
+    void SelectItems(const QRectF& rect);
 
 protected:
     void drawBackground(QPainter* painter, const QRectF& rect) override;

--- a/src/VoidUi/Sequencer/STimelineView.cpp
+++ b/src/VoidUi/Sequencer/STimelineView.cpp
@@ -95,7 +95,7 @@ void STimelineView::mouseMoveEvent(QMouseEvent* event)
     {
         m_Marquee.rect = QRect(m_Marquee.clickpos, event->pos()).normalized();
         QPolygonF marquee = mapToScene(m_Marquee.rect);
-        m_Scene->SelectTrackItems(marquee.boundingRect());
+        m_Scene->SelectItems(marquee.boundingRect());
 
         viewport()->update();
     }

--- a/src/VoidUi/Sequencer/STimelineView.cpp
+++ b/src/VoidUi/Sequencer/STimelineView.cpp
@@ -120,7 +120,7 @@ void STimelineView::mouseReleaseEvent(QMouseEvent* event)
     QGraphicsView::mouseReleaseEvent(event);
 }
 
-void STimelineView::enterEvent(QEvent* event)
+void STimelineView::enterEvent(EnterEvent* event)
 {
     QGraphicsView::enterEvent(event);
 

--- a/src/VoidUi/Sequencer/STimelineView.h
+++ b/src/VoidUi/Sequencer/STimelineView.h
@@ -8,7 +8,7 @@
 #include <QGraphicsView>
 
 /* Internal */
-#include "Definition.h"
+#include "QDefinition.h"
 #include "FrameRange.h"
 #include "SDragContext.h"
 #include "VoidObjects/Sequence/Sequence.h"
@@ -45,7 +45,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void drawForeground(QPainter* painter, const QRectF& rect) override;
-    void enterEvent(QEvent* event) override;
+    void enterEvent(EnterEvent* event) override;
     void leaveEvent(QEvent* event) override;
 
 private:

--- a/src/VoidUi/Sequencer/Sequencer.cpp
+++ b/src/VoidUi/Sequencer/Sequencer.cpp
@@ -172,12 +172,12 @@ void SequencerTimeline::Connect()
     connect(m_View->verticalScrollBar(), &QScrollBar::valueChanged, m_TrackHeader, &STrackHeaderWidget::SetScroll);
     connect(m_View, &STimelineView::sequenceCutRequested, this, static_cast<void (SequencerTimeline::*)(v_frame_t)>(&SequencerTimeline::RazorAt));
 
+    // Menu
     connect(m_Menu, &SequencerContextMenu::createTrackRequested, this, [this]() -> void
     {
         m_Context.Controller()->CreateVideoTrack(m_Sequence);
     });
-    connect(m_Menu, &SequencerContextMenu::removeTracksRequested, this, &SequencerTimeline::DeleteSelected);
-    connect(m_Menu, &SequencerContextMenu::removeTrackItemsRequested, this, &SequencerTimeline::DeleteSelected);
+    connect(m_Menu, &SequencerContextMenu::deleteSelectionRequested, this, &SequencerTimeline::DeleteSelected);
     connect(m_Menu, &SequencerContextMenu::editModeChangeRequested, m_Context.Controller(), &SequencerController::SetEditMode);
     connect(m_Menu, &SequencerContextMenu::colorChangeRequested, this, [this](bool reset) -> void
     {
@@ -191,6 +191,13 @@ void SequencerTimeline::Connect()
             m_Context.Controller()->SetTrackItemsColor(m_Context.SelectionModel()->SelectedItems(), color);
         }
     });
+    connect(m_Menu, &SequencerContextMenu::addEffectRequested, this, &SequencerTimeline::CreateEffect);
+}
+
+void SequencerTimeline::CreateEffect(const std::string& type)
+{
+    if (m_Context.SelectionModel()->HasTrackItemSelection())
+        m_Context.Controller()->CreateEffect(m_Context.SelectionModel()->SelectedItems(), type);
 }
 
 void SequencerTimeline::DeleteSelected()

--- a/src/VoidUi/Sequencer/Sequencer.cpp
+++ b/src/VoidUi/Sequencer/Sequencer.cpp
@@ -199,6 +199,8 @@ void SequencerTimeline::DeleteSelected()
         m_Context.Controller()->RemoveTracks(m_Sequence, m_Context.SelectionModel()->SelectedTracks());
     else if (m_Context.SelectionModel()->HasTrackItemSelection())
         m_Context.Controller()->RemoveTrackItems(m_Sequence, m_Context.SelectionModel()->SelectedItems());
+    else if (m_Context.SelectionModel()->HasEffectSelection())
+        m_Context.Controller()->RemoveTimelineEffects(m_Context.SelectionModel()->SelectedEffects());
 
     m_Context.SelectionModel()->Clear();
 }

--- a/src/VoidUi/Sequencer/Sequencer.cpp
+++ b/src/VoidUi/Sequencer/Sequencer.cpp
@@ -151,6 +151,9 @@ void SequencerTimeline::Connect()
     connect(m_Toolbar, &SToolbar::reset, this, &SequencerTimeline::Refresh);
     connect(m_Toolbar, &SToolbar::actionSwitched, this, [this](const SequencerAction& action) -> void { m_Context.SetAction(action); });
 
+    // Controller
+    connect(m_Context.Controller(), &SequencerController::editEffectRequested, this, &SequencerTimeline::editEffectRequested);
+
     connect(m_FitShortcut, &QShortcut::activated, m_View, &STimelineView::Focus);
     connect(m_DeleteShortcut, &QShortcut::activated, this, &SequencerTimeline::DeleteSelected);
     connect(m_RippleDeleteShortcut, &QShortcut::activated, this, &SequencerTimeline::RippleDeleteSelected);

--- a/src/VoidUi/Sequencer/Sequencer.cpp
+++ b/src/VoidUi/Sequencer/Sequencer.cpp
@@ -106,6 +106,7 @@ void SequencerTimeline::Build()
     m_FitShortcut = new QShortcut(QKeySequence("Alt+F"), this);
     m_DeleteShortcut = new QShortcut(QKeySequence(Qt::Key_Backspace), this);
     m_RippleDeleteShortcut = new QShortcut(QKeySequence("Ctrl+Backspace"), this);
+    m_ToggleStateShortcut = new QShortcut(QKeySequence(Qt::Key_D), this);
     m_Menu = new SequencerContextMenu(&m_Context, this);
 
     m_Layout = new QHBoxLayout(this);
@@ -157,13 +158,14 @@ void SequencerTimeline::Connect()
     connect(m_FitShortcut, &QShortcut::activated, m_View, &STimelineView::Focus);
     connect(m_DeleteShortcut, &QShortcut::activated, this, &SequencerTimeline::DeleteSelected);
     connect(m_RippleDeleteShortcut, &QShortcut::activated, this, &SequencerTimeline::RippleDeleteSelected);
+    connect(m_ToggleStateShortcut, &QShortcut::activated, this, &SequencerTimeline::ToggleItemState);
 
     connect(m_HZoomSlider, &QSlider::valueChanged, this, [this](int value) -> void
     {
         SetHorizontalScale((float)value / 10);
     });
 
-    connect(this, &QWidget::customContextMenuRequested, this, [this](const QPoint& position) -> void 
+    connect(this, &QWidget::customContextMenuRequested, this, [this](const QPoint& position) -> void
     {
         m_Menu->Show(mapToGlobal(position));
     });
@@ -186,7 +188,7 @@ void SequencerTimeline::Connect()
         else
         {
             QColor color = QColorDialog::getColor(QColor(255, 255, 255), this, "Select Trackitem Color");
-            m_Context.Controller()->SetTrackItemsColor(m_Context.SelectionModel()->SelectedItems(), color);    
+            m_Context.Controller()->SetTrackItemsColor(m_Context.SelectionModel()->SelectedItems(), color);
         }
     });
 }
@@ -197,7 +199,7 @@ void SequencerTimeline::DeleteSelected()
         m_Context.Controller()->RemoveTracks(m_Sequence, m_Context.SelectionModel()->SelectedTracks());
     else if (m_Context.SelectionModel()->HasTrackItemSelection())
         m_Context.Controller()->RemoveTrackItems(m_Sequence, m_Context.SelectionModel()->SelectedItems());
-    
+
     m_Context.SelectionModel()->Clear();
 }
 
@@ -207,6 +209,15 @@ void SequencerTimeline::RippleDeleteSelected()
         m_Context.Controller()->RippleRemoveTrackItems(m_Sequence, m_Context.SelectionModel()->SelectedItems());
 
     m_Context.SelectionModel()->Clear();
+}
+
+void SequencerTimeline::ToggleItemState()
+{
+    if (m_Context.SelectionModel()->HasTrackItemSelection())
+        m_Context.Controller()->ToggleItemState(m_Context.SelectionModel()->SelectedItems());
+
+    if (m_Context.SelectionModel()->HasEffectSelection())
+        m_Context.Controller()->ToggleItemState(m_Context.SelectionModel()->SelectedEffects());
 }
 
 void SequencerTimeline::UpdateAll()

--- a/src/VoidUi/Sequencer/Sequencer.cpp
+++ b/src/VoidUi/Sequencer/Sequencer.cpp
@@ -29,12 +29,15 @@ void SequencerTimeline::SetSequence(const SharedPlaybackSequence& sequence)
     {
         disconnect(m_Sequence.get(), &PlaybackSequence::trackAdded, this, &SequencerTimeline::AddTrack);
         disconnect(m_Sequence.get(), &PlaybackSequence::trackAboutToBeRemoved, this, &SequencerTimeline::RemoveTrack);
+        disconnect(m_Sequence.get(), &PlaybackSequence::maxTrackEffectsChanged, this, &SequencerTimeline::UpdateAll);
     }
 
     m_Sequence = sequence;
     connect(m_Sequence.get(), &PlaybackSequence::trackAdded, this, &SequencerTimeline::AddTrack);
     connect(m_Sequence.get(), &PlaybackSequence::trackAboutToBeRemoved, this, &SequencerTimeline::RemoveTrack);
+    connect(m_Sequence.get(), &PlaybackSequence::maxTrackEffectsChanged, this, &SequencerTimeline::UpdateAll);
 
+    m_Context.Geometry()->SetSequence(sequence);
     Refresh();
 }
 
@@ -201,6 +204,12 @@ void SequencerTimeline::RippleDeleteSelected()
         m_Context.Controller()->RippleRemoveTrackItems(m_Sequence, m_Context.SelectionModel()->SelectedItems());
 
     m_Context.SelectionModel()->Clear();
+}
+
+void SequencerTimeline::UpdateAll()
+{
+    m_TrackHeader->Update();
+    m_View->Refresh();
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequencer/Sequencer.h
+++ b/src/VoidUi/Sequencer/Sequencer.h
@@ -47,6 +47,9 @@ public:
 
     void SetHorizontalScale(float factor);
 
+signals:
+    void editEffectRequested(Effect*);
+
 private:
     QHBoxLayout* m_Layout;
     QSlider* m_HZoomSlider;

--- a/src/VoidUi/Sequencer/Sequencer.h
+++ b/src/VoidUi/Sequencer/Sequencer.h
@@ -62,6 +62,7 @@ private:
     QShortcut* m_FitShortcut;
     QShortcut* m_DeleteShortcut;
     QShortcut* m_RippleDeleteShortcut;
+    QShortcut* m_ToggleStateShortcut;
 
     SharedPlaybackSequence m_Sequence;
     SequencerContext m_Context;
@@ -71,6 +72,7 @@ private: /* Methods */
     void Connect();
     void DeleteSelected();
     void RippleDeleteSelected();
+    void ToggleItemState();
     void UpdateAll();
 };
 

--- a/src/VoidUi/Sequencer/Sequencer.h
+++ b/src/VoidUi/Sequencer/Sequencer.h
@@ -70,6 +70,7 @@ private:
 private: /* Methods */
     void Build();
     void Connect();
+    void CreateEffect(const std::string& type);
     void DeleteSelected();
     void RippleDeleteSelected();
     void ToggleItemState();

--- a/src/VoidUi/Sequencer/Sequencer.h
+++ b/src/VoidUi/Sequencer/Sequencer.h
@@ -68,6 +68,7 @@ private: /* Methods */
     void Connect();
     void DeleteSelected();
     void RippleDeleteSelected();
+    void UpdateAll();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequencer/Widgets/STrackHeader.cpp
+++ b/src/VoidUi/Sequencer/Widgets/STrackHeader.cpp
@@ -28,6 +28,21 @@ STrackHeader::STrackHeader(const SharedPlaybackTrack& track, SequencerContext* c
     connect(m_Track.get(), &PlaybackTrack::updated, this, [this]() -> void { update(); });
 }
 
+QSize STrackHeader::sizeHint() const
+{
+    return QSize(
+        Sequencer::TrackHeaderWidth,
+        m_Track->Type() == Sequence::TrackType::VIDEO
+            ? m_Context->Geometry()->VideoTrackHeight(m_Track->TrackIndex())
+            : m_Context->Geometry()->AudioTrackHeight(m_Track->TrackIndex())
+    );
+}
+
+void STrackHeader::Update()
+{
+    UpdateSize();
+}
+
 void STrackHeader::paintEvent(QPaintEvent* event)
 {
     QPainter painter(this);
@@ -76,7 +91,7 @@ void STrackHeader::mousePressEvent(QMouseEvent* event)
             m_Context->SelectionModel()->Toggle(m_Track);
         }
         else
-        {   
+        {
             m_Context->SelectionModel()->Clear();
             m_Context->SelectionModel()->Select(m_Track);
         }
@@ -100,6 +115,24 @@ void STrackHeader::resizeEvent(QResizeEvent* event)
     m_NameRect = QRect(m_StateRect.right() + spacing, 0, width() - (m_StateRect.right() + spacing + margin), height());
 
     QWidget::resizeEvent(event);
+}
+
+void STrackHeader::UpdateSize()
+{
+    // TODO: Check why the resize behaves differently when the layout is updated
+    // Probably because the layout alignment property? -- Needs more info and thought
+    // resize(
+    //     Sequencer::TrackHeaderWidth,
+    //     m_Track->Type() == Sequence::TrackType::VIDEO
+    //         ? m_Context->Geometry()->VideoTrackHeight(m_Track->TrackIndex())
+    //         : m_Context->Geometry()->AudioTrackHeight(m_Track->TrackIndex())    
+    // );
+    setFixedHeight(
+        m_Track->Type() == Sequence::TrackType::VIDEO
+            ? m_Context->Geometry()->VideoTrackHeight(m_Track->TrackIndex())
+            : m_Context->Geometry()->AudioTrackHeight(m_Track->TrackIndex())
+    );
+    update();
 }
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequencer/Widgets/STrackHeader.h
+++ b/src/VoidUi/Sequencer/Widgets/STrackHeader.h
@@ -20,8 +20,10 @@ class STrackHeader : public QWidget
 public:
     STrackHeader(const SharedPlaybackTrack& track, SequencerContext* context, QWidget* parent = nullptr);
 
-    QSize sizeHint() const override { return QSize(Sequencer::TrackHeaderWidth, Sequencer::TrackHeight); }
+    QSize sizeHint() const override;
     SharedPlaybackTrack Track() const { return m_Track; }
+
+    void Update();
 
 signals:
     void clicked(const SharedPlaybackTrack&);
@@ -49,6 +51,7 @@ private: /* Methods */
     QRect LockRect() const { return m_LockRect; }
     QRect StateRect() const { return m_StateRect; }
     QRect NameRect() const { return m_NameRect; }
+    void UpdateSize();
 };
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Sequencer/Widgets/STrackHeaderWidget.cpp
+++ b/src/VoidUi/Sequencer/Widgets/STrackHeaderWidget.cpp
@@ -54,6 +54,14 @@ void STrackHeaderWidget::Clear()
     }
 }
 
+void STrackHeaderWidget::Update()
+{
+    for (auto& header : findChildren<STrackHeader*>())
+        header->Update();
+    
+    m_ScrollLayout->update();
+}
+
 void STrackHeaderWidget::SetScroll(int value)
 {
     m_ScrollArea->verticalScrollBar()->setValue(value);

--- a/src/VoidUi/Sequencer/Widgets/STrackHeaderWidget.h
+++ b/src/VoidUi/Sequencer/Widgets/STrackHeaderWidget.h
@@ -27,6 +27,7 @@ public:
     void RemoveTrack(const SharedPlaybackTrack& track);
     void Clear();
 
+    void Update();
     void SetScroll(int value);
 
 private:

--- a/src/include/FormatForge.h
+++ b/src/include/FormatForge.h
@@ -106,6 +106,8 @@ public:
 
     bool IsRegistered(const std::string& extension) const;
 
+    const std::unordered_map<std::string, IOpForge>& Operators() const { return m_IOpForger; }
+
 private: /* Members */
     std::unordered_map<std::string, PixForge> m_ImageForger;
     std::unordered_map<std::string, MPixForge> m_MovieForger;

--- a/src/include/Operator.h
+++ b/src/include/Operator.h
@@ -22,6 +22,7 @@ public:
 
     Param* GetParam(const std::string& name);
     virtual bool Evaluate(ImageRow& row) = 0;
+    virtual std::string Type() const = 0;
 
     const std::vector<Param*>& Params() const { return m_Params; }
 


### PR DESCRIPTION
## Feat: Support Addition of Effects on TImeline (TrackItems) [Pending Track effects]
* Added Support for Timeline Effects on TrackItems
* TimelineEffects can be added on trackitems and have their ranges (timeline in - timeline out)
* Timeline effect gets a visual entity STimelineEffect in the Sequence View.
* Each track in Sequence View has a dynamic height which is calculated based on the max number of effects that are there on any item in the track.
* Added support for disabling timeline effect.
* Added support for disabling track item visually (pending consideration during playback).
* Repositioned timeline handles to be lower than the track item bounds making more clear appearance in the scene.
* Added support for Marquee selection of effects.
* Undo - Redo commands to remove tracks also uses binary serializer.
* Razor'd items also copy/duplicate the effects on the item.
* Registered operators are now available in the sequence context menu for addition as timeline effects on the track item.

### Next Steps:
- Core implementation of how effect updates the image data for the track item.
- Undo-redo on value changes for the Param in the Effect.