### PR TITLE
[VOID] Undo Updates

### DIFF
--- a/src/VoidObjects/Sequence/Sequence.cpp
+++ b/src/VoidObjects/Sequence/Sequence.cpp
@@ -241,6 +241,11 @@ void PlaybackSequence::UpdateRange(int start, int end)
     VOID_LOG_INFO("Sequence Range Updated. Range: {0}-{1}", m_StartFrame, m_EndFrame);
 }
 
+const SharedPlaybackTrack& PlaybackSequence::TrackAt(std::size_t index, const Sequence::TrackType& type) const
+{
+    return type == Sequence::TrackType::VIDEO ? m_VideoTracks.at(index) : m_AudioTracks.at(index);
+}
+
 int PlaybackSequence::VideoTrackIndex(const PlaybackTrack* track) const
 {
     auto _f = [track] (const SharedPlaybackTrack& t) -> bool { return track == t.get(); };
@@ -253,6 +258,11 @@ int PlaybackSequence::AudioTrackIndex(const PlaybackTrack* track) const
     auto _f = [track] (const SharedPlaybackTrack& t) -> bool { return track == t.get(); };
     auto it = std::find_if(m_AudioTracks.begin(), m_AudioTracks.end(), _f);
     return std::distance(m_AudioTracks.begin(), it);
+}
+
+int PlaybackSequence::TrackIndex(const PlaybackTrack* track) const
+{
+    return track->Type() == Sequence::TrackType::VIDEO ? VideoTrackIndex(track) : AudioTrackIndex(track);
 }
 
 bool PlaybackSequence::HasMedia() const

--- a/src/VoidObjects/Sequence/Sequence.h
+++ b/src/VoidObjects/Sequence/Sequence.h
@@ -61,11 +61,13 @@ public:
 
     const SharedPlaybackTrack& VideoTrackAt(std::size_t index) const { return m_VideoTracks.at(index); }
     const SharedPlaybackTrack& AudioTrackAt(std::size_t index) const { return m_AudioTracks.at(index); }
+    const SharedPlaybackTrack& TrackAt(std::size_t index, const Sequence::TrackType& type) const;
     const std::vector<SharedPlaybackTrack>& VideoTracks() const { return m_VideoTracks; }
     const std::vector<SharedPlaybackTrack>& AudioTracks() const { return m_AudioTracks; }
 
     int VideoTrackIndex(const PlaybackTrack* track) const;
     int AudioTrackIndex(const PlaybackTrack* track) const;
+    int TrackIndex(const PlaybackTrack* track) const;
 
     // const std::vector<SharedPlaybackTrack>& VideoTracks() const { return m_VideoTracks; }
     // const std::vector<SharedPlaybackTrack>& AudioTracks() const { return m_AudioTracks; }

--- a/src/VoidObjects/Sequence/Track.cpp
+++ b/src/VoidObjects/Sequence/Track.cpp
@@ -215,7 +215,7 @@ SharedTrackItem PlaybackTrack::GetTrackItem(v_frame_t frame)
     return m_Recent;
 }
 
-int PlaybackTrack::TrackIndex() const
+int PlaybackTrack::Index() const
 {
     if (const auto& sequence = Sequence())
         return m_Type == Sequence::TrackType::VIDEO ? sequence->VideoTrackIndex(this) : sequence->AudioTrackIndex(this);

--- a/src/VoidObjects/Sequence/Track.h
+++ b/src/VoidObjects/Sequence/Track.h
@@ -116,7 +116,7 @@ public:
 
     /* The parent of the Track should always be a Sequence, in case it exists inside a Sequence */
     inline PlaybackSequence* Sequence() const { return reinterpret_cast<PlaybackSequence*>(parent()); }
-    int TrackIndex() const;
+    int Index() const;
 
     /* Setters */
 

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -3,6 +3,7 @@
 
 /* Internal */
 #include "TrackItem.h"
+#include "Track.h"
 #include "VoidCore/Logging.h"
 #include "VoidObjects/VoidContext.h"
 #include "VoidObjects/Effects/Bridge.h"
@@ -71,6 +72,11 @@ void TrackItem::Unlink()
 {
     m_Media.reset();
     emit updated();
+}
+
+std::size_t TrackItem::Index() const
+{
+    return m_Track->ItemIndex(this);
 }
 
 void TrackItem::SetEnabled(bool enable)

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -52,6 +52,8 @@ public:
     bool Linked() const { return (bool)m_Media; }
     void Unlink();
 
+    std::size_t Index() const;
+
     void SetEnabled(bool enable);
     bool Enabled() const { return m_Enabled; }
 

--- a/src/VoidUi/Commands/MediaCommands.cpp
+++ b/src/VoidUi/Commands/MediaCommands.cpp
@@ -1,29 +1,28 @@
 // Copyright (c) 2025 waaake
 // Licensed under the MIT License
 
+/* STD */
+#include <sstream>
+
 /* Internal */
 #include "MediaCommands.h"
 
 VOID_NAMESPACE_OPEN
 
-/* Media Import Command {{{ */
+/// MediaImportCommand
 
 MediaImportCommand::MediaImportCommand(const std::string& path, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Path(MediaFS::ResolvedPath(path))
+    , m_InsertIndex(_MediaBridge.DataModel()->rowCount())
 {
-    /* The current index on which the Media Will be inserted */
-    m_InsertIndex = _MediaBridge.DataModel()->rowCount();
-
+    // m_InsertIndex = 
     setText("Import Media");
 }
 
 void MediaImportCommand::undo()
 {
-    /* Index at which the Media was inserted and now needs removal */
     QModelIndex index = _MediaBridge.DataModel()->index(m_InsertIndex, 0);
-
-    /* Remove the Media at the index */
     _MediaBridge.Remove(index);
 }
 
@@ -32,9 +31,7 @@ bool MediaImportCommand::Redo()
     return _MediaBridge.AddMedia(MediaStruct::FromFile(m_Path));
 }
 
-/* }}} */
-
-/* Media Remove Command {{{ */
+/// MediaRemoveCommand
 
 MediaRemoveCommand::MediaRemoveCommand(const QModelIndex& index, QUndoCommand* parent)
     : VoidUndoCommand(parent)
@@ -45,19 +42,21 @@ MediaRemoveCommand::MediaRemoveCommand(const QModelIndex& index, QUndoCommand* p
 
 void MediaRemoveCommand::undo()
 {
-    /* Add the Media to the Model */
-    _MediaBridge.InsertMedia(MediaStruct::FromFile(m_Path), m_Index.row());
+    SharedMediaClip media = std::make_shared<MediaClip>(_MediaBridge.ActiveProject());
+    std::istringstream is(m_Data, std::ios::binary);
+    media->Deserialize(is);
+
+    _MediaBridge.InsertMedia(media, m_Index.row());
 }
 
 bool MediaRemoveCommand::Redo()
 {
-    /* Update the internal struct so that we know where each clip was and it's path */
-    const SharedMediaClip clip = _MediaBridge.DataModel()->Media(m_Index);
-    m_Path = clip->Fullpath();
+    std::ostringstream os(std::ios::binary);
+    const SharedMediaClip& clip = _MediaBridge.DataModel()->Media(m_Index);
+    clip->Serialize(os);
+    m_Data = os.str();
 
     return _MediaBridge.Remove(m_Index);
 }
-
-/* }}} */
 
 VOID_NAMESPACE_CLOSE

--- a/src/VoidUi/Commands/MediaCommands.h
+++ b/src/VoidUi/Commands/MediaCommands.h
@@ -40,7 +40,7 @@ public:
     bool Redo() override;
 
 private: /* Members */
-    std::string m_Path;
+    std::string m_Data;
     QModelIndex m_Index;
 };
 

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -16,8 +16,8 @@ VOID_NAMESPACE_OPEN
 MoveTrackItemCommand::MoveTrackItemCommand(const SharedTrackItem& item, v_frame_t frame, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Sequence(item->Track()->Sequence())
-    , m_TrackIndex(item->Track()->TrackIndex())
-    , m_ItemIndex(item->Track()->ItemIndex(item))
+    , m_TrackIndex(item->Track()->Index())
+    , m_ItemIndex(item->Index())
     , m_Requested(frame)
     , m_Previous(item->TimelineIn())
     , m_TrackType(item->Track()->Type())
@@ -27,8 +27,7 @@ MoveTrackItemCommand::MoveTrackItemCommand(const SharedTrackItem& item, v_frame_
 
 void MoveTrackItemCommand::undo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         track->MoveItem(item, m_Previous);
@@ -37,8 +36,7 @@ void MoveTrackItemCommand::undo()
 
 bool MoveTrackItemCommand::Redo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         return track->MoveItem(item, m_Requested);
@@ -54,9 +52,9 @@ MoveItemToTrackCommand::MoveItemToTrackCommand(const SharedPlaybackTrack& track,
     , m_Sequence(track->Sequence())
     , m_PreviousFrame(item->TimelineIn())
     , m_RequestedFrame(frame)
-    , m_PreviousTrackIndex(track->TrackIndex())
+    , m_PreviousTrackIndex(track->Index())
     , m_RequestedTrackIndex(trackIndex)
-    , m_PreviousItemIndex(track->ItemIndex(item))
+    , m_PreviousItemIndex(item->Index())
     , m_Type(track->Type())
 {
     setText("Move TrackItem");
@@ -64,8 +62,8 @@ MoveItemToTrackCommand::MoveItemToTrackCommand(const SharedPlaybackTrack& track,
 
 void MoveItemToTrackCommand::undo()
 {
-    SharedPlaybackTrack previous = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_PreviousTrackIndex) : m_Sequence->AudioTrackAt(m_PreviousTrackIndex);
-    SharedPlaybackTrack requested = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_RequestedTrackIndex) : m_Sequence->AudioTrackAt(m_RequestedTrackIndex);
+    SharedPlaybackTrack previous = m_Sequence->TrackAt(m_PreviousTrackIndex, m_Type);
+    SharedPlaybackTrack requested = m_Sequence->TrackAt(m_RequestedTrackIndex, m_Type);
 
     if (previous && requested)
     {
@@ -78,8 +76,8 @@ void MoveItemToTrackCommand::undo()
 
 bool MoveItemToTrackCommand::Redo()
 {
-    SharedPlaybackTrack previous = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_PreviousTrackIndex) : m_Sequence->AudioTrackAt(m_PreviousTrackIndex);
-    SharedPlaybackTrack requested = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_RequestedTrackIndex) : m_Sequence->AudioTrackAt(m_RequestedTrackIndex);
+    SharedPlaybackTrack previous = m_Sequence->TrackAt(m_PreviousTrackIndex, m_Type);
+    SharedPlaybackTrack requested = m_Sequence->TrackAt(m_RequestedTrackIndex, m_Type);
 
     if (previous && requested)
     {
@@ -99,8 +97,8 @@ bool MoveItemToTrackCommand::Redo()
 OffsetItemCommand::OffsetItemCommand(const SharedTrackItem& item, int offset, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Sequence(item->Track()->Sequence())
-    , m_TrackIndex(item->Track()->TrackIndex())
-    , m_ItemIndex(item->Track()->ItemIndex(item))
+    , m_TrackIndex(item->Track()->Index())
+    , m_ItemIndex(item->Index())
     , m_Offset(offset)
     , m_TrackType(item->Track()->Type())
 {
@@ -109,8 +107,7 @@ OffsetItemCommand::OffsetItemCommand(const SharedTrackItem& item, int offset, QU
 
 void OffsetItemCommand::undo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         track->OffsetItem(item, -m_Offset);
@@ -121,8 +118,7 @@ bool OffsetItemCommand::Redo()
 {
     if (m_Offset == 0) return false;
 
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         return track->OffsetItem(item, m_Offset);
@@ -136,8 +132,8 @@ bool OffsetItemCommand::Redo()
 SetTrackItemColorCommand::SetTrackItemColorCommand(const SharedTrackItem& item, const QColor& color, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Sequence(item->Track()->Sequence())
-    , m_TrackIndex(item->Track()->TrackIndex())
-    , m_ItemIndex(item->Track()->ItemIndex(item))
+    , m_TrackIndex(item->Track()->Index())
+    , m_ItemIndex(item->Index())
     , m_Color(color)
     , m_Previous(item->Color())
     , m_TrackType(item->Track()->Type())
@@ -149,8 +145,8 @@ SetTrackItemColorCommand::SetTrackItemColorCommand(const SharedTrackItem& item, 
 SetTrackItemColorCommand::SetTrackItemColorCommand(const SharedTrackItem& item, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Sequence(item->Track()->Sequence())
-    , m_TrackIndex(item->Track()->TrackIndex())
-    , m_ItemIndex(item->Track()->ItemIndex(item))
+    , m_TrackIndex(item->Track()->Index())
+    , m_ItemIndex(item->Index())
     , m_Color(QColor(0, 0, 0))
     , m_Previous(item->Color())
     , m_Reset(true)
@@ -161,8 +157,7 @@ SetTrackItemColorCommand::SetTrackItemColorCommand(const SharedTrackItem& item, 
 
 void SetTrackItemColorCommand::undo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         item->SetColor(m_Previous);
@@ -171,8 +166,7 @@ void SetTrackItemColorCommand::undo()
 
 bool SetTrackItemColorCommand::Redo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         m_Reset ? item->ResetColor() : item->SetColor(m_Color);
@@ -187,7 +181,7 @@ bool SetTrackItemColorCommand::Redo()
 ToggleLockTrackCommand::ToggleLockTrackCommand(const SharedPlaybackTrack& track, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Sequence(track->Sequence())
-    , m_TrackIndex(track->TrackIndex())
+    , m_TrackIndex(track->Index())
     , m_TrackType(track->Type())
 {
     setText(track->Locked() ? "Unlock Track" : "Lock Track");
@@ -195,14 +189,13 @@ ToggleLockTrackCommand::ToggleLockTrackCommand(const SharedPlaybackTrack& track,
 
 void ToggleLockTrackCommand::undo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track) track->Lock(!track->Locked());
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
+        track->Lock(!track->Locked());
 }
 
 bool ToggleLockTrackCommand::Redo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         track->Lock(!track->Locked());
         return true;
@@ -216,7 +209,7 @@ bool ToggleLockTrackCommand::Redo()
 ToggleTrackStateCommand::ToggleTrackStateCommand(const SharedPlaybackTrack& track, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Sequence(track->Sequence())
-    , m_TrackIndex(track->TrackIndex())
+    , m_TrackIndex(track->Index())
     , m_TrackType(track->Type())
 {
     setText(track->Enabled() ? "Disable Track" : "Enable Track");
@@ -224,14 +217,13 @@ ToggleTrackStateCommand::ToggleTrackStateCommand(const SharedPlaybackTrack& trac
 
 void ToggleTrackStateCommand::undo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track) track->SetEnabled(!track->Enabled());
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
+        track->SetEnabled(!track->Enabled());
 }
 
 bool ToggleTrackStateCommand::Redo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         track->SetEnabled(!track->Enabled());
         return true;
@@ -247,17 +239,14 @@ ToggleTrackItemStateCommand::ToggleTrackItemStateCommand(const SharedTrackItem& 
     , m_Sequence(item->Track()->Sequence())
     , m_ItemIndex(item->Track()->ItemIndex(item))
     , m_TrackType(item->Track()->Type())
+    , m_TrackIndex(item->Track()->Index())
 {
-    const PlaybackTrack* const track = item->Track();
-    m_TrackIndex = track->Type() == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
-
     setText("Toggle TrackItem");
 }
 
 void ToggleTrackItemStateCommand::undo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         const SharedTrackItem item = track->ItemAt(m_ItemIndex);
         item->SetEnabled(!item->Enabled());
@@ -266,8 +255,7 @@ void ToggleTrackItemStateCommand::undo()
 
 bool ToggleTrackItemStateCommand::Redo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         const SharedTrackItem item = track->ItemAt(m_ItemIndex);
         item->SetEnabled(!item->Enabled());
@@ -285,15 +273,14 @@ ToggleTimelineEffectCommand::ToggleTimelineEffectCommand(Effect* effect, QUndoCo
     const PlaybackTrack* const track = effect->TimelineItem()->Track();
     const TrackItem* const item = effect->TimelineItem();
     m_TrackType = track->Type();
-    m_TrackIndex = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
-    m_ItemIndex = track->ItemIndex(item);
+    m_TrackIndex = track->Index();
+    m_ItemIndex = item->Index();
     m_EffectIndex = item->EffectIndex(effect);
 }
 
 void ToggleTimelineEffectCommand::undo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         const SharedTrackItem item = track->ItemAt(m_ItemIndex);
         Effect* effect = item->EffectAt(m_EffectIndex);
@@ -303,8 +290,7 @@ void ToggleTimelineEffectCommand::undo()
 
 bool ToggleTimelineEffectCommand::Redo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         const SharedTrackItem item = track->ItemAt(m_ItemIndex);
         Effect* effect = item->EffectAt(m_EffectIndex);
@@ -347,7 +333,7 @@ DeleteTrackCommand::DeleteTrackCommand(const SharedPlaybackTrack& track, QUndoCo
     , m_Sequence(track->Sequence())
     , m_Type(track->Type())
 {
-    m_TrackIndex = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track.get()) : m_Sequence->AudioTrackIndex(track.get());
+    m_TrackIndex = track->Index();
     setText("Delete Track");
 }
 
@@ -360,8 +346,7 @@ void DeleteTrackCommand::undo()
 
 bool DeleteTrackCommand::Redo()
 {
-    SharedPlaybackTrack track = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (SharedPlaybackTrack track = m_Sequence->TrackAt(m_TrackIndex, m_Type))
     {
         std::ostringstream os(std::ios::binary);
         track->Serialize(os);
@@ -383,16 +368,15 @@ DeleteTrackItemCommand::DeleteTrackItemCommand(const SharedTrackItem& item, QUnd
     PlaybackTrack* track = item->Track();
     m_Sequence = track->Sequence();
     m_TrackType = track->Type();
-    m_TrackIndex = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
-    m_ItemIndex = track->ItemIndex(item);
+    m_TrackIndex = track->Index();
+    m_ItemIndex = item->Index();
 
     setText("Delete TrackItem");
 }
 
 void DeleteTrackItemCommand::undo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         std::istringstream is(m_ItemData, std::ios::binary);
         SharedTrackItem item = std::make_shared<TrackItem>(track.get());
@@ -403,8 +387,7 @@ void DeleteTrackItemCommand::undo()
 
 bool DeleteTrackItemCommand::Redo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         std::ostringstream os(std::ios::binary);
         const SharedTrackItem item = track->ItemAt(m_ItemIndex);
@@ -482,8 +465,7 @@ CreateTimelineEffectCommand::CreateTimelineEffectCommand(const SharedTrackItem& 
 
 void CreateTimelineEffectCommand::undo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         const SharedTrackItem item = track->ItemAt(m_ItemIndex);
         item->RemoveEffect(m_EffectIndex);
@@ -492,8 +474,7 @@ void CreateTimelineEffectCommand::undo()
 
 bool CreateTimelineEffectCommand::Redo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         const SharedTrackItem item = track->ItemAt(m_ItemIndex);
         return (bool)track->CreateEffect(item, m_EffectType);
@@ -506,7 +487,7 @@ bool CreateTimelineEffectCommand::Redo()
 RazorTrackCommand::RazorTrackCommand(const SharedPlaybackTrack& track, v_frame_t frame, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Sequence(track->Sequence())
-    , m_TrackIndex(track->TrackIndex())
+    , m_TrackIndex(track->Index())
     , m_Type(track->Type())
     , m_Frame(frame)
 {
@@ -515,13 +496,13 @@ RazorTrackCommand::RazorTrackCommand(const SharedPlaybackTrack& track, v_frame_t
 
 void RazorTrackCommand::undo()
 {
-    SharedPlaybackTrack track = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    track->MergeCut(m_Frame);
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_Type))
+        track->MergeCut(m_Frame);
 }
 
 bool RazorTrackCommand::Redo()
 {
-    SharedPlaybackTrack track = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_Type);
     return track ? track->RazorAt(m_Frame) : false;
 }
 
@@ -562,7 +543,7 @@ bool RazorSequenceCommand::Redo()
 MergeCutCommand::MergeCutCommand(const SharedPlaybackTrack& track, v_frame_t frame, QUndoCommand* parent)
     : VoidUndoCommand(parent)
     , m_Sequence(track->Sequence())
-    , m_TrackIndex(track->TrackIndex())
+    , m_TrackIndex(track->Index())
     , m_Type(track->Type())
     , m_Frame(frame)
 {
@@ -587,7 +568,7 @@ OffsetItemSourceCommand::OffsetItemSourceCommand(const SharedTrackItem& item, in
     : VoidUndoCommand(parent)
     , m_Sequence(item->Track()->Sequence())
     , m_TrackType(item->Track()->Type())
-    , m_TrackIndex(item->Track()->TrackIndex())
+    , m_TrackIndex(item->Track()->Index())
     , m_ItemIndex(item->Track()->ItemIndex(item))
     , m_Offset(offset)
     , m_Previous(item->SourceIn())
@@ -597,8 +578,7 @@ OffsetItemSourceCommand::OffsetItemSourceCommand(const SharedTrackItem& item, in
 
 void OffsetItemSourceCommand::undo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         item->SetSourceIn(m_Previous);
@@ -610,8 +590,7 @@ bool OffsetItemSourceCommand::Redo()
     if (m_Offset == 0)
         return false;
 
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         item->SetSourceIn(item->SourceIn() + m_Offset);
@@ -627,7 +606,7 @@ TrimItemHeadCommand::TrimItemHeadCommand(const SharedTrackItem& item, int handle
     : VoidUndoCommand(parent)
     , m_Sequence(item->Track()->Sequence())
     , m_TrackType(item->Track()->Type())
-    , m_TrackIndex(item->Track()->TrackIndex())
+    , m_TrackIndex(item->Track()->Index())
     , m_ItemIndex(item->Track()->ItemIndex(item))
     , m_Handle(handle)
 {
@@ -636,8 +615,7 @@ TrimItemHeadCommand::TrimItemHeadCommand(const SharedTrackItem& item, int handle
 
 void TrimItemHeadCommand::undo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         item->TrimHead(-m_Handle);
@@ -648,8 +626,7 @@ bool TrimItemHeadCommand::Redo()
 {
     if (m_Handle == 0) return false;
 
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         if (m_Handle > item->Duration()) return false;
@@ -666,7 +643,7 @@ TrimItemTailCommand::TrimItemTailCommand(const SharedTrackItem& item, int handle
     : VoidUndoCommand(parent)
     , m_Sequence(item->Track()->Sequence())
     , m_TrackType(item->Track()->Type())
-    , m_TrackIndex(item->Track()->TrackIndex())
+    , m_TrackIndex(item->Track()->Index())
     , m_ItemIndex(item->Track()->ItemIndex(item))
     , m_Handle(handle)
 {
@@ -675,8 +652,7 @@ TrimItemTailCommand::TrimItemTailCommand(const SharedTrackItem& item, int handle
 
 void TrimItemTailCommand::undo()
 {
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         item->TrimTail(-m_Handle);
@@ -687,8 +663,7 @@ bool TrimItemTailCommand::Redo()
 {
     if (m_Handle == 0) return false;
 
-    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
-    if (track)
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         SharedTrackItem item = track->ItemAt(m_ItemIndex);
         if (m_Handle > item->Duration()) return false;

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -15,30 +15,35 @@ VOID_NAMESPACE_OPEN
 
 MoveTrackItemCommand::MoveTrackItemCommand(const SharedTrackItem& item, v_frame_t frame, QUndoCommand* parent)
     : VoidUndoCommand(parent)
-    , m_Item(item)
+    , m_Sequence(item->Track()->Sequence())
+    , m_TrackIndex(item->Track()->TrackIndex())
+    , m_ItemIndex(item->Track()->ItemIndex(item))
     , m_Requested(frame)
     , m_Previous(item->TimelineIn())
+    , m_TrackType(item->Track()->Type())
 {
     setText("Move TrackItem");
 }
 
 void MoveTrackItemCommand::undo()
 {
-    if (SharedTrackItem item = m_Item.lock())
+    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
     {
-        if (PlaybackTrack* track = item->Track())
-            track->MoveItem(item, m_Previous);
+        SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        track->MoveItem(item, m_Previous);
     }
 }
 
 bool MoveTrackItemCommand::Redo()
 {
-    if (SharedTrackItem item = m_Item.lock())
+    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
     {
-        if (PlaybackTrack* track = item->Track())
-            return track->MoveItem(item, m_Requested);
-        return false;
+        SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        return track->MoveItem(item, m_Requested);
     }
+
     return false;
 }
 
@@ -130,9 +135,12 @@ bool OffsetItemCommand::Redo()
 
 SetTrackItemColorCommand::SetTrackItemColorCommand(const SharedTrackItem& item, const QColor& color, QUndoCommand* parent)
     : VoidUndoCommand(parent)
-    , m_Item(item)
+    , m_Sequence(item->Track()->Sequence())
+    , m_TrackIndex(item->Track()->TrackIndex())
+    , m_ItemIndex(item->Track()->ItemIndex(item))
     , m_Color(color)
     , m_Previous(item->Color())
+    , m_TrackType(item->Track()->Type())
     , m_Reset(false)
 {
     setText("Set Trackitem Color");
@@ -140,23 +148,33 @@ SetTrackItemColorCommand::SetTrackItemColorCommand(const SharedTrackItem& item, 
 
 SetTrackItemColorCommand::SetTrackItemColorCommand(const SharedTrackItem& item, QUndoCommand* parent)
     : VoidUndoCommand(parent)
-    , m_Item(item)
+    , m_Sequence(item->Track()->Sequence())
+    , m_TrackIndex(item->Track()->TrackIndex())
+    , m_ItemIndex(item->Track()->ItemIndex(item))
     , m_Color(QColor(0, 0, 0))
     , m_Previous(item->Color())
     , m_Reset(true)
+    , m_TrackType(item->Track()->Type())
 {
     setText("Reset Trackitem Color");
 }
 
 void SetTrackItemColorCommand::undo()
 {
-    if (SharedTrackItem item = m_Item.lock()) item->SetColor(m_Previous);
+    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        item->SetColor(m_Previous);
+    }
 }
 
 bool SetTrackItemColorCommand::Redo()
 {
-    if (SharedTrackItem item = m_Item.lock())
+    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
     {
+        SharedTrackItem item = track->ItemAt(m_ItemIndex);
         m_Reset ? item->ResetColor() : item->SetColor(m_Color);
         return true;
     }
@@ -168,22 +186,25 @@ bool SetTrackItemColorCommand::Redo()
 
 ToggleLockTrackCommand::ToggleLockTrackCommand(const SharedPlaybackTrack& track, QUndoCommand* parent)
     : VoidUndoCommand(parent)
-    , m_Track(track)
-    , m_Previous(track->Locked())
+    , m_Sequence(track->Sequence())
+    , m_TrackIndex(track->TrackIndex())
+    , m_TrackType(track->Type())
 {
-    setText(m_Previous ? "Unlock Track" : "Lock Track");
+    setText(track->Locked() ? "Unlock Track" : "Lock Track");
 }
 
 void ToggleLockTrackCommand::undo()
 {
-    if (SharedPlaybackTrack track = m_Track.lock()) track->Lock(m_Previous);
+    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track) track->Lock(!track->Locked());
 }
 
 bool ToggleLockTrackCommand::Redo()
 {
-    if (SharedPlaybackTrack track = m_Track.lock())
+    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
     {
-        track->Lock(!m_Previous);
+        track->Lock(!track->Locked());
         return true;
     }
 
@@ -194,22 +215,25 @@ bool ToggleLockTrackCommand::Redo()
 
 ToggleTrackStateCommand::ToggleTrackStateCommand(const SharedPlaybackTrack& track, QUndoCommand* parent)
     : VoidUndoCommand(parent)
-    , m_Track(track)
-    , m_Previous(track->Enabled())
+    , m_Sequence(track->Sequence())
+    , m_TrackIndex(track->TrackIndex())
+    , m_TrackType(track->Type())
 {
-    setText(m_Previous ? "Disable Track" : "Enable Track");
+    setText(track->Enabled() ? "Disable Track" : "Enable Track");
 }
 
 void ToggleTrackStateCommand::undo()
 {
-    if (SharedPlaybackTrack track = m_Track.lock()) track->SetEnabled(m_Previous);
+    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track) track->SetEnabled(!track->Enabled());
 }
 
 bool ToggleTrackStateCommand::Redo()
 {
-    if (SharedPlaybackTrack track = m_Track.lock())
+    SharedPlaybackTrack track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
     {
-        track->SetEnabled(!m_Previous);
+        track->SetEnabled(!track->Enabled());
         return true;
     }
 
@@ -318,41 +342,34 @@ bool CreateTrackCommand::Redo()
 
 /// DeleteTrackCommand
 
-DeleteTrackCommand::DeleteTrackCommand(const SharedPlaybackSequence& sequence, int index, const Sequence::TrackType& type, QUndoCommand* parent)
+DeleteTrackCommand::DeleteTrackCommand(const SharedPlaybackTrack& track, QUndoCommand* parent)
     : VoidUndoCommand(parent)
-    , m_Sequence(sequence)
-    , m_Type(type)
-    , m_TrackIndex(index)
+    , m_Sequence(track->Sequence())
+    , m_Type(track->Type())
 {
+    m_TrackIndex = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track.get()) : m_Sequence->AudioTrackIndex(track.get());
     setText("Delete Track");
 }
 
 void DeleteTrackCommand::undo()
 {
-    if (SharedPlaybackSequence sequence = m_Sequence.lock())
-    {
-        std::istringstream is(m_TrackData, std::ios::binary);
-        SharedPlaybackTrack track = sequence->CreateTrack(m_Type, m_TrackIndex);
-        track->Deserialize(is);
-    }
+    std::istringstream is(m_TrackData, std::ios::binary);
+    SharedPlaybackTrack track = m_Sequence->CreateTrack(m_Type, m_TrackIndex);
+    track->Deserialize(is);
 }
 
 bool DeleteTrackCommand::Redo()
 {
-    if (SharedPlaybackSequence sequence = m_Sequence.lock())
+    SharedPlaybackTrack track = m_Type == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
     {
-        if (const SharedPlaybackTrack track = sequence->VideoTrackAt(m_TrackIndex))
-        {
-            std::ostringstream os(std::ios::binary);
-            track->Serialize(os);
-            m_TrackData = os.str();
+        std::ostringstream os(std::ios::binary);
+        track->Serialize(os);
+        m_TrackData = os.str();
 
-            track->Clear();
-            sequence->RemoveTrack(track);
-            return true;
-        }
-
-        return false;
+        track->Clear();
+        m_Sequence->RemoveTrack(track);
+        return true;
     }
 
     return false;
@@ -360,46 +377,41 @@ bool DeleteTrackCommand::Redo()
 
 /// DeleteTrackItemCommand
 
-DeleteTrackItemCommand::DeleteTrackItemCommand(const SharedPlaybackSequence& sequence, const Sequence::TrackType& type, int trackindex, int index, QUndoCommand* parent)
+DeleteTrackItemCommand::DeleteTrackItemCommand(const SharedTrackItem& item, QUndoCommand* parent)
     : VoidUndoCommand(parent)
-    , m_Sequence(sequence)
-    , m_Type(type)
-    , m_TrackIndex(trackindex)
-    , m_ItemIndex(index)
 {
+    PlaybackTrack* track = item->Track();
+    m_Sequence = track->Sequence();
+    m_TrackType = track->Type();
+    m_TrackIndex = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
+    m_ItemIndex = track->ItemIndex(item);
+
     setText("Delete TrackItem");
 }
 
 void DeleteTrackItemCommand::undo()
 {
-    if (SharedPlaybackSequence sequence = m_Sequence.lock())
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
     {
-        const SharedPlaybackTrack& track = m_Type == Sequence::TrackType::VIDEO ? sequence->VideoTrackAt(m_TrackIndex) : sequence->AudioTrackAt(m_TrackIndex);
-        if (track)
-        {
-            std::istringstream is(m_ItemData, std::ios::binary);
-            SharedTrackItem item = std::make_shared<TrackItem>(track.get());
-            item->Deserialize(is);
-            track->AddItem(item);
-        }
+        std::istringstream is(m_ItemData, std::ios::binary);
+        SharedTrackItem item = std::make_shared<TrackItem>(track.get());
+        item->Deserialize(is);
+        track->AddItem(item);
     }
 }
 
 bool DeleteTrackItemCommand::Redo()
 {
-    if (SharedPlaybackSequence sequence = m_Sequence.lock())
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
     {
-        const SharedPlaybackTrack& track = m_Type == Sequence::TrackType::VIDEO ? sequence->VideoTrackAt(m_TrackIndex) : sequence->AudioTrackAt(m_TrackIndex);
-        if (track)
-        {
-            std::ostringstream os(std::ios::binary);
-            const SharedTrackItem item = track->ItemAt(m_ItemIndex);
-            item->Serialize(os);
-            m_ItemData = os.str();
-            track->RemoveItem(item);
-            return true;
-        }
-        return false;
+        std::ostringstream os(std::ios::binary);
+        const SharedTrackItem item = track->ItemAt(m_ItemIndex);
+        item->Serialize(os);
+        m_ItemData = os.str();
+        track->RemoveItem(item);
+        return true;
     }
     return false;
 }

--- a/src/VoidUi/Commands/SequenceCommands.h
+++ b/src/VoidUi/Commands/SequenceCommands.h
@@ -21,8 +21,10 @@ public:
     bool Redo() override;
 
 private:
-    std::weak_ptr<TrackItem> m_Item;
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex, m_ItemIndex;
     v_frame_t m_Requested, m_Previous;
+    Sequence::TrackType m_TrackType;
 };
 
 class MoveItemToTrackCommand : public VoidUndoCommand
@@ -63,9 +65,11 @@ public:
     bool Redo() override;
 
 private:
-    std::weak_ptr<TrackItem> m_Item;
     QColor m_Color;
     QColor m_Previous;
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex, m_ItemIndex;
+    Sequence::TrackType m_TrackType;
     bool m_Reset;
 };
 
@@ -77,8 +81,9 @@ public:
     bool Redo() override;
 
 private:
-    std::weak_ptr<PlaybackTrack> m_Track;
-    bool m_Previous;
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
+    Sequence::TrackType m_TrackType;
 };
 
 class ToggleTrackStateCommand : public VoidUndoCommand
@@ -89,8 +94,9 @@ public:
     bool Redo() override;
 
 private:
-    std::weak_ptr<PlaybackTrack> m_Track;
-    bool m_Previous;
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
+    Sequence::TrackType m_TrackType;
 };
 
 class ToggleTrackItemStateCommand : public VoidUndoCommand
@@ -138,13 +144,13 @@ private:
 class DeleteTrackCommand : public VoidUndoCommand
 {
 public:
-    DeleteTrackCommand(const SharedPlaybackSequence& sequence, int index, const Sequence::TrackType& type, QUndoCommand* parent = nullptr);
+    DeleteTrackCommand(const SharedPlaybackTrack& track, QUndoCommand* parent = nullptr);
     void undo() override;
     bool Redo() override;
 
 private:
     std::string m_TrackData;
-    std::weak_ptr<PlaybackSequence> m_Sequence;
+    PlaybackSequence* m_Sequence;
     Sequence::TrackType m_Type;
     int m_TrackIndex;
 };
@@ -152,16 +158,16 @@ private:
 class DeleteTrackItemCommand : public VoidUndoCommand
 {
 public:
-    DeleteTrackItemCommand(const SharedPlaybackSequence& sequence, const Sequence::TrackType& type, int trackindex, int index, QUndoCommand* parent = nullptr);
+    DeleteTrackItemCommand(const SharedTrackItem& item, QUndoCommand* parent = nullptr);
     void undo() override;
     bool Redo() override;
 
 private:
-    std::weak_ptr<PlaybackSequence> m_Sequence;
-    Sequence::TrackType m_Type;
+    std::string m_ItemData;
+    PlaybackSequence* m_Sequence;
     int m_TrackIndex;
     int m_ItemIndex;
-    std::string m_ItemData;
+    Sequence::TrackType m_TrackType;
 };
 
 class DeleteTimelineEffectCommand : public VoidUndoCommand

--- a/src/VoidUi/Engine/IconForge.cpp
+++ b/src/VoidUi/Engine/IconForge.cpp
@@ -54,6 +54,7 @@ QPixmap IconForge::Pixmap(const IconType& icon, int size, const QColor& color)
     pixmap.fill(Qt::transparent);
 
     QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
     painter.setFont(font);
     painter.setPen(color);
     painter.drawText(pixmap.rect(), Qt::AlignCenter, QChar(static_cast<char16_t>(icon)));

--- a/src/VoidUi/Media/MediaBridge.cpp
+++ b/src/VoidUi/Media/MediaBridge.cpp
@@ -200,7 +200,7 @@ void MBridge::AddToPlaylist(QByteArray& data, Playlist* playlist)
         QDataStream stream(&data, QIODevice::ReadOnly);
         int count;
         stream >> count;
-    
+
         QUndoStack* stack = m_Project->UndoStack();
         stack->beginMacro("Add Media to Playlist");
 
@@ -275,7 +275,7 @@ bool MBridge::AddMedia(MediaStruct&& mstruct)
         m_Project->AddMedia(clip);
         emit mediaAdded(clip);
         // Success
-        return true;    
+        return true;
     }
 
     VOID_LOG_INFO("Invalid Media Type");
@@ -353,6 +353,19 @@ bool MBridge::InsertMedia(const MediaStruct& mstruct, int index)
     }
 
     VOID_LOG_INFO("Invalid Media Type");
+    return false;
+}
+
+bool MBridge::InsertMedia(const SharedMediaClip& media, int index)
+{
+    if (media->Valid())
+    {
+        m_Project->InsertMedia(media, index);
+        emit mediaAdded(media);
+        return true;
+    }
+
+    VOID_LOG_INFO("Invalid Media");
     return false;
 }
 
@@ -684,7 +697,7 @@ QMenu* MBridge::RecentProjectsMenu(QMenu* parent)
 {
     if (!m_RecentProjectsMenu)
         m_RecentProjectsMenu = new QMenu("Recent Projects", parent);
-    
+
     ResetProjectsMenu();
     return m_RecentProjectsMenu;
 }

--- a/src/VoidUi/Media/MediaBridge.h
+++ b/src/VoidUi/Media/MediaBridge.h
@@ -90,9 +90,10 @@ public:
      * Adds Media to the Graph
      */
     bool AddMedia(MediaStruct&& mstruct);
-    bool AddMedia(const MediaStruct& mstruct);    
+    bool AddMedia(const MediaStruct& mstruct);
     bool InsertMedia(MediaStruct&& mstruct, int index);
     bool InsertMedia(const MediaStruct& mstruct, int index);
+    bool InsertMedia(const SharedMediaClip& media, int index);
 
     void AddTag(const QModelIndex& index, const std::string& tag);
     void AddTag(const SharedMediaClip& media, const std::string& tag);

--- a/src/VoidUi/Sequencer/Graphics/STrack.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrack.cpp
@@ -27,7 +27,7 @@ STrack::STrack(const SharedPlaybackTrack& track, SequencerContext* context, QGra
     connect(m_Track.get(), &PlaybackTrack::itemAboutToBeRemoved, this, &STrack::RemoveItem);
     connect(m_Track.get(), &PlaybackTrack::itemRemoved, this, &STrack::Update);
 
-    int index = track->TrackIndex();
+    int index = track->Index();
     m_BoundingRect = QRectF(
         0,
         0,
@@ -67,7 +67,7 @@ void STrack::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QW
 void STrack::Update()
 {
     prepareGeometryChange();
-    int index = m_Track->TrackIndex();
+    int index = m_Track->Index();
     setPos(0, m_Context->Geometry()->TrackRect(index).top());
     
     m_BoundingRect = QRectF(

--- a/src/VoidUi/Sequencer/Graphics/STrack.h
+++ b/src/VoidUi/Sequencer/Graphics/STrack.h
@@ -25,7 +25,7 @@ public:
 
     SharedPlaybackTrack& Track() { return m_Track; }
     const SharedPlaybackTrack& Track() const { return m_Track; }
-    int Index() const { return m_Track->TrackIndex(); }
+    int Index() const { return m_Track->Index(); }
     bool Locked() const { return m_Track->Locked(); }
     bool Enabled() const { return m_Track->Enabled(); }
     bool IsRazored(v_frame_t frame) const { return m_Track->IsRazored(frame); }

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -129,20 +129,20 @@ void SequencerController::CreateAudioTrack(const SharedPlaybackSequence& sequenc
     _MediaBridge.PushCommand(new CreateTrackCommand(sequence, Sequence::TrackType::AUDIO));
 }
 
-void SequencerController::RemoveTracks(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedPlaybackTrack>& tracks)
+void SequencerController::RemoveTracks(const std::unordered_set<SharedPlaybackTrack>& tracks)
 {
     QUndoStack* stack = _MediaBridge.UndoStack();
 
     stack->beginMacro("Remove Track(s)");
     for (const auto& track : tracks)
-        stack->push(new DeleteTrackCommand(sequence, track->TrackIndex(), track->Type()));
+        stack->push(new DeleteTrackCommand(track));
     stack->endMacro();
 }
 
-void SequencerController::RemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items)
+void SequencerController::RemoveTrackItems(const std::unordered_set<SharedTrackItem>& items)
 {
     if (m_EditMode == EditMode::RIPPLE)
-        return RippleRemoveTrackItems(sequence, items);
+        return RippleRemoveTrackItems(items);
 
     QUndoStack* stack = _MediaBridge.UndoStack();
 
@@ -174,12 +174,12 @@ void SequencerController::RemoveTrackItems(const SharedPlaybackSequence& sequenc
     for (const auto& item : items)
     {
         const PlaybackTrack* track = item->Track();
-        stack->push(new DeleteTrackItemCommand(sequence, track->Type(), track->TrackIndex(), track->ItemIndex(item)));
+        stack->push(new DeleteTrackItemCommand(item));
     }
     stack->endMacro();
 }
 
-void SequencerController::RippleRemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items)
+void SequencerController::RippleRemoveTrackItems(const std::unordered_set<SharedTrackItem>& items)
 {
     QUndoStack* stack = _MediaBridge.UndoStack();
 
@@ -213,7 +213,7 @@ void SequencerController::RippleRemoveTrackItems(const SharedPlaybackSequence& s
         const PlaybackTrack* track = item->Track();
         int index = track->ItemIndex(item);
 
-        stack->push(new DeleteTrackItemCommand(sequence, track->Type(), track->TrackIndex(), track->ItemIndex(item)));
+        stack->push(new DeleteTrackItemCommand(item));
 
         std::size_t max = track->NumItems();
         // Last Item --- Nothing else to offset/move

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -49,9 +49,9 @@ public:
     void RippleMoveItem(const SharedPlaybackTrack& track, const SharedTrackItem& item, int trackIndex, v_frame_t frame);
     void CreateVideoTrack(const SharedPlaybackSequence& sequence);
     void CreateAudioTrack(const SharedPlaybackSequence& sequence);
-    void RemoveTracks(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedPlaybackTrack>& tracks);
-    void RemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items);
-    void RippleRemoveTrackItems(const SharedPlaybackSequence& sequence, const std::unordered_set<SharedTrackItem>& items);
+    void RemoveTracks(const std::unordered_set<SharedPlaybackTrack>& tracks);
+    void RemoveTrackItems(const std::unordered_set<SharedTrackItem>& items);
+    void RippleRemoveTrackItems(const std::unordered_set<SharedTrackItem>& items);
     void CreateEffect(const std::unordered_set<SharedTrackItem>& items, const std::string& type);
     void RemoveTimelineEffects(const std::unordered_set<Effect*>& effects);
 

--- a/src/VoidUi/Sequencer/Sequencer.cpp
+++ b/src/VoidUi/Sequencer/Sequencer.cpp
@@ -203,9 +203,9 @@ void SequencerTimeline::CreateEffect(const std::string& type)
 void SequencerTimeline::DeleteSelected()
 {
     if (m_Context.SelectionModel()->HasTrackSelection())
-        m_Context.Controller()->RemoveTracks(m_Sequence, m_Context.SelectionModel()->SelectedTracks());
+        m_Context.Controller()->RemoveTracks(m_Context.SelectionModel()->SelectedTracks());
     else if (m_Context.SelectionModel()->HasTrackItemSelection())
-        m_Context.Controller()->RemoveTrackItems(m_Sequence, m_Context.SelectionModel()->SelectedItems());
+        m_Context.Controller()->RemoveTrackItems(m_Context.SelectionModel()->SelectedItems());
     else if (m_Context.SelectionModel()->HasEffectSelection())
         m_Context.Controller()->RemoveTimelineEffects(m_Context.SelectionModel()->SelectedEffects());
 
@@ -215,7 +215,7 @@ void SequencerTimeline::DeleteSelected()
 void SequencerTimeline::RippleDeleteSelected()
 {
     if (m_Context.SelectionModel()->HasTrackItemSelection())
-        m_Context.Controller()->RippleRemoveTrackItems(m_Sequence, m_Context.SelectionModel()->SelectedItems());
+        m_Context.Controller()->RippleRemoveTrackItems(m_Context.SelectionModel()->SelectedItems());
 
     m_Context.SelectionModel()->Clear();
 }

--- a/src/VoidUi/Sequencer/Widgets/STrackHeader.cpp
+++ b/src/VoidUi/Sequencer/Widgets/STrackHeader.cpp
@@ -33,8 +33,8 @@ QSize STrackHeader::sizeHint() const
     return QSize(
         Sequencer::TrackHeaderWidth,
         m_Track->Type() == Sequence::TrackType::VIDEO
-            ? m_Context->Geometry()->VideoTrackHeight(m_Track->TrackIndex())
-            : m_Context->Geometry()->AudioTrackHeight(m_Track->TrackIndex())
+            ? m_Context->Geometry()->VideoTrackHeight(m_Track->Index())
+            : m_Context->Geometry()->AudioTrackHeight(m_Track->Index())
     );
 }
 
@@ -124,13 +124,13 @@ void STrackHeader::UpdateSize()
     // resize(
     //     Sequencer::TrackHeaderWidth,
     //     m_Track->Type() == Sequence::TrackType::VIDEO
-    //         ? m_Context->Geometry()->VideoTrackHeight(m_Track->TrackIndex())
-    //         : m_Context->Geometry()->AudioTrackHeight(m_Track->TrackIndex())    
+    //         ? m_Context->Geometry()->VideoTrackHeight(m_Track->Index())
+    //         : m_Context->Geometry()->AudioTrackHeight(m_Track->Index())    
     // );
     setFixedHeight(
         m_Track->Type() == Sequence::TrackType::VIDEO
-            ? m_Context->Geometry()->VideoTrackHeight(m_Track->TrackIndex())
-            : m_Context->Geometry()->AudioTrackHeight(m_Track->TrackIndex())
+            ? m_Context->Geometry()->VideoTrackHeight(m_Track->Index())
+            : m_Context->Geometry()->AudioTrackHeight(m_Track->Index())
     );
     update();
 }


### PR DESCRIPTION
### Changes
- Media deletion now serializes the media and deserializes it back on undo.
- Sequence command currently work with indexes to ensure the undo - redo works correctly even when the pointer/shared_pointer becomes stale (like after deletion and undo).
- Added index helper APIs directly on sequence components.