### PR TITLE
[VOID] Track Effects

### DIFF
--- a/src/Bindings/CoreModule.cpp
+++ b/src/Bindings/CoreModule.cpp
@@ -169,6 +169,9 @@ void BindCore(py::module_& m)
         .def("set_enabled", &Effect::SetEnabled, py::arg("enable"))
         .def("timeline_in", &Effect::TimelineIn)
         .def("timeline_out", &Effect::TimelineOut)
+        .def("set_timeline_in", &Effect::SetTimelineIn, py::arg("frame"))
+        .def("set_timeline_out", &Effect::SetTimelineOut, py::arg("frame"))
+        .def("set_timeline_range", &Effect::SetTimelineRange, py::arg("start"), py::arg("end"))
         .def("get_value", &Effect::Value, py::return_value_policy::reference)
         .def("set_value", &Effect::SetValue, py::arg("param"), py::arg("value"));
 
@@ -178,9 +181,23 @@ void BindCore(py::module_& m)
         .def("end_frame", &PlaybackSequence::EndFrame)
         .def("set_range", &PlaybackSequence::SetRange, py::arg("start"), py::arg("end"))
         .def("has_media", &PlaybackSequence::HasMedia)
-        .def("create_track", static_cast<SharedPlaybackTrack (PlaybackSequence::*)(const Sequence::TrackType&)>(&PlaybackSequence::CreateTrack), py::arg("type"), py::return_value_policy::reference)
-        .def("remove_track", static_cast<void (PlaybackSequence::*)(const SharedPlaybackTrack&)>(&PlaybackSequence::RemoveTrack), py::arg("track"))
-        .def("remove_track", static_cast<void (PlaybackSequence::*)(int, const Sequence::TrackType&)>(&PlaybackSequence::RemoveTrack), py::arg("index"), py::arg("type"))
+        .def(
+            "create_track",
+            static_cast<SharedPlaybackTrack (PlaybackSequence::*)(const Sequence::TrackType&)>(&PlaybackSequence::CreateTrack),
+            py::arg("type"),
+            py::return_value_policy::reference
+        )
+        .def(
+            "remove_track",
+            static_cast<void (PlaybackSequence::*)(const SharedPlaybackTrack&)>(&PlaybackSequence::RemoveTrack),
+            py::arg("track")
+        )
+        .def(
+            "remove_track",
+            static_cast<void (PlaybackSequence::*)(int, const Sequence::TrackType&)>(&PlaybackSequence::RemoveTrack),
+            py::arg("index"),
+            py::arg("type")
+        )
         .def("video_track", &PlaybackSequence::VideoTrackAt, py::arg("index"), py::return_value_policy::reference)
         .def("audio_track", &PlaybackSequence::AudioTrackAt, py::arg("index"), py::return_value_policy::reference)
         .def("video_tracks", &PlaybackSequence::VideoTracks, py::return_value_policy::reference)
@@ -211,7 +228,29 @@ void BindCore(py::module_& m)
         .def("move_item", &PlaybackTrack::MoveItem, py::arg("track_item"), py::arg("frame"))
         .def("item_at", &PlaybackTrack::ItemAt, py::arg("index"), py::return_value_policy::reference)
         .def("items", &PlaybackTrack::Items, py::return_value_policy::reference)
-        .def("create_effect", &PlaybackTrack::CreateEffect, py::arg("track_item"), py::arg("effect"), py::return_value_policy::reference);
+        .def(
+            "create_effect",
+            static_cast<Effect* (PlaybackTrack::*)(const SharedTrackItem&, const std::string&)>(&PlaybackTrack::CreateEffect),
+            py::arg("track_item"),
+            py::arg("effect"),
+            py::return_value_policy::reference
+        )
+        .def(
+            "create_effect",
+            static_cast<Effect* (PlaybackTrack::*)(const std::string&)>(&PlaybackTrack::CreateEffect),
+            py::arg("effect"),
+            py::return_value_policy::reference
+        )
+        .def("remove_effect", [](const SharedPlaybackTrack& self, Effect* effect) -> void
+            {
+                int index = self->EffectIndex(effect);
+                if (index < 0) return;
+
+                self->RemoveEffect(index, true);
+            },
+            py::arg("effect")
+        )
+        .def("clear_effects", &PlaybackTrack::ClearEffects);
 
     py::class_<TrackItem, SharedTrackItem>(m, "TrackItem")
         .def("__repr__", [](py::handle h) -> std::string

--- a/src/VoidObjects/Effects/Bridge.cpp
+++ b/src/VoidObjects/Effects/Bridge.cpp
@@ -29,6 +29,19 @@ Effect* EffectsBridge::CreateEffect(const std::string& type)
     return nullptr;
 }
 
+Effect* EffectsBridge::CreateEffect(const std::string& type, const std::string& name)
+{
+    if (std::unique_ptr<ImageOp> creator = Forge::Instance().GetImageOp(type))
+    {
+        /**
+         * We want to transfer the ownership of the created operator to the effect
+         * such that it will be it's new parent and will decide when the creator needs to be deleted
+         */
+        return new Effect(creator.release(), name);
+    }
+    return nullptr;
+}
+
 Effect* EffectsBridge::CreateEffect(const std::string& type, v_frame_t in, v_frame_t out)
 {
     if (std::unique_ptr<ImageOp> creator = Forge::Instance().GetImageOp(type))
@@ -38,6 +51,19 @@ Effect* EffectsBridge::CreateEffect(const std::string& type, v_frame_t in, v_fra
          * such that it will be it's new parent and will decide when the creator needs to be deleted
          */
         return new Effect(creator.release(), EffectName(type), in, out);
+    }
+    return nullptr;
+}
+
+Effect* EffectsBridge::CreateEffect(const std::string& type, const std::string& name, v_frame_t in, v_frame_t out)
+{
+    if (std::unique_ptr<ImageOp> creator = Forge::Instance().GetImageOp(type))
+    {
+        /**
+         * We want to transfer the ownership of the created operator to the effect
+         * such that it will be it's new parent and will decide when the creator needs to be deleted
+         */
+        return new Effect(creator.release(), name, in, out);
     }
     return nullptr;
 }

--- a/src/VoidObjects/Effects/Bridge.h
+++ b/src/VoidObjects/Effects/Bridge.h
@@ -21,7 +21,9 @@ public:
     static EffectsBridge& Instance();
 
     Effect* CreateEffect(const std::string& type);
+    Effect* CreateEffect(const std::string& type, const std::string& name);    
     Effect* CreateEffect(const std::string& type, v_frame_t in, v_frame_t out);
+    Effect* CreateEffect(const std::string& type, const std::string& name, v_frame_t in, v_frame_t out);
     Effect* Copy(const Effect* effect);
 
 private: /* Members */

--- a/src/VoidObjects/Effects/Effects.cpp
+++ b/src/VoidObjects/Effects/Effects.cpp
@@ -14,11 +14,14 @@ Effect::Effect(ImageOp* iop, const std::string& name, QObject* parent)
 Effect::Effect(ImageOp* iop, const std::string& name, v_frame_t in, v_frame_t out, QObject* parent)
     : VoidObject(parent)
     , m_Operator(iop)
+    , m_TrackItem(nullptr)
+    , m_Track(nullptr)
     , m_Name(name)
     , m_Color(225, 220, 225)
     , m_TimelineIn(in)
     , m_TimelineOut(out)
     , m_Enabled(true)
+    , m_Type(EffectType::ITEM)
 {
 }
 
@@ -34,6 +37,14 @@ Effect::~Effect()
 void Effect::SetTimelineItem(TrackItem* item)
 {
     m_TrackItem = item;
+    m_Type = EffectType::ITEM;
+    emit updated();
+}
+
+void Effect::SetTrack(PlaybackTrack* track)
+{
+    m_Track = track;
+    m_Type = EffectType::TRACK;
     emit updated();
 }
 
@@ -113,6 +124,7 @@ void Effect::Serialize(rapidjson::Value& out, rapidjson::Document::AllocatorType
     out.SetObject();
     out.AddMember("name_", rapidjson::Value(m_Name.c_str(), allocator), allocator);
     out.AddMember("enabled_", static_cast<int>(m_Enabled), allocator);
+    out.AddMember("internal_type_", static_cast<int>(m_Type), allocator);
     out.AddMember("timeline_in_", static_cast<int64_t>(m_TimelineIn), allocator);
     out.AddMember("timeline_out_", static_cast<int64_t>(m_TimelineOut), allocator);
     out.AddMember("color_r_", m_Color.red(), allocator);
@@ -145,6 +157,7 @@ void Effect::Serialize(std::ostream& out) const
     WriteString(out, m_Name);
     
     out.write(reinterpret_cast<const char*>(&m_Enabled), sizeof(m_Enabled));
+    out.write(reinterpret_cast<const char*>(&m_Type), sizeof(m_Type));
     out.write(reinterpret_cast<const char*>(&m_TimelineIn), sizeof(m_TimelineIn));
     out.write(reinterpret_cast<const char*>(&m_TimelineOut), sizeof(m_TimelineOut));
 
@@ -165,6 +178,7 @@ void Effect::Deserialize(const rapidjson::Value& in)
 {
     m_Name = in["name_"].GetString();
     m_Enabled = in["enabled_"].GetInt();
+    m_Type = static_cast<EffectType>(in["internal_type_"].GetInt());
     m_TimelineIn = in["timeline_in_"].GetInt64();
     m_TimelineOut = in["timeline_out_"].GetInt64();
 
@@ -198,6 +212,7 @@ void Effect::Deserialize(std::istream& in)
     m_Name = ReadString(in);
 
     in.read(reinterpret_cast<char*>(&m_Enabled), sizeof(m_Enabled));
+    in.read(reinterpret_cast<char*>(&m_Type), sizeof(m_Type));
     in.read(reinterpret_cast<char*>(&m_TimelineIn), sizeof(m_TimelineIn));
     in.read(reinterpret_cast<char*>(&m_TimelineOut), sizeof(m_TimelineOut));
 

--- a/src/VoidObjects/Effects/Effects.cpp
+++ b/src/VoidObjects/Effects/Effects.cpp
@@ -2,7 +2,8 @@
 // Licensed under the MIT License
 
 #include "Effects.h"
-#include "VoidCore/Logging.h"
+#include "VoidObjects/Sequence/Track.h"
+#include "VoidObjects/Sequence/TrackItem.h"
 
 VOID_NAMESPACE_OPEN
 
@@ -92,6 +93,14 @@ const ValueType& Effect::Value(const std::string& param) const
 
     static ValueType invalid = std::monostate{};
     return invalid;
+}
+
+bool Effect::Enabled() const
+{
+    if (m_Enabled)
+        return m_Type == EffectType::TRACK ? m_Track->Enabled() : m_TrackItem->Enabled();
+
+    return false;
 }
 
 void Effect::SetEnabled(bool enable)

--- a/src/VoidObjects/Effects/Effects.h
+++ b/src/VoidObjects/Effects/Effects.h
@@ -73,7 +73,7 @@ public:
      */
     const ValueType& Value(const std::string& param) const;
 
-    [[nodiscard]] bool Enabled() const { return m_Enabled; }
+    [[nodiscard]] bool Enabled() const;
     void SetEnabled(bool enable);
 
     Param* GetParam(const std::string& name) const { return m_Operator->GetParam(name); }

--- a/src/VoidObjects/Effects/Effects.h
+++ b/src/VoidObjects/Effects/Effects.h
@@ -14,11 +14,20 @@
 
 VOID_NAMESPACE_OPEN
 
+class PlaybackTrack;
 class TrackItem;
 
 class VOID_API Effect : public VoidObject
 {
     Q_OBJECT
+
+public:
+    enum class EffectType
+    {
+        CLIP,
+        ITEM,
+        TRACK
+    };
 
 public:
     Effect(ImageOp* iop, const std::string& name, QObject* parent = nullptr);
@@ -27,6 +36,11 @@ public:
 
     TrackItem* TimelineItem() const { return m_TrackItem; }
     void SetTimelineItem(TrackItem* item);
+
+    PlaybackTrack* Track() const { return m_Track; }
+    void SetTrack(PlaybackTrack* track);
+
+    const EffectType& GetEffectType() const { return m_Type; }
 
     const std::string& Name() const { return m_Name; }
     void SetName(const std::string& name);
@@ -88,9 +102,11 @@ signals:
 private:
     ImageOp* m_Operator;
     TrackItem* m_TrackItem;
+    PlaybackTrack* m_Track;
     std::string m_Name;
     QColor m_Color;
     v_frame_t m_TimelineIn, m_TimelineOut;
+    EffectType m_Type;
     bool m_Enabled;
 };
 

--- a/src/VoidObjects/Sequence/Track.cpp
+++ b/src/VoidObjects/Sequence/Track.cpp
@@ -45,7 +45,26 @@ Effect* PlaybackTrack::CreateEffect(const std::string& effect)
     // Can only be created at the timeline level, if there are no current track items on it
     if (m_Items.Empty())
     {
-        if (Effect* created = _EffectsBridge.CreateEffect(effect, m_StartFrame, m_EndFrame))
+        PlaybackSequence* sequence = Sequence();
+        if (Effect* created = _EffectsBridge.CreateEffect(effect, sequence->StartFrame(), sequence->EndFrame()))
+        {
+            created->SetTrack(this);
+            m_Effects.push_back(created);
+            emit effectAdded(created);
+            emit maxEffectsChanged();
+            return created;
+        }
+    }
+    return nullptr;
+}
+
+Effect* PlaybackTrack::CreateEffect(const std::string& effect, const std::string& name)
+{
+    // Can only be created at the timeline level, if there are no current track items on it
+    if (m_Items.Empty())
+    {
+        PlaybackSequence* sequence = Sequence();
+        if (Effect* created = _EffectsBridge.CreateEffect(effect, name, sequence->StartFrame(), sequence->EndFrame()))
         {
             created->SetTrack(this);
             m_Effects.push_back(created);
@@ -90,6 +109,17 @@ void PlaybackTrack::ClearEffects()
 Effect* PlaybackTrack::CreateEffect(const SharedTrackItem& item, const std::string& effect)
 {
     Effect* created = item->CreateEffect(effect);
+    if (created)
+    {
+        emit effectAdded(created);
+        CalculateMaxEffects(item);
+    }
+    return created;
+}
+
+Effect* PlaybackTrack::CreateEffect(const SharedTrackItem& item, const std::string& effect, const std::string& name)
+{
+    Effect* created = item->CreateEffect(effect, name);
     if (created)
     {
         emit effectAdded(created);

--- a/src/VoidObjects/Sequence/Track.cpp
+++ b/src/VoidObjects/Sequence/Track.cpp
@@ -211,6 +211,7 @@ SharedMediaClip PlaybackTrack::Media(v_frame_t frame)
 void PlaybackTrack::Clear()
 {
     m_Items.Clear();
+    ClearEffects();
     SetRange(0, 0, false);
     emit cleared();
 }
@@ -384,6 +385,10 @@ bool PlaybackTrack::AddItem(const SharedTrackItem& item)
 
 bool PlaybackTrack::AddItem(const SharedTrackItem& item, v_frame_t frame)
 {
+    // Effects Track -- Can't allow Track items to be moved to this unless effects are cleared
+    // Need to double check this behaviour in other dccs too
+    if (m_Effects.size()) return false;
+
     if (m_Items.Add(item, frame))
     {
         CalculateMaxEffects(item);

--- a/src/VoidObjects/Sequence/Track.cpp
+++ b/src/VoidObjects/Sequence/Track.cpp
@@ -34,6 +34,59 @@ PlaybackTrack::~PlaybackTrack()
 {
 }
 
+int PlaybackTrack::EffectIndex(const Effect* const effect) const
+{
+    auto it = std::find(m_Effects.begin(), m_Effects.end(), effect);
+    return it == m_Effects.end() ? -1 : it - m_Effects.begin();
+}
+
+Effect* PlaybackTrack::CreateEffect(const std::string& effect)
+{
+    // Can only be created at the timeline level, if there are no current track items on it
+    if (m_Items.Empty())
+    {
+        if (Effect* created = _EffectsBridge.CreateEffect(effect, m_StartFrame, m_EndFrame))
+        {
+            created->SetTrack(this);
+            m_Effects.push_back(created);
+            emit effectAdded(created);
+            emit maxEffectsChanged();
+            return created;
+        }
+    }
+    return nullptr;
+}
+
+void PlaybackTrack::InsertEffect(Effect* effect, int index)
+{
+    effect->SetTrack(this);
+    m_Effects.insert(m_Effects.begin() + index, effect);
+    emit effectAdded(effect);
+    emit maxEffectsChanged();
+}
+
+void PlaybackTrack::RemoveEffect(int index, bool destroy)
+{
+    Effect*& effect = m_Effects[index];
+    emit effectAboutToBeRemoved(effect);
+    if (destroy)
+    {
+        effect->deleteLater();
+        delete effect;
+        effect = nullptr;
+    }
+
+    m_Effects.erase(m_Effects.begin() + index);
+    emit effectRemoved();
+    emit maxEffectsChanged();
+}
+
+void PlaybackTrack::ClearEffects()
+{
+    for (int i = static_cast<int>(m_Effects.size()) - 1; i >= 0; --i)
+        RemoveEffect(i, true);
+}
+
 Effect* PlaybackTrack::CreateEffect(const SharedTrackItem& item, const std::string& effect)
 {
     Effect* created = item->CreateEffect(effect);
@@ -349,7 +402,6 @@ void PlaybackTrack::Serialize(rapidjson::Value& out, rapidjson::Document::Alloca
     out.AddMember("track_type", static_cast<int>(m_Type), allocator);
     
     out.AddMember("item_count", static_cast<int64_t>(m_Items.Size()), allocator);
-
     rapidjson::Value trackitems(rapidjson::kArrayType);
     for (const SharedTrackItem& item: m_Items)
     {
@@ -360,6 +412,23 @@ void PlaybackTrack::Serialize(rapidjson::Value& out, rapidjson::Document::Alloca
     }
 
     out.AddMember("TrackItems", trackitems, allocator);
+
+    out.AddMember("effect_count", static_cast<int>(m_Effects.size()), allocator);
+    rapidjson::Value effects(rapidjson::kArrayType);
+    for (const auto& effect : m_Effects)
+    {
+        rapidjson::Value entry(rapidjson::kObjectType);
+        std::string type(effect->Type());
+        entry.AddMember("typename", rapidjson::Value(type.c_str(), allocator), allocator);
+
+        rapidjson::Value effectObject;
+        effect->Serialize(effectObject, allocator);
+        entry.AddMember("effect", effectObject, allocator);
+
+        effects.PushBack(entry, allocator);
+    }
+
+    out.AddMember("timeline_effects", effects, allocator);
 }
 
 void PlaybackTrack::Serialize(std::ostream& out) const
@@ -378,6 +447,15 @@ void PlaybackTrack::Serialize(std::ostream& out) const
 
     for (int i = 0; i < itemCount; ++i)
         m_Items.AtIndex(i)->Serialize(out);
+    
+    int effectsCount = static_cast<int>(m_Effects.size());
+    out.write(reinterpret_cast<const char*>(&effectsCount), sizeof(effectsCount));
+
+    for (const auto& effect : m_Effects)
+    {
+        WriteString(out, effect->Type());
+        effect->Serialize(out);
+    }
 }
 
 void PlaybackTrack::Deserialize(const rapidjson::Value& in)
@@ -401,6 +479,18 @@ void PlaybackTrack::Deserialize(const rapidjson::Value& in)
         item->Deserialize(trackitems[i]);
         AddItem(item);
     }
+
+    const rapidjson::Value::ConstArray effects = in["timeline_effects"].GetArray();
+    m_Effects.reserve(effects.Size());
+    for (int i = 0; i < effects.Size(); ++i)
+    {
+        std::string type = effects[i]["typename"].GetString();
+        if (Effect* effect = _EffectsBridge.CreateEffect(type))
+        {
+            effect->Deserialize(effects[i]["effect"]);
+            m_Effects.push_back(effect);
+        }
+    }
 }
 
 void PlaybackTrack::Deserialize(std::istream& in)
@@ -422,6 +512,20 @@ void PlaybackTrack::Deserialize(std::istream& in)
         SharedTrackItem item = std::make_shared<TrackItem>(this);
         item->Deserialize(in);
         AddItem(item);
+    }
+
+    int effectsCount;
+    in.read(reinterpret_cast<char*>(&effectsCount), sizeof(effectsCount));
+    m_Effects.reserve(effectsCount);
+
+    for (int i = 0; i < effectsCount; ++i)
+    {
+        std::string type = ReadString(in);
+        if (Effect* effect = _EffectsBridge.CreateEffect(type))
+        {
+            effect->Deserialize(in);
+            m_Effects.push_back(effect);
+        }
     }
 }
 

--- a/src/VoidObjects/Sequence/Track.h
+++ b/src/VoidObjects/Sequence/Track.h
@@ -21,6 +21,7 @@
 VOID_NAMESPACE_OPEN
 
 class PlaybackSequence;
+class STimelineEffect;
 
 class VOID_API PlaybackTrack : public VoidObject
 {
@@ -46,15 +47,22 @@ public:
     // }
 
     std::size_t NumItems() const { return m_Items.Size(); }
+    int NumEffects() const { return static_cast<int>(m_Effects.size()); }
     std::size_t ItemIndex(const SharedTrackItem& item) const { return m_Items.ItemIndex(item); }
     std::size_t ItemIndex(const TrackItem* item) const { return m_Items.ItemIndex(item); }
+    int EffectIndex(const Effect* const effect) const;
     SharedTrackItem ItemAt(std::size_t index) const { return m_Items.AtIndex(index); }
+    Effect* EffectAt(std::size_t index) const { return m_Effects.at(index); }
     MFrameRange ItemRange(std::size_t index) const { return m_Items.AtIndex(index)->TimelineRange(); }
     const std::vector<SharedTrackItem>& Items() const { return m_Items.Items(); }
 
+    Effect* CreateEffect(const std::string& effect);
+    void InsertEffect(Effect* effect, int index);
+    void RemoveEffect(int index, bool destroy = true);
+    void ClearEffects();
     Effect* CreateEffect(const SharedTrackItem& item, const std::string& effect);
     void CopyEffect(Effect* effect, const SharedTrackItem& item);
-    int MaxEffects() const { return m_MaxEffects; }
+    int MaxEffects() const { return m_Effects.empty() ? m_MaxEffects : static_cast<int>(m_Effects.size()); }
 
     /**
      * @brief Clears anything in the track and sets the provided media as first
@@ -91,6 +99,7 @@ public:
     v_frame_t GetSnapFrame(v_frame_t frame, const SharedTrackItem& trackitem, int threshold = 5) const;
 
     inline bool IsEmpty() const { return m_Items.Empty(); }
+    inline bool IsEffectsTrack() const { return !m_Effects.empty(); }
 
     // /* Returns the Color associated with the Track */
     // inline QColor Color() const { return m_Color; }
@@ -148,16 +157,19 @@ public:
 signals: /* Signals Denoting actions in the Track */
     void cleared();
     void itemAdded(const SharedTrackItem&);
-    void effectAdded(const Effect* const);
     void itemAboutToBeRemoved(const SharedTrackItem&);
-    void maxEffectsChanged();
     void itemRemoved();
+    void effectAdded(Effect*);
+    void effectAboutToBeRemoved(Effect*);
+    void effectRemoved();
+    void maxEffectsChanged();
     void updated();
     void rangeChanged(int start, int end);
 
 protected: /* Members */
     TrackMap m_Items;
     std::unordered_set<v_frame_t> m_Razored;
+    std::vector<Effect*> m_Effects;
 
     SharedTrackItem m_Recent;
     std::string m_Name;

--- a/src/VoidObjects/Sequence/Track.h
+++ b/src/VoidObjects/Sequence/Track.h
@@ -57,10 +57,12 @@ public:
     const std::vector<SharedTrackItem>& Items() const { return m_Items.Items(); }
 
     Effect* CreateEffect(const std::string& effect);
+    Effect* CreateEffect(const std::string& effect, const std::string& name);
     void InsertEffect(Effect* effect, int index);
     void RemoveEffect(int index, bool destroy = true);
     void ClearEffects();
     Effect* CreateEffect(const SharedTrackItem& item, const std::string& effect);
+    Effect* CreateEffect(const SharedTrackItem& item, const std::string& effect, const std::string& name);
     void CopyEffect(Effect* effect, const SharedTrackItem& item);
     int MaxEffects() const { return m_Effects.empty() ? m_MaxEffects : static_cast<int>(m_Effects.size()); }
 

--- a/src/VoidObjects/Sequence/TrackItem.cpp
+++ b/src/VoidObjects/Sequence/TrackItem.cpp
@@ -104,6 +104,25 @@ Effect* TrackItem::CreateEffect(const std::string& type)
     return nullptr;
 }
 
+Effect* TrackItem::CreateEffect(const std::string& type, const std::string& name)
+{
+    if (Effect* effect = _EffectsBridge.CreateEffect(type, name, m_TimelineIn, m_TimelineOut))
+    {
+        effect->SetTimelineItem(this);
+        // VOID_LOG_INFO("Effect Created -> {}", effect->Name());
+        m_Effects.push_back(effect);
+
+        emit effectCreated(effect);
+
+        // For every effect that gets updated, the media will be set dirty
+        // connect(effect, &Effect::updated, this, [this]() -> void { SetDirty(true); });
+        // SetDirty(true);
+        return effect;
+    }
+
+    return nullptr;
+}
+
 void TrackItem::AddEffect(Effect* effect)
 {
     effect->SetTimelineItem(this);

--- a/src/VoidObjects/Sequence/TrackItem.h
+++ b/src/VoidObjects/Sequence/TrackItem.h
@@ -63,6 +63,7 @@ public:
 
     std::string Name() const { return m_Media ? m_Media->Name() : m_Name; }
     Effect* CreateEffect(const std::string& type);
+    Effect* CreateEffect(const std::string& type, const std::string& name);
     void AddEffect(Effect* effect);
     void InsertEffect(Effect* effect, int index);
     bool RemoveEffect(const std::string& name);

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -300,6 +300,38 @@ bool ToggleTimelineEffectCommand::Redo()
     return false;
 }
 
+/// ToggleTrackEffectCommand
+
+ToggleTrackEffectCommand::ToggleTrackEffectCommand(Effect* effect, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Sequence(effect->Track()->Sequence())
+{
+    const PlaybackTrack* const track = effect->Track();
+    m_TrackType = track->Type();
+    m_TrackIndex = track->Index();
+    m_EffectIndex = track->EffectIndex(effect);
+}
+
+void ToggleTrackEffectCommand::undo()
+{
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
+    {
+        Effect* effect = track->EffectAt(m_EffectIndex);
+        effect->SetEnabled(!effect->Enabled());
+    }
+}
+
+bool ToggleTrackEffectCommand::Redo()
+{
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
+    {
+        Effect* effect = track->EffectAt(m_EffectIndex);
+        effect->SetEnabled(!effect->Enabled());
+        return true;
+    }
+    return false;
+}
+
 /// CreateTrackCommand
 
 CreateTrackCommand::CreateTrackCommand(const SharedPlaybackSequence& sequence, const Sequence::TrackType& type, QUndoCommand* parent)

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -420,7 +420,7 @@ DeleteTimelineEffectCommand::DeleteTimelineEffectCommand(Effect* effect, QUndoCo
 
 void DeleteTimelineEffectCommand::undo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType);
     if (track)
     {
         std::istringstream is(m_EffectData, std::ios::binary);
@@ -433,7 +433,7 @@ void DeleteTimelineEffectCommand::undo()
 
 bool DeleteTimelineEffectCommand::Redo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType);
     if (track)
     {
         std::ostringstream os(std::ios::binary);
@@ -464,7 +464,7 @@ DeleteTrackEffectCommand::DeleteTrackEffectCommand(Effect* effect, QUndoCommand*
 
 void DeleteTrackEffectCommand::undo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType);
     if (track)
     {
         std::istringstream is(m_EffectData, std::ios::binary);
@@ -476,7 +476,7 @@ void DeleteTrackEffectCommand::undo()
 
 bool DeleteTrackEffectCommand::Redo()
 {
-    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType);
     if (track)
     {
         std::ostringstream os(std::ios::binary);
@@ -498,7 +498,7 @@ CreateTimelineEffectCommand::CreateTimelineEffectCommand(const SharedTrackItem& 
 {
     const PlaybackTrack* const track = item->Track();
     m_TrackType = track->Type();
-    m_TrackIndex = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
+    m_TrackIndex = track->Index();
     m_ItemIndex = track->ItemIndex(item);
     m_EffectIndex = item->NumEffects();
 
@@ -520,7 +520,60 @@ bool CreateTimelineEffectCommand::Redo()
     if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
     {
         const SharedTrackItem item = track->ItemAt(m_ItemIndex);
-        return (bool)track->CreateEffect(item, m_EffectType);
+
+        if (m_Name.empty())
+        {
+            if (Effect* effect = track->CreateEffect(item, m_EffectType))
+            {
+                m_Name = effect->Name();
+                return true;
+            }
+        }
+        else
+        {
+            return (bool)track->CreateEffect(item, m_EffectType, m_Name);
+        }
+    }
+    return false;
+}
+
+/// CreateTrackEffectCommand
+
+CreateTrackEffectCommand::CreateTrackEffectCommand(const SharedPlaybackTrack& track, const std::string type, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Sequence(track->Sequence())
+    , m_EffectType(type)
+{
+    m_TrackType = track->Type();
+    m_TrackIndex = track->Index();
+    m_EffectIndex = track->NumEffects();
+
+    QString text("Create '%1' Effect");
+    setText(text.arg(type.c_str()));
+}
+
+void CreateTrackEffectCommand::undo()
+{
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
+        track->RemoveEffect(m_EffectIndex);
+}
+
+bool CreateTrackEffectCommand::Redo()
+{
+    if (const SharedPlaybackTrack& track = m_Sequence->TrackAt(m_TrackIndex, m_TrackType))
+    {
+        if (m_Name.empty())
+        {
+            if (Effect* effect = track->CreateEffect(m_EffectType))
+            {
+                m_Name = effect->Name();
+                return true;
+            }
+        }
+        else
+        {
+            return (bool)track->CreateEffect(m_EffectType, m_Name);
+        }
     }
     return false;
 }

--- a/src/VoidUi/Commands/SequenceCommands.cpp
+++ b/src/VoidUi/Commands/SequenceCommands.cpp
@@ -340,8 +340,9 @@ DeleteTrackCommand::DeleteTrackCommand(const SharedPlaybackTrack& track, QUndoCo
 void DeleteTrackCommand::undo()
 {
     std::istringstream is(m_TrackData, std::ios::binary);
-    SharedPlaybackTrack track = m_Sequence->CreateTrack(m_Type, m_TrackIndex);
+    SharedPlaybackTrack track = std::make_shared<PlaybackTrack>(m_Type, m_Sequence);
     track->Deserialize(is);
+    m_Type == Sequence::TrackType::VIDEO ? m_Sequence->AddVideoTrack(track, m_TrackIndex) : m_Sequence->AddAudioTrack(track, m_TrackIndex);
 }
 
 bool DeleteTrackCommand::Redo()
@@ -441,6 +442,48 @@ bool DeleteTimelineEffectCommand::Redo()
         effect->Serialize(os);
         m_EffectData = os.str();
         item->RemoveEffect(m_EffectIndex);
+        return true;
+    }
+    return false;
+}
+
+/// DeleteTrackEffectCommand
+
+DeleteTrackEffectCommand::DeleteTrackEffectCommand(Effect* effect, QUndoCommand* parent)
+    : VoidUndoCommand(parent)
+    , m_Sequence(effect->Track()->Sequence())
+{
+    const PlaybackTrack* const track = effect->Track();
+    m_TrackType = track->Type();
+    m_TrackIndex = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackIndex(track) : m_Sequence->AudioTrackIndex(track);
+    m_EffectIndex = track->EffectIndex(effect);
+    m_EffectType = effect->Type();
+
+    setText("Delete Timeline Effect");
+}
+
+void DeleteTrackEffectCommand::undo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        std::istringstream is(m_EffectData, std::ios::binary);
+        Effect* effect = EffectsBridge::Instance().CreateEffect(m_EffectType);
+        effect->Deserialize(is);
+        track->InsertEffect(effect, m_EffectIndex);
+    }
+}
+
+bool DeleteTrackEffectCommand::Redo()
+{
+    const SharedPlaybackTrack& track = m_TrackType == Sequence::TrackType::VIDEO ? m_Sequence->VideoTrackAt(m_TrackIndex) : m_Sequence->AudioTrackAt(m_TrackIndex);
+    if (track)
+    {
+        std::ostringstream os(std::ios::binary);
+        Effect* effect = track->EffectAt(m_EffectIndex);
+        effect->Serialize(os);
+        m_EffectData = os.str();
+        track->RemoveEffect(m_EffectIndex, true);
         return true;
     }
     return false;

--- a/src/VoidUi/Commands/SequenceCommands.h
+++ b/src/VoidUi/Commands/SequenceCommands.h
@@ -210,9 +210,26 @@ public:
 
 private:
     std::string m_EffectType;
+    std::string m_Name;
     PlaybackSequence* m_Sequence;
     int m_TrackIndex;
     int m_ItemIndex;
+    int m_EffectIndex;
+    Sequence::TrackType m_TrackType;
+};
+
+class CreateTrackEffectCommand : public VoidUndoCommand
+{
+public:
+    CreateTrackEffectCommand(const SharedPlaybackTrack& track, const std::string type, QUndoCommand* parent = nullptr);
+    void undo() override;
+    bool Redo() override;
+
+private:
+    std::string m_EffectType;
+    std::string m_Name;
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
     int m_EffectIndex;
     Sequence::TrackType m_TrackType;
 };

--- a/src/VoidUi/Commands/SequenceCommands.h
+++ b/src/VoidUi/Commands/SequenceCommands.h
@@ -128,6 +128,20 @@ private:
     Sequence::TrackType m_TrackType;
 };
 
+class ToggleTrackEffectCommand : public VoidUndoCommand
+{
+public:
+    explicit ToggleTrackEffectCommand(Effect* effect, QUndoCommand* parent = nullptr);
+    void undo() override;
+    bool Redo() override;
+
+private:
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
+    int m_EffectIndex;
+    Sequence::TrackType m_TrackType;
+};
+
 class CreateTrackCommand : public VoidUndoCommand
 {
 public:

--- a/src/VoidUi/Commands/SequenceCommands.h
+++ b/src/VoidUi/Commands/SequenceCommands.h
@@ -186,6 +186,21 @@ private:
     Sequence::TrackType m_TrackType;
 };
 
+class DeleteTrackEffectCommand : public VoidUndoCommand
+{
+public:
+    explicit DeleteTrackEffectCommand(Effect* effect, QUndoCommand* parent = nullptr);
+    void undo() override;
+    bool Redo() override;
+
+private:
+    std::string m_EffectData, m_EffectType;
+    PlaybackSequence* m_Sequence;
+    int m_TrackIndex;
+    int m_EffectIndex;
+    Sequence::TrackType m_TrackType;
+};
+
 class CreateTimelineEffectCommand : public VoidUndoCommand
 {
 public:

--- a/src/VoidUi/Sequencer/Graphics/STrack.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrack.cpp
@@ -185,6 +185,9 @@ void STrack::UpdateItems()
         trackitem->Update();
         trackitem->UpdateItems();
     }
+
+    for (auto& [_, effect] : m_Effects)
+        effect->Update();
 }
 
 STrackItem* STrack::ItemAt(int index) const

--- a/src/VoidUi/Sequencer/Graphics/STrack.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrack.cpp
@@ -9,6 +9,7 @@
 /* Internal */
 #include "STrack.h"
 #include "STrackItem.h"
+#include "STimelineEffect.h"
 #include "VoidUi/Sequencer/SContext.h"
 #include "VoidCore/Logging.h"
 
@@ -26,6 +27,16 @@ STrack::STrack(const SharedPlaybackTrack& track, SequencerContext* context, QGra
     connect(m_Track.get(), &PlaybackTrack::cleared, this, &STrack::Clear);
     connect(m_Track.get(), &PlaybackTrack::itemAboutToBeRemoved, this, &STrack::RemoveItem);
     connect(m_Track.get(), &PlaybackTrack::itemRemoved, this, &STrack::Update);
+    connect(m_Track.get(), &PlaybackTrack::effectAdded, this, [this](Effect* effect) -> void
+    {
+        if (effect->GetEffectType() == Effect::EffectType::TRACK)
+            AddEffect(effect, m_Track->EffectIndex(effect));
+    });
+    connect(m_Track.get(), &PlaybackTrack::effectAboutToBeRemoved, this, [this](Effect* effect) -> void
+    {
+        if (effect->GetEffectType() == Effect::EffectType::TRACK)
+            RemoveEffect(effect);
+    });
 
     int index = track->Index();
     m_BoundingRect = QRectF(
@@ -37,7 +48,9 @@ STrack::STrack(const SharedPlaybackTrack& track, SequencerContext* context, QGra
             : m_Context->Geometry()->AudioTrackHeight(index)
     );
     setPos(0, context->Geometry()->TrackRect(index).top());
+
     BuildItems();
+    AddEffects();
 
     m_RazorMarker = new STrackRazorItem(context, this);
     m_RazorMarker->setVisible(false);
@@ -94,6 +107,39 @@ void STrack::Clear()
     m_Items.clear();
 }
 
+void STrack::AddEffect(Effect* effect)
+{
+    AddEffect(effect, m_Track->EffectIndex(effect));
+}
+
+void STrack::AddEffect(Effect* effect, int index)
+{
+    STimelineEffect* teffect = new STimelineEffect(effect, m_Context, this);
+    teffect->setPos(0, boundingRect().height() - 2 - (Sequencer::TimelineEffectHeight + Sequencer::TimelineEffectHeight * index));
+    m_Effects[effect] = std::move(teffect);
+}
+
+void STrack::AddEffects()
+{
+    for (int i = 0; i < m_Track->NumEffects(); ++i)
+        AddEffect(m_Track->EffectAt(i), i);
+}
+
+void STrack::RemoveEffect(Effect* effect)
+{
+    if (m_Effects.find(effect) == m_Effects.end())
+        return;
+    
+    STimelineEffect*& teffect = m_Effects[effect];
+    teffect->setVisible(false);
+    teffect->setParent(nullptr);
+    teffect->deleteLater();
+    delete teffect;
+    teffect = nullptr;
+
+    m_Effects.erase(effect);
+}
+
 void STrack::AddItem(const SharedTrackItem& item)
 {
     STrackItem* trackitem = new STrackItem(item, m_Context, this);
@@ -113,6 +159,15 @@ void STrack::RemoveItem(const SharedTrackItem& item)
     trackitem = nullptr;
 
     m_Items.erase(item.get());
+}
+
+void STrack::UpdateEffects()
+{
+    for (auto& [effect, teffect] : m_Effects)
+    {
+        teffect->setPos(0, boundingRect().height() - 2 - (Sequencer::TimelineEffectHeight + Sequencer::TimelineEffectHeight * m_Track->EffectIndex(effect)));
+        teffect->Update();
+    }
 }
 
 void STrack::UpdateItem(const SharedTrackItem& item)

--- a/src/VoidUi/Sequencer/Graphics/STrack.h
+++ b/src/VoidUi/Sequencer/Graphics/STrack.h
@@ -35,8 +35,13 @@ public:
     void Update() override;
     void Clear();
 
+    void AddEffect(Effect* effect);
+    void AddEffect(Effect* effect, int index);
+    void AddEffects();
+    void RemoveEffect(Effect* effect);
     void AddItem(const SharedTrackItem& item);
     void RemoveItem(const SharedTrackItem& item);
+    void UpdateEffects();
     void UpdateItem(const SharedTrackItem& item);
     void UpdateItems();
 
@@ -51,6 +56,7 @@ protected:
 
 private:
     std::unordered_map<TrackItem*, STrackItem*> m_Items;
+    std::unordered_map<Effect*, STimelineEffect*> m_Effects;
     STrackRazorItem* m_RazorMarker;
     SharedPlaybackTrack m_Track;
 

--- a/src/VoidUi/Sequencer/Graphics/STrack.h
+++ b/src/VoidUi/Sequencer/Graphics/STrack.h
@@ -28,6 +28,7 @@ public:
     int Index() const { return m_Track->Index(); }
     bool Locked() const { return m_Track->Locked(); }
     bool Enabled() const { return m_Track->Enabled(); }
+    bool IsEffectsTrack() const { return m_Track->IsEffectsTrack(); }
     bool IsRazored(v_frame_t frame) const { return m_Track->IsRazored(frame); }
 
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;

--- a/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
+++ b/src/VoidUi/Sequencer/Graphics/STrackItem.cpp
@@ -324,7 +324,7 @@ void STrackItem::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
         STrack* track = m_Context->Controller()->TrackAt(scenePos());
         STrack* current = Track();
 
-        if (track && track->Locked())
+        if (track && (track->Locked() || track->IsEffectsTrack()))
         {
             Update();
             return;

--- a/src/VoidUi/Sequencer/Models/SSelectionModel.cpp
+++ b/src/VoidUi/Sequencer/Models/SSelectionModel.cpp
@@ -108,6 +108,8 @@ void SSelectionModel::Toggle(Effect* effect)
 
 bool SSelectionModel::IsSelected(const TrackItem* item)
 {
+    if (!item) return false;
+
     auto it = std::find_if(
         m_Items.begin(),
         m_Items.end(),

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -398,7 +398,10 @@ void SequencerController::ToggleItemState(const std::unordered_set<Effect*>& eff
     stack->beginMacro("Toggle Timeline Effect(s)");
 
     for (Effect* effect : effects)
-        stack->push(new ToggleTimelineEffectCommand(effect));
+        if (effect->GetEffectType() == Effect::EffectType::TRACK)
+            stack->push(new ToggleTrackEffectCommand(effect));
+        else
+            stack->push(new ToggleTimelineEffectCommand(effect));
 
     stack->endMacro();
 }

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -259,8 +259,8 @@ void SequencerController::RemoveTimelineEffects(const std::unordered_set<Effect*
         TrackItem* _aitem = _a->TimelineItem();
         TrackItem* _bitem = _b->TimelineItem();
 
-        int _aitemidx = _aitem ? _aitem->Track()->ItemIndex(_aitem) : -1;
-        int _bitemidx = _bitem ? _bitem->Track()->ItemIndex(_bitem) : -2;
+        int _aitemidx = _aitem ? _aitem->Track()->ItemIndex(_aitem) : _a->Track()->Index();
+        int _bitemidx = _bitem ? _bitem->Track()->ItemIndex(_bitem) : _b->Track()->Index();
 
         // Sort ascending based on the track item index -- effect _b belongs to a different track item than _a
         if (_aitemidx != _bitemidx)
@@ -276,7 +276,12 @@ void SequencerController::RemoveTimelineEffects(const std::unordered_set<Effect*
     stack->beginMacro("Delete Timeline Effect(s)");
 
     for (auto& effect : sorted)
-        stack->push(new DeleteTimelineEffectCommand(effect));
+    {
+        if (effect->GetEffectType() == Effect::EffectType::TRACK)
+            stack->push(new DeleteTrackEffectCommand(effect));
+        else
+            stack->push(new DeleteTimelineEffectCommand(effect));
+    }
 
     stack->endMacro();
 }

--- a/src/VoidUi/Sequencer/SController.cpp
+++ b/src/VoidUi/Sequencer/SController.cpp
@@ -61,7 +61,7 @@ void SequencerController::RippleMoveItem(const SharedTrackItem& item, v_frame_t 
         {
             const SharedTrackItem& trackitem = track->ItemAt(i);
             stack->push(new OffsetItemCommand(trackitem, offset));
-        }    
+        }
     }
 
     stack->push(new MoveTrackItemCommand(item, frame));
@@ -233,6 +233,19 @@ void SequencerController::RippleRemoveTrackItems(const std::unordered_set<Shared
     stack->endMacro();
 }
 
+void SequencerController::CreateEffect(const std::unordered_set<SharedPlaybackTrack>& tracks, const std::string& type)
+{
+    QUndoStack* stack = _MediaBridge.UndoStack();
+
+    QString text("Create '%1' Effect");
+    stack->beginMacro(text.arg(type.c_str()));
+
+    for (const SharedPlaybackTrack& track : tracks)
+        stack->push(new CreateTrackEffectCommand(track, type));
+
+    stack->endMacro();
+}
+
 void SequencerController::CreateEffect(const std::unordered_set<SharedTrackItem>& items, const std::string& type)
 {
     QUndoStack* stack = _MediaBridge.UndoStack();
@@ -256,20 +269,43 @@ void SequencerController::RemoveTimelineEffects(const std::unordered_set<Effect*
 
     std::sort(sorted.begin(), sorted.end(), [&](const Effect* _a, const Effect* _b) -> bool
     {
-        TrackItem* _aitem = _a->TimelineItem();
-        TrackItem* _bitem = _b->TimelineItem();
+        if (_a->GetEffectType() != _b->GetEffectType())
+            return _a->GetEffectType() < _b->GetEffectType();
 
-        int _aitemidx = _aitem ? _aitem->Track()->ItemIndex(_aitem) : _a->Track()->Index();
-        int _bitemidx = _bitem ? _bitem->Track()->ItemIndex(_bitem) : _b->Track()->Index();
+        if (_a->GetEffectType() == Effect::EffectType::ITEM)
+        {
+            TrackItem* _aitem = _a->TimelineItem();
+            TrackItem* _bitem = _b->TimelineItem();
 
-        // Sort ascending based on the track item index -- effect _b belongs to a different track item than _a
-        if (_aitemidx != _bitemidx)
-            return _aitemidx < _bitemidx;
+            int _aitemidx = _aitem->Index();
+            int _bitemidx = _bitem->Index();
 
-        // Sort descending based on the effect index
-        // we need the items to be reversed such that when deleting them, the index of other items don't change
-        // and running undo works as expected
-        return _aitem->EffectIndex(_a) > _bitem->EffectIndex(_b);
+            // Sort ascending based on the track item index -- effect _b belongs to a different track item than _a
+            if (_aitemidx != _bitemidx)
+                return _aitemidx < _bitemidx;
+
+            // Sort descending based on the effect index
+            // we need the items to be reversed such that when deleting them, the index of other items don't change
+            // and running undo works as expected
+            return _aitem->EffectIndex(_a) > _bitem->EffectIndex(_b);
+        }
+        else
+        {
+            PlaybackTrack* _atrk = _a->Track();
+            PlaybackTrack* _btrk = _b->Track();
+
+            int _atrkidx = _atrk->Index();
+            int _btrkidx = _btrk->Index();
+
+            // Sort ascending based on the track item index -- effect _b belongs to a different track item than _a
+            if (_atrkidx != _btrkidx)
+                return _atrkidx < _btrkidx;
+
+            // Sort descending based on the effect index
+            // we need the items to be reversed such that when deleting them, the index of other items don't change
+            // and running undo works as expected
+            return _atrk->EffectIndex(_a) > _btrk->EffectIndex(_b);
+        }
     });
 
     QUndoStack* stack = _MediaBridge.UndoStack();

--- a/src/VoidUi/Sequencer/SController.h
+++ b/src/VoidUi/Sequencer/SController.h
@@ -52,6 +52,7 @@ public:
     void RemoveTracks(const std::unordered_set<SharedPlaybackTrack>& tracks);
     void RemoveTrackItems(const std::unordered_set<SharedTrackItem>& items);
     void RippleRemoveTrackItems(const std::unordered_set<SharedTrackItem>& items);
+    void CreateEffect(const std::unordered_set<SharedPlaybackTrack>& tracks, const std::string& type);
     void CreateEffect(const std::unordered_set<SharedTrackItem>& items, const std::string& type);
     void RemoveTimelineEffects(const std::unordered_set<Effect*>& effects);
 

--- a/src/VoidUi/Sequencer/SMenu.cpp
+++ b/src/VoidUi/Sequencer/SMenu.cpp
@@ -95,15 +95,18 @@ void SequencerContextMenu::Connect()
 
 void SequencerContextMenu::Validate()
 {
-    m_RemoveSelectedAction->setEnabled(m_Context->SelectionModel()->HasAnySelection());
-    m_ColorItemAction->setEnabled(m_Context->SelectionModel()->HasTrackItemSelection());
-    m_ResetItemColorAction->setEnabled(m_Context->SelectionModel()->HasTrackItemSelection());
+    const SSelectionModel* sel = m_Context->SelectionModel();
+    const SequencerController* controller = m_Context->Controller();
 
-    m_NoOverwriteAction->setChecked(m_Context->Controller()->GetEditMode() == SequencerController::EditMode::NO_OVERWRITE);
-    m_OverwriteAction->setChecked(m_Context->Controller()->GetEditMode() == SequencerController::EditMode::OVERWRITE);
-    m_RippleAction->setChecked(m_Context->Controller()->GetEditMode() == SequencerController::EditMode::RIPPLE);
+    m_RemoveSelectedAction->setEnabled(sel->HasAnySelection());
+    m_ColorItemAction->setEnabled(sel->HasTrackItemSelection());
+    m_ResetItemColorAction->setEnabled(sel->HasTrackItemSelection());
 
-    m_EffectsMenu->setEnabled(m_Context->SelectionModel()->HasTrackItemSelection());
+    m_NoOverwriteAction->setChecked(controller->GetEditMode() == SequencerController::EditMode::NO_OVERWRITE);
+    m_OverwriteAction->setChecked(controller->GetEditMode() == SequencerController::EditMode::OVERWRITE);
+    m_RippleAction->setChecked(controller->GetEditMode() == SequencerController::EditMode::RIPPLE);
+
+    m_EffectsMenu->setEnabled(sel->HasTrackItemSelection() || sel->HasTrackSelection());
 }
 
 void SequencerContextMenu::BuildEffectsMenu()

--- a/src/VoidUi/Sequencer/STimelineGeometry.cpp
+++ b/src/VoidUi/Sequencer/STimelineGeometry.cpp
@@ -37,7 +37,9 @@ QRectF STimelineGeometry::TrackHeaderRect(int index) const
 int STimelineGeometry::VideoTrackHeight(int index) const
 {
     SharedPlaybackTrack track = m_Sequence->VideoTrackAt(index);
-    return Sequencer::TrackHeight + track->MaxEffects() * Sequencer::TimelineEffectHeight;
+    return track->IsEffectsTrack()
+            ? track->MaxEffects() * Sequencer::TimelineEffectHeight + 4
+            : Sequencer::TrackHeight + track->MaxEffects() * Sequencer::TimelineEffectHeight;
 }
 
 int STimelineGeometry::AudioTrackHeight(int index) const

--- a/src/VoidUi/Sequencer/STimelineScene.cpp
+++ b/src/VoidUi/Sequencer/STimelineScene.cpp
@@ -139,6 +139,7 @@ void STimelineScene::UpdateItems()
     {
         track->Update();
         track->UpdateItems();
+        track->UpdateEffects();
     }
 }
 
@@ -155,6 +156,9 @@ STrack*& STimelineScene::TrackAt(int index)
 void STimelineScene::SelectItems(const QRectF& rect)
 {
     const QList<QGraphicsItem*> hits = items(rect, Qt::IntersectsItemShape);
+    if (hits.empty())
+        return;
+
     std::vector<SharedTrackItem> trackitems;
     std::vector<Effect*> effects;
     trackitems.reserve(hits.size());

--- a/src/VoidUi/Sequencer/Sequencer.cpp
+++ b/src/VoidUi/Sequencer/Sequencer.cpp
@@ -198,6 +198,8 @@ void SequencerTimeline::CreateEffect(const std::string& type)
 {
     if (m_Context.SelectionModel()->HasTrackItemSelection())
         m_Context.Controller()->CreateEffect(m_Context.SelectionModel()->SelectedItems(), type);
+    else if (m_Context.SelectionModel()->HasTrackSelection())
+        m_Context.Controller()->CreateEffect(m_Context.SelectionModel()->SelectedTracks(), type);
 }
 
 void SequencerTimeline::DeleteSelected()


### PR DESCRIPTION
## Feat: Support Effects on Track in the Sequencer
- Effects as an entity can now be created on the track.
- Tracks holding effects are called Effects Track.
- Ensured functionality for deletion/disabling works on the track effects too.
- Items cannot be moved to tracks having effects, unless the track is cleared first.
- Creating Effects and then undo-redo now creates effects with the same name as before.